### PR TITLE
Add data attribute to suppress keyboard shortcuts in a region of an application.

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -421,6 +421,10 @@ class CommandRegistry {
    * The registry **does not** install its own listener for `'keydown'`
    * events. This allows the application full control over the nodes
    * and phase for which the registry processes `'keydown'` events.
+   *
+   * When the keydown event is processed, if the event target or any of its
+   * ancestor nodes has a `data-p-suppress-shortcuts` attribute, its keydown
+   * events will not invoke commands.
    */
   processKeydownEvent(event: KeyboardEvent): void {
     // Bail immediately if playing back keystrokes.
@@ -1388,6 +1392,9 @@ namespace Private {
     let targ = event.target as (Element | null);
     let curr = event.currentTarget as (Element | null);
     for (let dist = 0; targ !== null; targ = targ.parentElement, ++dist) {
+      if (targ.hasAttribute('data-p-suppress-shortcuts')) {
+        return -1;
+      }
       if (Selector.matches(targ, selector)) {
         return dist;
       }

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -509,18 +509,22 @@ describe('@lumino/commands', () => {
 
     let elemID = 0;
     let elem: HTMLElement = null!;
+    let parent: HTMLElement = null!;
 
     beforeEach(() => {
+      parent = document.createElement('div') as HTMLElement;
       elem = document.createElement('div') as HTMLElement;
+      parent.classList.add('p-test-parent');
       elem.id = `test${elemID++}`;
       elem.addEventListener('keydown', event => {
         registry.processKeydownEvent(event);
       });
-      document.body.appendChild(elem);
+      parent.appendChild(elem);
+      document.body.appendChild(parent);
     });
 
     afterEach(() => {
-      document.body.removeChild(elem);
+      document.body.removeChild(parent);
     });
 
     describe('#addKeyBinding()', () => {
@@ -594,6 +598,22 @@ describe('@lumino/commands', () => {
         let event = generate('keydown', { keyCode: 59, ctrlKey: true });
         elem.dispatchEvent(event);
         expect(called).to.equal(true);
+      });
+
+      it('should not dispatch on a suppressed node', () => {
+        let called = false;
+        registry.addCommand('test', {
+          execute: () => { called = true; }
+        });
+        registry.addKeyBinding({
+          keys: ['Ctrl ;'],
+          selector: `.p-test-parent`,
+          command: 'test'
+        });
+        parent.setAttribute('data-p-suppress-shortcuts', 'true');
+        let event = generate('keydown', { keyCode: 59, ctrlKey: true });
+        elem.dispatchEvent(event);
+        expect(called).to.equal(false);
       });
 
       it('should not dispatch on a non-matching keyboard event', () => {


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/lumino/issues/10