### PR TITLE
Fix unpaired surrogates for datastore IDs

### DIFF
--- a/examples/example-datastore/src/server.ts
+++ b/examples/example-datastore/src/server.ts
@@ -225,7 +225,6 @@ wsServer.on('request', request => {
         let acks = [];
         let propagate = [];
         for (let t of data.content.transactions) {
-          console.log(t.patch.editor.e1);
           if (store.add(t)) {
             acks.push(t.id);
             propagate.push(t);

--- a/examples/example-datastore/src/server.ts
+++ b/examples/example-datastore/src/server.ts
@@ -225,6 +225,7 @@ wsServer.on('request', request => {
         let acks = [];
         let propagate = [];
         for (let t of data.content.transactions) {
+          console.log(t.patch.editor.e1);
           if (store.add(t)) {
             acks.push(t.id);
             propagate.push(t);

--- a/packages/datastore/src/datastore.ts
+++ b/packages/datastore/src/datastore.ts
@@ -44,7 +44,7 @@ import {
 } from './table';
 
 import {
-  createDuplexId
+  createDuplexId, encodeId
 } from './utilities';
 
 
@@ -370,7 +370,8 @@ class Datastore implements IDisposable, IIterable<Table<Schema>>, IMessageHandle
     this._context = context;
     this._tables = tables;
     this._adapter = adapter || null;
-    this._transactionIdFactory = transactionIdFactory || createDuplexId;
+    this._transactionIdFactory =
+      transactionIdFactory || Private.defaultTransactionIdFactory;
     if (this._adapter) {
       this._adapter.onRemoteTransaction = this._onRemoteTransaction.bind(this);
       this._adapter.onUndo = this._onUndo.bind(this);
@@ -1143,5 +1144,13 @@ namespace Private {
   export
   function isChangeEmpty(change: Datastore.Change): boolean {
     return Object.keys(change).length === 0;
+  }
+
+  /**
+   * Create a transaction ID.
+   */
+  export
+  function defaultTransactionIdFactory(version: number, storeId: number) {
+    return encodeId(createDuplexId(version, storeId));
   }
 }

--- a/packages/datastore/src/field.ts
+++ b/packages/datastore/src/field.ts
@@ -125,6 +125,24 @@ abstract class Field<Value extends ReadonlyJSONValue, Update extends ReadonlyJSO
   abstract unapplyPatch(args: Field.PatchArgs<Value, Patch, Metadata>): Field.PatchResult<Value, Change>;
 
   /**
+   * Encode a system patch so that it can be sent across a network.
+   *
+   * @param patch - The patch to encode.
+   *
+   * @returns a JSON value that can be sent across the network.
+   */
+  abstract encodePatch(patch: Patch): Patch;
+
+  /**
+   * Decode a system patch from the network.
+   *
+   * @param patch - The object to decode.
+   *
+   * @returns a JSON value that can be sent across the network.
+   */
+  abstract decodePatch(patch: Patch): Patch;
+
+  /**
    * Merge two change objects into a single change object.
    *
    * @param first - The first change object of interest.

--- a/packages/datastore/src/index.ts
+++ b/packages/datastore/src/index.ts
@@ -18,3 +18,4 @@ export * from './schema';
 export * from './serveradapter';
 export * from './table';
 export * from './textfield';
+export * from './utilities';

--- a/packages/datastore/src/listfield.ts
+++ b/packages/datastore/src/listfield.ts
@@ -179,7 +179,7 @@ class ListField<T extends ReadonlyJSONValue> extends Field<ListField.Value<T>, L
     return patch.map(part => ({
       ...part,
       removedIds: part.removedIds.map(id => encodeId(id)),
-      inserteIds: part.insertedIds.map(id => encodeId(id))
+      insertedIds: part.insertedIds.map(id => encodeId(id))
     }));
   }
 
@@ -194,7 +194,7 @@ class ListField<T extends ReadonlyJSONValue> extends Field<ListField.Value<T>, L
     return patch.map(part => ({
       ...part,
       removedIds: part.removedIds.map(id => decodeId(id)),
-      inserteIds: part.insertedIds.map(id => decodeId(id))
+      insertedIds: part.insertedIds.map(id => decodeId(id))
     }));
   }
 

--- a/packages/datastore/src/listfield.ts
+++ b/packages/datastore/src/listfield.ts
@@ -8,7 +8,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import {
-  ArrayExt, StringExt
+  ArrayExt
 } from '@lumino/algorithm';
 
 import {
@@ -20,7 +20,7 @@ import {
 } from './field';
 
 import {
-  createTriplexIds
+  createTriplexIds, idCmp
 } from './utilities';
 
 
@@ -499,7 +499,7 @@ namespace Private {
     // Iterate over the identifiers to remove.
     while (i < n) {
       // Find the boundary identifier for the current id.
-      let j = ArrayExt.lowerBound(metadata.ids, ids[i], StringExt.cmp);
+      let j = ArrayExt.lowerBound(metadata.ids, ids[i], idCmp);
 
       // If the boundary is at the end of the array, or if the boundary id
       // does not match the id we are looking for, then we are dealing with
@@ -519,7 +519,7 @@ namespace Private {
       let count = 0;
 
       // Find the extent of the chunk.
-      while (i < n && StringExt.cmp(ids[i], metadata.ids[j]) === 0) {
+      while (i < n && idCmp(ids[i], metadata.ids[j]) === 0) {
         count++;
         i++;
         j++;
@@ -579,7 +579,7 @@ namespace Private {
 
       // Add the id to the ids which will be actually inserted.
       insertIds.push(ids[i]);
-      indices.push(ArrayExt.lowerBound(metadata.ids, ids[i], StringExt.cmp));
+      indices.push(ArrayExt.lowerBound(metadata.ids, ids[i], idCmp));
       insertValues.push(values[i]);
     }
     return chunkifyInsertions(insertIds, insertValues, indices);

--- a/packages/datastore/src/mapfield.ts
+++ b/packages/datastore/src/mapfield.ts
@@ -8,7 +8,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import {
-  ArrayExt
+  ArrayExt, StringExt
 } from '@lumino/algorithm';
 
 import {
@@ -20,7 +20,7 @@ import {
 } from './field';
 
 import {
-  createDuplexId, idCmp
+  createDuplexId, encodeId, decodeId
 } from './utilities';
 
 
@@ -208,6 +208,28 @@ class MapField<T extends ReadonlyJSONValue> extends Field<MapField.Value<T>, Map
   }
 
   /**
+   * Encode a system patch so that it can be sent across a network.
+   *
+   * @param patch - The patch to encode.
+   *
+   * @returns a JSON value that can be sent across the network.
+   */
+  encodePatch(patch: MapField.Patch<T>): MapField.Patch<T> {
+    return { ...patch, id: encodeId(patch.id) };
+  }
+
+  /**
+   * Decode a system patch from the network.
+   *
+   * @param patch - The object to decode.
+   *
+   * @returns a JSON value that can be sent across the network.
+   */
+  decodePatch(patch: MapField.Patch<T>): MapField.Patch<T> {
+    return { ...patch, id: decodeId(patch.id) };
+  }
+
+  /**
    * Merge two change objects into a single change object.
    *
    * @param first - The first change object of interest.
@@ -341,7 +363,7 @@ namespace Private {
     let values = metadata.values[key] || (metadata.values[key] = []);
 
     // Find the insert index for the id.
-    let i = ArrayExt.lowerBound(ids, id, idCmp);
+    let i = ArrayExt.lowerBound(ids, id, StringExt.cmp);
 
     // Overwrite or insert the value as appropriate.
     if (i < ids.length && ids[i] === id) {
@@ -376,7 +398,7 @@ namespace Private {
     let values = metadata.values[key] || (metadata.values[key] = []);
 
     // Find the insert index for the id.
-    let i = ArrayExt.lowerBound(ids, id, idCmp);
+    let i = ArrayExt.lowerBound(ids, id, StringExt.cmp);
 
     // Find and remove the index for the id.
     if (ids[i] === id) {

--- a/packages/datastore/src/mapfield.ts
+++ b/packages/datastore/src/mapfield.ts
@@ -8,7 +8,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import {
-  ArrayExt, StringExt
+  ArrayExt
 } from '@lumino/algorithm';
 
 import {
@@ -20,7 +20,7 @@ import {
 } from './field';
 
 import {
-  createDuplexId
+  createDuplexId, idCmp
 } from './utilities';
 
 
@@ -341,7 +341,7 @@ namespace Private {
     let values = metadata.values[key] || (metadata.values[key] = []);
 
     // Find the insert index for the id.
-    let i = ArrayExt.lowerBound(ids, id, StringExt.cmp);
+    let i = ArrayExt.lowerBound(ids, id, idCmp);
 
     // Overwrite or insert the value as appropriate.
     if (i < ids.length && ids[i] === id) {
@@ -376,7 +376,7 @@ namespace Private {
     let values = metadata.values[key] || (metadata.values[key] = []);
 
     // Find the insert index for the id.
-    let i = ArrayExt.lowerBound(ids, id, StringExt.cmp);
+    let i = ArrayExt.lowerBound(ids, id, idCmp);
 
     // Find and remove the index for the id.
     if (ids[i] === id) {

--- a/packages/datastore/src/registerfield.ts
+++ b/packages/datastore/src/registerfield.ts
@@ -8,7 +8,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import {
-  ArrayExt
+  ArrayExt, StringExt
 } from '@lumino/algorithm';
 
 import {
@@ -20,7 +20,7 @@ import {
 } from './field';
 
 import {
-  createDuplexId, idCmp
+  createDuplexId, encodeId, decodeId
 } from './utilities';
 
 
@@ -136,6 +136,28 @@ class RegisterField<T extends ReadonlyJSONValue> extends Field<RegisterField.Val
 
     // Return the result of the patch.
     return { value, change };
+  }
+
+  /**
+   * Encode a system patch so that it can be sent across a network.
+   *
+   * @param patch - The patch to encode.
+   *
+   * @returns a JSON value that can be sent across the network.
+   */
+  encodePatch(patch: RegisterField.Patch<T>): RegisterField.Patch<T> {
+    return { ...patch, id: encodeId(patch.id) };
+  }
+
+  /**
+   * Decode a system patch from the network.
+   *
+   * @param patch - The object to decode.
+   *
+   * @returns a JSON value that can be sent across the network.
+   */
+  decodePatch(patch: RegisterField.Patch<T>): RegisterField.Patch<T> {
+    return { ...patch, id: decodeId(patch.id) };
   }
 
   /**
@@ -268,7 +290,7 @@ namespace Private {
     let { ids, values } = metadata;
 
     // Find the insert index for the id.
-    let i = ArrayExt.lowerBound(ids, id, idCmp);
+    let i = ArrayExt.lowerBound(ids, id, StringExt.cmp);
 
     // Overwrite or insert the value as appropriate.
     if (i < ids.length && ids[i] === id) {
@@ -302,7 +324,7 @@ namespace Private {
     let { ids, values } = metadata;
 
     // Find the remove index for the id.
-    let i = ArrayExt.lowerBound(ids, id, idCmp);
+    let i = ArrayExt.lowerBound(ids, id, StringExt.cmp);
     if (ids[i] === id) {
       ArrayExt.removeAt(ids, i);
       ArrayExt.removeAt(values, i);

--- a/packages/datastore/src/registerfield.ts
+++ b/packages/datastore/src/registerfield.ts
@@ -8,7 +8,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import {
-  ArrayExt, StringExt
+  ArrayExt
 } from '@lumino/algorithm';
 
 import {
@@ -20,7 +20,7 @@ import {
 } from './field';
 
 import {
-  createDuplexId
+  createDuplexId, idCmp
 } from './utilities';
 
 
@@ -268,7 +268,7 @@ namespace Private {
     let { ids, values } = metadata;
 
     // Find the insert index for the id.
-    let i = ArrayExt.lowerBound(ids, id, StringExt.cmp);
+    let i = ArrayExt.lowerBound(ids, id, idCmp);
 
     // Overwrite or insert the value as appropriate.
     if (i < ids.length && ids[i] === id) {
@@ -302,7 +302,7 @@ namespace Private {
     let { ids, values } = metadata;
 
     // Find the remove index for the id.
-    let i = ArrayExt.lowerBound(ids, id, StringExt.cmp);
+    let i = ArrayExt.lowerBound(ids, id, idCmp);
     if (ids[i] === id) {
       ArrayExt.removeAt(ids, i);
       ArrayExt.removeAt(values, i);

--- a/packages/datastore/src/table.ts
+++ b/packages/datastore/src/table.ts
@@ -140,6 +140,57 @@ class Table<S extends Schema> implements IIterable<Record<S>> {
     // Return the change object.
     return tc;
   }
+
+  /**
+   * @internal
+   *
+   * Encode a table patch so that it can be sent across the network.
+   *
+   * @param data: The patch to encode.
+   *
+   * @returns The patch which can be sent across the network.
+   */
+  static encodePatch<U extends Schema>(table: Table<U>, data: Table.Patch<U>): Table.Patch<U> {
+    let schema = table.schema;
+    let tp: Table.MutablePatch<U> = {};
+
+    for (let id in data) {
+      let recordPatch = data[id];
+      let encoded: Record.MutablePatch<U> = {};
+      for (let name in recordPatch) {
+        let field = schema.fields[name];
+        encoded[name] = field.encodePatch(recordPatch[name]!);
+      }
+      tp[id] = encoded;
+    }
+    return tp;
+  }
+
+  /**
+   * @internal
+   *
+   * Decode a table patch from the network.
+   *
+   * @param data: The patch to decode.
+   *
+   * @returns The patch which can be sent across the network.
+   */
+  static decodePatch<U extends Schema>(table: Table<U>, data: Table.Patch<U>): Table.Patch<U> {
+    let schema = table.schema;
+    let tp: Table.MutablePatch<U> = {};
+
+    for (let id in data) {
+      let recordPatch = data[id];
+      let encoded: Record.MutablePatch<U> = {};
+      for (let name in recordPatch) {
+        let field = schema.fields[name];
+        encoded[name] = field.decodePatch(recordPatch[name]!);
+      }
+      tp[id] = encoded;
+    }
+    return tp;
+  }
+
   /**
    * The schema for the table.
    *

--- a/packages/datastore/src/table.ts
+++ b/packages/datastore/src/table.ts
@@ -181,12 +181,12 @@ class Table<S extends Schema> implements IIterable<Record<S>> {
 
     for (let id in data) {
       let recordPatch = data[id];
-      let encoded: Record.MutablePatch<U> = {};
+      let decoded: Record.MutablePatch<U> = {};
       for (let name in recordPatch) {
         let field = schema.fields[name];
-        encoded[name] = field.decodePatch(recordPatch[name]!);
+        decoded[name] = field.decodePatch(recordPatch[name]!);
       }
-      tp[id] = encoded;
+      tp[id] = decoded;
     }
     return tp;
   }

--- a/packages/datastore/src/textfield.ts
+++ b/packages/datastore/src/textfield.ts
@@ -8,7 +8,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import {
-  ArrayExt
+  ArrayExt, StringExt
 } from '@lumino/algorithm';
 
 import {
@@ -16,7 +16,7 @@ import {
 } from './field';
 
 import {
-  createTriplexIds, idCmp
+  createTriplexIds, encodeId, decodeId
 } from './utilities';
 
 
@@ -171,6 +171,36 @@ class TextField extends Field<TextField.Value, TextField.Update, TextField.Metad
 
     // Return the patch result.
     return { value, change };
+  }
+
+  /**
+   * Encode a system patch so that it can be sent across a network.
+   *
+   * @param patch - The patch to encode.
+   *
+   * @returns a JSON value that can be sent across the network.
+   */
+  encodePatch(patch: TextField.Patch): TextField.Patch {
+    return patch.map(part => ({
+      ...part,
+      removedIds: part.removedIds.map(id => encodeId(id)),
+      inserteIds: part.insertedIds.map(id => encodeId(id))
+    }));
+  }
+
+  /**
+   * Decode a system patch from the network.
+   *
+   * @param patch - The object to decode.
+   *
+   * @returns a JSON value that can be sent across the network.
+   */
+  decodePatch(patch: TextField.Patch): TextField.Patch {
+    return patch.map(part => ({
+      ...part,
+      removedIds: part.removedIds.map(id => decodeId(id)),
+      inserteIds: part.insertedIds.map(id => decodeId(id))
+    }));
   }
 
   /**
@@ -533,7 +563,7 @@ namespace Private {
     // Iterate over the identifiers to remove.
     while (i < n) {
       // Find the boundary identifier for the current id.
-      let j = ArrayExt.lowerBound(metadata.ids, ids[i], idCmp);
+      let j = ArrayExt.lowerBound(metadata.ids, ids[i], StringExt.cmp);
 
       // If the boundary is at the end of the array, or if the boundary id
       // does not match the id we are looking for, then we are dealing with
@@ -553,7 +583,7 @@ namespace Private {
       let count = 0;
 
       // Find the extent of the chunk.
-      while (i < n && idCmp(ids[i], metadata.ids[j]) === 0) {
+      while (i < n && StringExt.cmp(ids[i], metadata.ids[j]) === 0) {
         count++;
         i++;
         j++;
@@ -613,7 +643,7 @@ namespace Private {
 
       // Add the id to the ids which will be actually inserted.
       insertIds.push(ids[i]);
-      indices.push(ArrayExt.lowerBound(metadata.ids, ids[i], idCmp));
+      indices.push(ArrayExt.lowerBound(metadata.ids, ids[i], StringExt.cmp));
       insertText += text[i];
     }
     return chunkifyInsertions(insertIds, insertText, indices);

--- a/packages/datastore/src/textfield.ts
+++ b/packages/datastore/src/textfield.ts
@@ -184,7 +184,7 @@ class TextField extends Field<TextField.Value, TextField.Update, TextField.Metad
     return patch.map(part => ({
       ...part,
       removedIds: part.removedIds.map(id => encodeId(id)),
-      inserteIds: part.insertedIds.map(id => encodeId(id))
+      insertedIds: part.insertedIds.map(id => encodeId(id))
     }));
   }
 
@@ -199,7 +199,7 @@ class TextField extends Field<TextField.Value, TextField.Update, TextField.Metad
     return patch.map(part => ({
       ...part,
       removedIds: part.removedIds.map(id => decodeId(id)),
-      inserteIds: part.insertedIds.map(id => decodeId(id))
+      insertedIds: part.insertedIds.map(id => decodeId(id))
     }));
   }
 

--- a/packages/datastore/src/textfield.ts
+++ b/packages/datastore/src/textfield.ts
@@ -8,7 +8,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import {
-  ArrayExt, StringExt
+  ArrayExt
 } from '@lumino/algorithm';
 
 import {
@@ -16,7 +16,7 @@ import {
 } from './field';
 
 import {
-  createTriplexIds
+  createTriplexIds, idCmp
 } from './utilities';
 
 
@@ -533,7 +533,7 @@ namespace Private {
     // Iterate over the identifiers to remove.
     while (i < n) {
       // Find the boundary identifier for the current id.
-      let j = ArrayExt.lowerBound(metadata.ids, ids[i], StringExt.cmp);
+      let j = ArrayExt.lowerBound(metadata.ids, ids[i], idCmp);
 
       // If the boundary is at the end of the array, or if the boundary id
       // does not match the id we are looking for, then we are dealing with
@@ -553,7 +553,7 @@ namespace Private {
       let count = 0;
 
       // Find the extent of the chunk.
-      while (i < n && StringExt.cmp(ids[i], metadata.ids[j]) === 0) {
+      while (i < n && idCmp(ids[i], metadata.ids[j]) === 0) {
         count++;
         i++;
         j++;
@@ -613,7 +613,7 @@ namespace Private {
 
       // Add the id to the ids which will be actually inserted.
       insertIds.push(ids[i]);
-      indices.push(ArrayExt.lowerBound(metadata.ids, ids[i], StringExt.cmp));
+      indices.push(ArrayExt.lowerBound(metadata.ids, ids[i], idCmp));
       insertText += text[i];
     }
     return chunkifyInsertions(insertIds, insertText, indices);

--- a/packages/datastore/src/utilities.ts
+++ b/packages/datastore/src/utilities.ts
@@ -180,7 +180,6 @@ function createTriplexIds(n: number, version: number, store: number, lower: stri
  */
 export
 function encodeId(str: string): string {
-  // return Private.pairSurrogates(str);
   return Private.btoaUTF16(str);
 }
 
@@ -197,7 +196,6 @@ function encodeId(str: string): string {
  */
 export
 function decodeId(str: string): string {
-  //return Private.stripSurrogates(str);
   return Private.atobUTF16(str);
 }
 

--- a/packages/datastore/tests/src/datastore.spec.ts
+++ b/packages/datastore/tests/src/datastore.spec.ts
@@ -231,6 +231,21 @@ describe('@lumino/datastore', () => {
           });
       });
 
+      it('should create valid unicode transaction IDs by default', () => {
+        let encoder = new TextEncoder();
+        let decoder = new TextDecoder('utf8');
+
+        for (let i = 0; i < 100000; i++) {
+          let t1 = datastore.get(schema1);
+          let id = datastore.beginTransaction();
+          t1.update({ 'my-record': { enabled: true } });
+          datastore.endTransaction();
+
+          // Test that the transaction id is valid unicode by encoding and
+          // then decoding it.
+          expect(decoder.decode(encoder.encode(id))).to.equal(id);
+        }
+      }).timeout(30000);
     });
 
     describe('dispose()', () => {

--- a/packages/datastore/tests/src/index.spec.ts
+++ b/packages/datastore/tests/src/index.spec.ts
@@ -15,3 +15,4 @@ import './mapfield.spec';
 import './registerfield.spec';
 import './table.spec';
 import './textfield.spec';
+import './utilities.spec';

--- a/packages/datastore/tests/src/utilities.spec.ts
+++ b/packages/datastore/tests/src/utilities.spec.ts
@@ -25,7 +25,7 @@ describe('@lumino/datastore', () => {
   describe('createDuplexId', () => {
     it('should generate valid strings without unpaired surrogates', () => {
       let prev = '';
-      for (let version = 0; version < 10000; version++) {
+      for (let version = 0; version < 100000; version++) {
         let id = createDuplexId(version, storeId);
         expect(idCmp(id, prev)).to.be.above(0);
 
@@ -42,7 +42,7 @@ describe('@lumino/datastore', () => {
   describe('createTriplexId', () => {
     it('should generate valid strings without unpaired surrogates', () => {
       let ids: string[] = [];
-      for (let version = 0; version < 10000; version++) {
+      for (let version = 0; version < 100000; version++) {
         // Generate a random index for insertion.
         let index = Math.round(Math.random()*ids.length);
         // Fetch the lower and upper identifiers.
@@ -66,6 +66,6 @@ describe('@lumino/datastore', () => {
         ids.splice(index, 0, id);
       }
 
-    });
+    }).timeout(20000);
   });
 });

--- a/packages/datastore/tests/src/utilities.spec.ts
+++ b/packages/datastore/tests/src/utilities.spec.ts
@@ -12,11 +12,7 @@ import {
 } from 'chai';
 
 import {
-  StringExt
-} from '@lumino/algorithm';
-
-import {
-  createDuplexId, createTriplexId
+  createDuplexId, createTriplexId, idCmp
 } from '@lumino/datastore';
 
 
@@ -31,7 +27,7 @@ describe('@lumino/datastore', () => {
       let prev = '';
       for (let version = 0; version < 10000; version++) {
         let id = createDuplexId(version, storeId);
-        expect(StringExt.cmp(id, prev)).to.be.above(0);
+        expect(idCmp(id, prev)).to.be.above(0);
 
         // The new ID should be valid unicode, without unpaired surrogates.
         // We can test this by round-tripping an encode/decode and checking
@@ -56,9 +52,9 @@ describe('@lumino/datastore', () => {
         let id = createTriplexId(version, storeId, lower, upper);
 
         // The new ID should fall between the upper and lower bounds.
-        expect(StringExt.cmp(id, lower)).to.be.above(0);
+        expect(idCmp(id, lower)).to.be.above(0);
         if (index !== ids.length) {
-          expect(StringExt.cmp(id, upper)).to.be.below(0);
+          expect(idCmp(id, upper)).to.be.below(0);
         }
 
         // The new ID should be valid unicode, without unpaired surrogates.

--- a/packages/datastore/tests/src/utilities.spec.ts
+++ b/packages/datastore/tests/src/utilities.spec.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2019, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+import {
+  expect
+} from 'chai';
+
+import {
+  StringExt
+} from '@lumino/algorithm';
+
+import {
+  createDuplexId, createTriplexId
+} from '@lumino/datastore';
+
+
+describe('@lumino/datastore', () => {
+  let storeId = 1;
+  let encoder = new TextEncoder();
+  let decoder = new TextDecoder('utf8');
+
+
+  describe('createDuplexId', () => {
+    it('should generate valid strings without unpaired surrogates', () => {
+      let prev = '';
+      for (let version = 0; version < 10000; version++) {
+        let id = createDuplexId(version, storeId);
+        expect(StringExt.cmp(id, prev)).to.be.above(0);
+
+        // The new ID should be valid unicode, without unpaired surrogates.
+        // We can test this by round-tripping an encode/decode and checking
+        // that the string is the same.
+        expect(decoder.decode(encoder.encode(id))).to.equal(id);
+
+        prev = id;
+      }
+    });
+  });
+
+  describe('createTriplexId', () => {
+    it('should generate valid strings without unpaired surrogates', () => {
+      let ids: string[] = [];
+      for (let version = 0; version < 10000; version++) {
+        // Generate a random index for insertion.
+        let index = Math.round(Math.random()*ids.length);
+        // Fetch the lower and upper identifiers.
+        let lower = index === 0 ? '' : ids[index - 1];
+        let upper = index === ids.length ? '' : ids[index];
+        // Create an id to be inserted into the index position.
+        let id = createTriplexId(version, storeId, lower, upper);
+
+        // The new ID should fall between the upper and lower bounds.
+        expect(StringExt.cmp(id, lower)).to.be.above(0);
+        if (index !== ids.length) {
+          expect(StringExt.cmp(id, upper)).to.be.below(0);
+        }
+
+        // The new ID should be valid unicode, without unpaired surrogates.
+        // We can test this by round-tripping an encode/decode and checking
+        // that the string is the same.
+        expect(decoder.decode(encoder.encode(id))).to.equal(id);
+
+        // Insert the new id into the sorted IDs list.
+        ids.splice(index, 0, id);
+      }
+
+    });
+  });
+});

--- a/packages/datastore/tests/src/utilities.spec.ts
+++ b/packages/datastore/tests/src/utilities.spec.ts
@@ -12,7 +12,11 @@ import {
 } from 'chai';
 
 import {
-  createDuplexId, createTriplexId, idCmp
+  StringExt
+} from '@lumino/algorithm';
+
+import {
+  createDuplexId, createTriplexId, encodeId, decodeId
 } from '@lumino/datastore';
 
 
@@ -27,12 +31,12 @@ describe('@lumino/datastore', () => {
       let prev = '';
       for (let version = 0; version < 100000; version++) {
         let id = createDuplexId(version, storeId);
-        expect(idCmp(id, prev)).to.be.above(0);
+        expect(StringExt.cmp(id, prev)).to.be.above(0);
 
         // The new ID should be valid unicode, without unpaired surrogates.
         // We can test this by round-tripping an encode/decode and checking
         // that the string is the same.
-        expect(decoder.decode(encoder.encode(id))).to.equal(id);
+        expect(decodeId(decoder.decode(encoder.encode(encodeId(id))))).to.equal(id);
 
         prev = id;
       }
@@ -52,15 +56,15 @@ describe('@lumino/datastore', () => {
         let id = createTriplexId(version, storeId, lower, upper);
 
         // The new ID should fall between the upper and lower bounds.
-        expect(idCmp(id, lower)).to.be.above(0);
+        expect(StringExt.cmp(id, lower)).to.be.above(0);
         if (index !== ids.length) {
-          expect(idCmp(id, upper)).to.be.below(0);
+          expect(StringExt.cmp(id, upper)).to.be.below(0);
         }
 
         // The new ID should be valid unicode, without unpaired surrogates.
         // We can test this by round-tripping an encode/decode and checking
         // that the string is the same.
-        expect(decoder.decode(encoder.encode(id))).to.equal(id);
+        expect(decodeId(decoder.decode(encoder.encode(encodeId(id))))).to.equal(id);
 
         // Insert the new id into the sorted IDs list.
         ids.splice(index, 0, id);

--- a/packages/datastore/tests/src/utilities.spec.ts
+++ b/packages/datastore/tests/src/utilities.spec.ts
@@ -42,7 +42,7 @@ describe('@lumino/datastore', () => {
   describe('createTriplexId', () => {
     it('should generate valid strings without unpaired surrogates', () => {
       let ids: string[] = [];
-      for (let version = 0; version < 100000; version++) {
+      for (let version = 0; version < 10000; version++) {
         // Generate a random index for insertion.
         let index = Math.round(Math.random()*ids.length);
         // Fetch the lower and upper identifiers.
@@ -66,6 +66,6 @@ describe('@lumino/datastore', () => {
         ids.splice(index, 0, id);
       }
 
-    }).timeout(20000);
+    }).timeout(30000);
   });
 });


### PR DESCRIPTION
Okay, buckle in, this is a tricky one.

The datastore package here currently has a bug which is a bit of a show-stopper. Elements of text or list fields get IDs associated with them. These IDs encode the store ID, the version at the time of insert, and where they were inserted. These IDs are absolutely orderable, allowing conflicts to be resolved (the whole idea of CRDTs).

The element IDs are represented as strings, where each character represents two bytes. The fact that they are representable as strings is nice for a few reasons:
* Comparisons and other string methods are fast.
* Their memory footprint is lighter than alternatives like typed arrays.

Unfortunately, the ID generation scheme (i.e., the core algorithm), can generate unpaired surrogate characters. These are invalid Unicode, and as such, they are not transmitted faithfully between collaborators, and cause non-synchronized field state.

This is one attempt to solve that problem. Here I am trying to stick with string IDs due to their nice features, and instead do some patching up to make sure that they are valid Unicode. The essential idea here is to take each ID, look for unpaired surrogates, and give them a pair character. This makes them valid, but can break their absolute ordering. So the other part of this is to strip out those "dummy" surrogates before doing any of the bitwise math and comparisons that are involved in the CRDT algorithm.

It's a bit kludgy, but it is entirely API-compatible with the previous implementation, making only changes to private functionality, and seems to work in my testing.