### PR TITLE
Fix lumino links

### DIFF
--- a/packages/algorithm/package.json
+++ b/packages/algorithm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/algorithm",
   "version": "1.2.0",
-  "description": "lumino Algorithms and Iterators",
+  "description": "Lumino Algorithms and Iterators",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/algorithm/package.json
+++ b/packages/algorithm/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/algorithm",
   "version": "1.2.0",
   "description": "lumino Algorithms and Iterators",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/application",
   "version": "1.7.3",
   "description": "lumino Pluggable Application",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/application",
   "version": "1.7.3",
-  "description": "lumino Pluggable Application",
+  "description": "Lumino Pluggable Application",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/collections",
   "version": "1.2.0",
-  "description": "lumino Generic Collections",
+  "description": "Lumino Generic Collections",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/collections",
   "version": "1.2.0",
   "description": "lumino Generic Collections",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/commands",
   "version": "1.7.2",
   "description": "lumino Commands",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/commands",
   "version": "1.7.2",
-  "description": "lumino Commands",
+  "description": "Lumino Commands",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/coreutils",
   "version": "1.3.1",
   "description": "lumino Core Utilities",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/coreutils",
   "version": "1.3.1",
-  "description": "lumino Core Utilities",
+  "description": "Lumino Core Utilities",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/datagrid",
   "version": "0.3.1",
-  "description": "lumino Tabular Data Grid",
+  "description": "Lumino Tabular Data Grid",
   "homepage": "https://github.com/jupyterlabab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlabab/lumino/issues"

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/datagrid",
   "version": "0.3.1",
   "description": "lumino Tabular Data Grid",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlabab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlabab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlabab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/datastore",
   "version": "0.8.0",
   "description": "lumino DataStore",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlabab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlabab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlabab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/datastore",
   "version": "0.8.0",
-  "description": "lumino DataStore",
+  "description": "Lumino DataStore",
   "homepage": "https://github.com/jupyterlabab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlabab/lumino/issues"

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/default-theme",
   "version": "0.1.8",
-  "description": "lumino Default Theme",
+  "description": "Lumino Default Theme",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/default-theme",
   "version": "0.1.8",
   "description": "lumino Default Theme",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -21,7 +21,7 @@
   "style": "style/index.css",
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "dependencies": {
     "@lumino/dragdrop": "^1.4.1",

--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/disposable",
   "version": "1.3.1",
   "description": "lumino Disposable",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/disposable",
   "version": "1.3.1",
-  "description": "lumino Disposable",
+  "description": "Lumino Disposable",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/domutils/package.json
+++ b/packages/domutils/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/domutils",
   "version": "1.1.4",
   "description": "lumino DOM Utilities",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/domutils/package.json
+++ b/packages/domutils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/domutils",
   "version": "1.1.4",
-  "description": "lumino DOM Utilities",
+  "description": "Lumino DOM Utilities",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/dragdrop",
   "version": "1.4.1",
-  "description": "lumino Drag and Drop",
+  "description": "Lumino Drag and Drop",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/dragdrop",
   "version": "1.4.1",
   "description": "lumino Drag and Drop",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/keyboard",
   "version": "1.1.3",
-  "description": "lumino Keyboard",
+  "description": "Lumino Keyboard",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/keyboard",
   "version": "1.1.3",
   "description": "lumino Keyboard",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/messaging",
   "version": "1.3.0",
-  "description": "lumino Message Passing",
+  "description": "Lumino Message Passing",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/messaging",
   "version": "1.3.0",
   "description": "lumino Message Passing",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/properties",
   "version": "1.1.3",
   "description": "lumino Attached Properties",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/properties",
   "version": "1.1.3",
-  "description": "lumino Attached Properties",
+  "description": "Lumino Attached Properties",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/signaling/package.json
+++ b/packages/signaling/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/signaling",
   "version": "1.3.1",
-  "description": "lumino Signals and Slots",
+  "description": "Lumino Signals and Slots",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/signaling/package.json
+++ b/packages/signaling/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/signaling",
   "version": "1.3.1",
   "description": "lumino Signals and Slots",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/virtualdom",
   "version": "1.2.0",
-  "description": "lumino Virtual DOM",
+  "description": "Lumino Virtual DOM",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"

--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/virtualdom",
   "version": "1.2.0",
   "description": "lumino Virtual DOM",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -2,9 +2,9 @@
   "name": "@lumino/widgets",
   "version": "1.9.3",
   "description": "lumino Widgets",
-  "homepage": "https://github.com/luminojs/lumino",
+  "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
-    "url": "https://github.com/luminojs/lumino/issues"
+    "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
   "author": "S. Chris Colbert <sccolbert@gmail.com>",
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "scripts": {
     "api": "api-extractor run --local --verbose",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lumino/widgets",
   "version": "1.9.3",
-  "description": "lumino Widgets",
+  "description": "Lumino Widgets",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
     "url": "https://github.com/jupyterlab/lumino/issues"


### PR DESCRIPTION
At the suggestion of @afshin,
1. Changed the github links to point to jupyterlab/lumino
2. Changed lumino -> Lumino in the description field.
