### PR TITLE
Update selector, data attribute, and event namespaces.

### DIFF
--- a/examples/example-datastore/style/index.css
+++ b/examples/example-datastore/style/index.css
@@ -28,7 +28,7 @@ body {
   flex: 1 1 auto;
 }
 
-.p-Dockpanel-widget .CodeMirror {
+.lm-Dockpanel-widget .CodeMirror {
   width: 100%;
   height: 100%;
   margin: 16px;
@@ -39,7 +39,7 @@ body {
   background: slategray;
 }
 
-.p-DockPanel-overlay {
+.lm-DockPanel-overlay {
   background: rgba(255, 255, 255, 0.8);
   border: 1px dashed black;
   transition-property: top, left, right, bottom;

--- a/examples/example-datastore/style/tabbar.css
+++ b/examples/example-datastore/style/tabbar.css
@@ -8,13 +8,13 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-TabBar {
+.lm-TabBar {
   min-height: 24px;
   max-height: 24px;
 }
 
 
-.p-TabBar-content {
+.lm-TabBar-content {
   min-width: 0;
   min-height: 0;
   align-items: flex-end;
@@ -22,7 +22,7 @@
 }
 
 
-.p-TabBar-tab {
+.lm-TabBar-tab {
   padding: 0px 10px;
   background: #E5E5E5;
   border: 1px solid #C0C0C0;
@@ -37,47 +37,47 @@
 }
 
 
-.p-TabBar-tab.p-mod-current {
+.lm-TabBar-tab.lm-mod-current {
   background: white;
 }
 
 
-.p-TabBar-tab:hover:not(.p-mod-current) {
+.lm-TabBar-tab:hover:not(.lm-mod-current) {
   background: #F0F0F0;
 }
 
 
-.p-TabBar-tab:first-child {
+.lm-TabBar-tab:first-child {
   margin-left: 0;
 }
 
 
-.p-TabBar-tab.p-mod-current {
+.lm-TabBar-tab.lm-mod-current {
   min-height: 23px;
   max-height: 23px;
   transform: translateY(1px);
 }
 
 
-.p-TabBar-tabIcon,
-.p-TabBar-tabLabel,
-.p-TabBar-tabCloseIcon {
+.lm-TabBar-tabIcon,
+.lm-TabBar-tabLabel,
+.lm-TabBar-tabCloseIcon {
   display: inline-block;
 }
 
 
-.p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon {
+.lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon {
   margin-left: 4px;
 }
 
 
-.p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:before {
+.lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon:before {
   content: '\f00d';
   font-family: FontAwesome;
 }
 
 
-.p-TabBar-tab.p-mod-drag-image {
+.lm-TabBar-tab.lm-mod-drag-image {
   min-height: 23px;
   max-height: 23px;
   min-width: 125px;

--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -321,16 +321,16 @@ function main(): void {
   contextMenu.addItem({ command: 'example:copy', selector: '.content' });
   contextMenu.addItem({ command: 'example:paste', selector: '.content' });
 
-  contextMenu.addItem({ command: 'example:one', selector: '.p-CommandPalette' });
-  contextMenu.addItem({ command: 'example:two', selector: '.p-CommandPalette' });
-  contextMenu.addItem({ command: 'example:three', selector: '.p-CommandPalette' });
-  contextMenu.addItem({ command: 'example:four', selector: '.p-CommandPalette' });
-  contextMenu.addItem({ command: 'example:black', selector: '.p-CommandPalette' });
+  contextMenu.addItem({ command: 'example:one', selector: '.lm-CommandPalette' });
+  contextMenu.addItem({ command: 'example:two', selector: '.lm-CommandPalette' });
+  contextMenu.addItem({ command: 'example:three', selector: '.lm-CommandPalette' });
+  contextMenu.addItem({ command: 'example:four', selector: '.lm-CommandPalette' });
+  contextMenu.addItem({ command: 'example:black', selector: '.lm-CommandPalette' });
 
-  contextMenu.addItem({ command: 'notebook:new', selector: '.p-CommandPalette-input' });
-  contextMenu.addItem({ command: 'example:save-on-exit', selector: '.p-CommandPalette-input' });
-  contextMenu.addItem({ command: 'example:open-task-manager', selector: '.p-CommandPalette-input' });
-  contextMenu.addItem({ type: 'separator', selector: '.p-CommandPalette-input' });
+  contextMenu.addItem({ command: 'notebook:new', selector: '.lm-CommandPalette-input' });
+  contextMenu.addItem({ command: 'example:save-on-exit', selector: '.lm-CommandPalette-input' });
+  contextMenu.addItem({ command: 'example:open-task-manager', selector: '.lm-CommandPalette-input' });
+  contextMenu.addItem({ type: 'separator', selector: '.lm-CommandPalette-input' });
 
   document.addEventListener('keydown', (event: KeyboardEvent) => {
     commands.processKeydownEvent(event);

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -423,7 +423,7 @@ class CommandRegistry {
    * and phase for which the registry processes `'keydown'` events.
    *
    * When the keydown event is processed, if the event target or any of its
-   * ancestor nodes has a `data-p-suppress-shortcuts` attribute, its keydown
+   * ancestor nodes has a `data-lm-suppress-shortcuts` attribute, its keydown
    * events will not invoke commands.
    */
   processKeydownEvent(event: KeyboardEvent): void {
@@ -1392,7 +1392,7 @@ namespace Private {
     let targ = event.target as (Element | null);
     let curr = event.currentTarget as (Element | null);
     for (let dist = 0; targ !== null; targ = targ.parentElement, ++dist) {
-      if (targ.hasAttribute('data-p-suppress-shortcuts')) {
+      if (targ.hasAttribute('data-lm-suppress-shortcuts')) {
         return -1;
       }
       if (Selector.matches(targ, selector)) {

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1395,6 +1395,11 @@ namespace Private {
       if (targ.hasAttribute('data-lm-suppress-shortcuts')) {
         return -1;
       }
+      /* <DEPRECATED> */
+      if (targ.hasAttribute('data-p-suppress-shortcuts')) {
+        return -1;
+      }
+      /* </DEPRECATED> */
       if (Selector.matches(targ, selector)) {
         return dist;
       }

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -514,7 +514,7 @@ describe('@lumino/commands', () => {
     beforeEach(() => {
       parent = document.createElement('div') as HTMLElement;
       elem = document.createElement('div') as HTMLElement;
-      parent.classList.add('p-test-parent');
+      parent.classList.add('lm-test-parent');
       elem.id = `test${elemID++}`;
       elem.addEventListener('keydown', event => {
         registry.processKeydownEvent(event);
@@ -607,10 +607,10 @@ describe('@lumino/commands', () => {
         });
         registry.addKeyBinding({
           keys: ['Ctrl ;'],
-          selector: `.p-test-parent`,
+          selector: `.lm-test-parent`,
           command: 'test'
         });
-        parent.setAttribute('data-p-suppress-shortcuts', 'true');
+        parent.setAttribute('data-lm-suppress-shortcuts', 'true');
         let event = generate('keydown', { keyCode: 59, ctrlKey: true });
         elem.dispatchEvent(event);
         expect(called).to.equal(false);

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -71,7 +71,7 @@ class DataGrid extends Widget {
    */
   constructor(options: DataGrid.IOptions = {}) {
     super();
-    this.addClass('p-DataGrid');
+    this.addClass('lm-DataGrid');
 
     // Parse the simple options.
     this._style = options.style || DataGrid.defaultStyle;
@@ -130,10 +130,10 @@ class DataGrid extends Widget {
     this._scrollCorner = new Widget();
 
     // Add the extra class names to the child widgets.
-    this._viewport.addClass('p-DataGrid-viewport');
-    this._vScrollBar.addClass('p-DataGrid-scrollBar');
-    this._hScrollBar.addClass('p-DataGrid-scrollBar');
-    this._scrollCorner.addClass('p-DataGrid-scrollCorner');
+    this._viewport.addClass('lm-DataGrid-viewport');
+    this._vScrollBar.addClass('lm-DataGrid-scrollBar');
+    this._hScrollBar.addClass('lm-DataGrid-scrollBar');
+    this._scrollCorner.addClass('lm-DataGrid-scrollCorner');
 
     // Add the on-screen canvas to the viewport node.
     this._viewport.node.appendChild(this._canvas);

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -72,6 +72,9 @@ class DataGrid extends Widget {
   constructor(options: DataGrid.IOptions = {}) {
     super();
     this.addClass('lm-DataGrid');
+    /* <DEPRECATED> */
+    this.addClass('p-DataGrid');
+    /* </DEPRECATED> */
 
     // Parse the simple options.
     this._style = options.style || DataGrid.defaultStyle;
@@ -134,6 +137,12 @@ class DataGrid extends Widget {
     this._vScrollBar.addClass('lm-DataGrid-scrollBar');
     this._hScrollBar.addClass('lm-DataGrid-scrollBar');
     this._scrollCorner.addClass('lm-DataGrid-scrollCorner');
+    /* <DEPRECATED> */
+    this._viewport.addClass('p-DataGrid-viewport');
+    this._vScrollBar.addClass('p-DataGrid-scrollBar');
+    this._hScrollBar.addClass('p-DataGrid-scrollBar');
+    this._scrollCorner.addClass('p-DataGrid-scrollCorner');
+    /* </DEPRECATED> */
 
     // Add the on-screen canvas to the viewport node.
     this._viewport.node.appendChild(this._canvas);

--- a/packages/default-theme/style/commandpalette.css
+++ b/packages/default-theme/style/commandpalette.css
@@ -8,25 +8,25 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-CommandPalette {
+.lm-CommandPalette {
   font-family: sans-serif;
   background: #F5F5F5;
 }
 
 
-.p-CommandPalette-search {
+.lm-CommandPalette-search {
   padding: 8px;
 }
 
 
-.p-CommandPalette-wrapper {
+.lm-CommandPalette-wrapper {
   padding: 4px 6px;
   background: white;
   border: 1px solid #E0E0E0;
 }
 
 
-.p-CommandPalette-input {
+.lm-CommandPalette-input {
   width: 100%;
   border: none;
   outline: none;
@@ -34,7 +34,7 @@
 }
 
 
-.p-CommandPalette-header {
+.lm-CommandPalette-header {
   padding: 4px;
   color: #757575;
   font-size: 12px;
@@ -44,20 +44,20 @@
 }
 
 
-.p-CommandPalette-header:hover::before {
+.lm-CommandPalette-header:hover::before {
   content: '\2026'; /* ellipsis */
   float: right;
   margin-right: 4px;
 }
 
 
-.p-CommandPalette-header > mark {
+.lm-CommandPalette-header > mark {
   background-color: transparent;
   font-weight: bold;
 }
 
 
-.p-CommandPalette-item {
+.lm-CommandPalette-item {
   padding: 4px 8px;
   color: #757575;
   font-size: 13px;
@@ -65,7 +65,7 @@
 }
 
 
-.p-CommandPalette-emptyMessage {
+.lm-CommandPalette-emptyMessage {
   padding: 4px;
   color: #757575;
   font-size: 12px;
@@ -74,38 +74,38 @@
 }
 
 
-.p-CommandPalette-item.p-mod-disabled {
+.lm-CommandPalette-item.lm-mod-disabled {
   color: rgba(0, 0, 0, 0.25);
 }
 
 
-.p-CommandPalette-item.p-mod-active {
+.lm-CommandPalette-item.lm-mod-active {
   background: #7FDBFF;
 }
 
 
-.p-CommandPalette-item:hover:not(.p-mod-active):not(.p-mod-disabled) {
+.lm-CommandPalette-item:hover:not(.lm-mod-active):not(.lm-mod-disabled) {
   background: #E5E5E5;
 }
 
 
-.p-CommandPalette-itemIcon {
+.lm-CommandPalette-itemIcon {
   display: none;
 }
 
 
-.p-CommandPalette-itemLabel > mark {
+.lm-CommandPalette-itemLabel > mark {
   background-color: transparent;
   font-weight: bold;
 }
 
 
-.p-CommandPalette-item.p-mod-disabled mark {
+.lm-CommandPalette-item.lm-mod-disabled mark {
   color: rgba(0, 0, 0, 0.4);
 }
 
 
-.p-CommandPalette-itemCaption {
+.lm-CommandPalette-itemCaption {
   color: #9E9E9E;
   font-size: 11px;
   font-weight: 400;

--- a/packages/default-theme/style/commandpalette.css
+++ b/packages/default-theme/style/commandpalette.css
@@ -8,17 +8,20 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-CommandPalette, /* </DEPRECATED> */
 .lm-CommandPalette {
   font-family: sans-serif;
   background: #F5F5F5;
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-search, /* </DEPRECATED> */
 .lm-CommandPalette-search {
   padding: 8px;
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-wrapper, /* </DEPRECATED> */
 .lm-CommandPalette-wrapper {
   padding: 4px 6px;
   background: white;
@@ -26,6 +29,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-input, /* </DEPRECATED> */
 .lm-CommandPalette-input {
   width: 100%;
   border: none;
@@ -34,6 +38,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-header, /* </DEPRECATED> */
 .lm-CommandPalette-header {
   padding: 4px;
   color: #757575;
@@ -44,6 +49,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-header:hover::before, /* </DEPRECATED> */
 .lm-CommandPalette-header:hover::before {
   content: '\2026'; /* ellipsis */
   float: right;
@@ -51,12 +57,14 @@
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-header > mark, /* </DEPRECATED> */
 .lm-CommandPalette-header > mark {
   background-color: transparent;
   font-weight: bold;
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-item, /* </DEPRECATED> */
 .lm-CommandPalette-item {
   padding: 4px 8px;
   color: #757575;
@@ -65,6 +73,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-emptyMessage, /* </DEPRECATED> */
 .lm-CommandPalette-emptyMessage {
   padding: 4px;
   color: #757575;
@@ -74,37 +83,48 @@
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-item.p-mod-disabled, /* </DEPRECATED> */
 .lm-CommandPalette-item.lm-mod-disabled {
   color: rgba(0, 0, 0, 0.25);
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-item.p-mod-active, /* </DEPRECATED> */
 .lm-CommandPalette-item.lm-mod-active {
   background: #7FDBFF;
 }
 
 
+/* <DEPRECATED> */
+.p-CommandPalette-item:hover:not(.p-mod-active):not(.p-mod-disabled),
+/* </DEPRECATED> */
 .lm-CommandPalette-item:hover:not(.lm-mod-active):not(.lm-mod-disabled) {
   background: #E5E5E5;
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-itemIcon, /* </DEPRECATED> */
 .lm-CommandPalette-itemIcon {
   display: none;
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-itemLabel > mark, /* </DEPRECATED> */
 .lm-CommandPalette-itemLabel > mark {
   background-color: transparent;
   font-weight: bold;
 }
 
 
+/* <DEPRECATED> */
+.p-CommandPalette-item.p-mod-disabled mark,
+/* </DEPRECATED> */
 .lm-CommandPalette-item.lm-mod-disabled mark {
   color: rgba(0, 0, 0, 0.4);
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-itemCaption, /* </DEPRECATED> */
 .lm-CommandPalette-itemCaption {
   color: #9E9E9E;
   font-size: 11px;

--- a/packages/default-theme/style/datagrid.css
+++ b/packages/default-theme/style/datagrid.css
@@ -6,6 +6,8 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
+
+/* <DEPRECATED> */ .p-DataGrid, /* </DEPRECATED> */
 .lm-DataGrid {
   min-width: 64px;
   min-height: 64px;
@@ -13,11 +15,13 @@
 }
 
 
+/* <DEPRECATED> */ .p-DataGrid-scrollCorner, /* </DEPRECATED> */
 .lm-DataGrid-scrollCorner {
   background-color: #F0F0F0;
 }
 
 
+/* <DEPRECATED> */ .p-DataGrid-scrollCorner::after, /* </DEPRECATED> */
 .lm-DataGrid-scrollCorner::after {
   content: '';
   position: absolute;

--- a/packages/default-theme/style/datagrid.css
+++ b/packages/default-theme/style/datagrid.css
@@ -6,19 +6,19 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-.p-DataGrid {
+.lm-DataGrid {
   min-width: 64px;
   min-height: 64px;
   border: 1px solid #A0A0A0;
 }
 
 
-.p-DataGrid-scrollCorner {
+.lm-DataGrid-scrollCorner {
   background-color: #F0F0F0;
 }
 
 
-.p-DataGrid-scrollCorner::after {
+.lm-DataGrid-scrollCorner::after {
   content: '';
   position: absolute;
   top: 0;

--- a/packages/default-theme/style/dockpanel.css
+++ b/packages/default-theme/style/dockpanel.css
@@ -8,6 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-DockPanel-overlay, /* </DEPRECATED> */
 .lm-DockPanel-overlay {
   background: rgba(255, 255, 255, 0.6);
   border: 1px dashed black;

--- a/packages/default-theme/style/dockpanel.css
+++ b/packages/default-theme/style/dockpanel.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-DockPanel-overlay {
+.lm-DockPanel-overlay {
   background: rgba(255, 255, 255, 0.6);
   border: 1px dashed black;
   transition-property: top, left, right, bottom;

--- a/packages/default-theme/style/menu.css
+++ b/packages/default-theme/style/menu.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-Menu {
+.lm-Menu {
   padding: 3px 0px;
   background: white;
   color: rgba(0, 0, 0, 0.87);
@@ -18,50 +18,50 @@
 }
 
 
-.p-Menu-item.p-mod-active {
+.lm-Menu-item.lm-mod-active {
   background: #E5E5E5;
 }
 
 
-.p-Menu-item.p-mod-disabled {
+.lm-Menu-item.lm-mod-disabled {
   color: rgba(0, 0, 0, 0.25);
 }
 
 
-.p-Menu-itemIcon {
+.lm-Menu-itemIcon {
   width: 21px;
   padding: 4px 2px;
 }
 
 
-.p-Menu-itemLabel {
+.lm-Menu-itemLabel {
   padding: 4px 35px 4px 2px;
 }
 
 
-.p-Menu-itemMnemonic {
+.lm-Menu-itemMnemonic {
   text-decoration: underline;
 }
 
 
-.p-Menu-itemShortcut {
+.lm-Menu-itemShortcut {
   padding: 4px 0px;
 }
 
 
-.p-Menu-itemSubmenuIcon {
+.lm-Menu-itemSubmenuIcon {
   width: 16px;
   padding: 4px 0px;
 }
 
 
-.p-Menu-item[data-type='separator'] > div {
+.lm-Menu-item[data-type='separator'] > div {
   padding: 0;
   height: 9px;
 }
 
 
-.p-Menu-item[data-type='separator'] > div::after {
+.lm-Menu-item[data-type='separator'] > div::after {
   content: '';
   display: block;
   position: relative;
@@ -70,17 +70,17 @@
 }
 
 
-.p-Menu-itemIcon::before,
-.p-Menu-itemSubmenuIcon::before {
+.lm-Menu-itemIcon::before,
+.lm-Menu-itemSubmenuIcon::before {
   font-family: FontAwesome;
 }
 
 
-.p-Menu-item.p-mod-toggled > .p-Menu-itemIcon::before {
+.lm-Menu-item.lm-mod-toggled > .lm-Menu-itemIcon::before {
   content: '\f00c';
 }
 
 
-.p-Menu-item[data-type='submenu'] > .p-Menu-itemSubmenuIcon::before {
+.lm-Menu-item[data-type='submenu'] > .lm-Menu-itemSubmenuIcon::before {
   content: '\f0da';
 }

--- a/packages/default-theme/style/menu.css
+++ b/packages/default-theme/style/menu.css
@@ -8,6 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-Menu, /* </DEPRECATED> */
 .lm-Menu {
   padding: 3px 0px;
   background: white;
@@ -18,49 +19,62 @@
 }
 
 
+/* <DEPRECATED> */ .p-Menu-item.p-mod-active, /* </DEPRECATED> */
 .lm-Menu-item.lm-mod-active {
   background: #E5E5E5;
 }
 
 
+/* <DEPRECATED> */ .p-Menu-item.p-mod-disabled, /* </DEPRECATED> */
 .lm-Menu-item.lm-mod-disabled {
   color: rgba(0, 0, 0, 0.25);
 }
 
 
+/* <DEPRECATED> */ .p-Menu-itemIcon, /* </DEPRECATED> */
 .lm-Menu-itemIcon {
   width: 21px;
   padding: 4px 2px;
 }
 
 
+/* <DEPRECATED> */ .p-Menu-itemLabel, /* </DEPRECATED> */
 .lm-Menu-itemLabel {
   padding: 4px 35px 4px 2px;
 }
 
 
+/* <DEPRECATED> */ .p-Menu-itemMnemonic, /* </DEPRECATED> */
 .lm-Menu-itemMnemonic {
   text-decoration: underline;
 }
 
 
+/* <DEPRECATED> */ .p-Menu-itemShortcut, /* </DEPRECATED> */
 .lm-Menu-itemShortcut {
   padding: 4px 0px;
 }
 
 
+/* <DEPRECATED> */ .p-Menu-itemSubmenuIcon, /* </DEPRECATED> */
 .lm-Menu-itemSubmenuIcon {
   width: 16px;
   padding: 4px 0px;
 }
 
 
+/* <DEPRECATED> */
+.p-Menu-item[data-type='separator'] > div,
+/* </DEPRECATED> */
 .lm-Menu-item[data-type='separator'] > div {
   padding: 0;
   height: 9px;
 }
 
 
+/* <DEPRECATED> */
+.p-Menu-item[data-type='separator'] > div::after,
+/* </DEPRECATED> */
 .lm-Menu-item[data-type='separator'] > div::after {
   content: '';
   display: block;
@@ -70,17 +84,27 @@
 }
 
 
+/* <DEPRECATED> */
+.p-Menu-itemIcon::before,
+.p-Menu-itemSubmenuIcon::before,
+/* </DEPRECATED> */
 .lm-Menu-itemIcon::before,
 .lm-Menu-itemSubmenuIcon::before {
   font-family: FontAwesome;
 }
 
 
+/* <DEPRECATED> */
+.p-Menu-item.lm-mod-toggled > .p-Menu-itemIcon::before,
+/* </DEPRECATED> */
 .lm-Menu-item.lm-mod-toggled > .lm-Menu-itemIcon::before {
   content: '\f00c';
 }
 
 
+/* <DEPRECATED> */
+.p-Menu-item[data-type='submenu'] > .p-Menu-itemSubmenuIcon::before,
+/* </DEPRECATED> */
 .lm-Menu-item[data-type='submenu'] > .lm-Menu-itemSubmenuIcon::before {
   content: '\f0da';
 }

--- a/packages/default-theme/style/menubar.css
+++ b/packages/default-theme/style/menubar.css
@@ -8,6 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-MenuBar, /* </DEPRECATED> */
 .lm-MenuBar {
   padding-left: 5px;
   background: #FAFAFA;
@@ -17,11 +18,13 @@
 }
 
 
+/* <DEPRECATED> */ .p-MenuBar-menu, /* </DEPRECATED> */
 .lm-MenuBar-menu {
   transform: translateY(-1px);
 }
 
 
+/* <DEPRECATED> */ .p-MenuBar-item, /* </DEPRECATED> */
 .lm-MenuBar-item {
   padding: 4px 8px;
   border-left: 1px solid transparent;
@@ -29,11 +32,15 @@
 }
 
 
+/* <DEPRECATED> */ .p-MenuBar-item.p-mod-active, /* </DEPRECATED> */
 .lm-MenuBar-item.lm-mod-active {
   background: #E5E5E5;
 }
 
 
+/* <DEPRECATED> */
+.p-MenuBar.p-mod-active .p-MenuBar-item.p-mod-active,
+/* </DEPRECATED> */
 .lm-MenuBar.lm-mod-active .lm-MenuBar-item.lm-mod-active {
   z-index: 10001;
   background: white;

--- a/packages/default-theme/style/menubar.css
+++ b/packages/default-theme/style/menubar.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-MenuBar {
+.lm-MenuBar {
   padding-left: 5px;
   background: #FAFAFA;
   color: rgba(0, 0, 0, 0.87);
@@ -17,24 +17,24 @@
 }
 
 
-.p-MenuBar-menu {
+.lm-MenuBar-menu {
   transform: translateY(-1px);
 }
 
 
-.p-MenuBar-item {
+.lm-MenuBar-item {
   padding: 4px 8px;
   border-left: 1px solid transparent;
   border-right: 1px solid transparent;
 }
 
 
-.p-MenuBar-item.p-mod-active {
+.lm-MenuBar-item.lm-mod-active {
   background: #E5E5E5;
 }
 
 
-.p-MenuBar.p-mod-active .p-MenuBar-item.p-mod-active {
+.lm-MenuBar.lm-mod-active .lm-MenuBar-item.lm-mod-active {
   z-index: 10001;
   background: white;
   border-left: 1px solid #C0C0C0;

--- a/packages/default-theme/style/scrollbar.css
+++ b/packages/default-theme/style/scrollbar.css
@@ -8,6 +8,9 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='horizontal'],
+/* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='horizontal'] {
   min-height: 16px;
   max-height: 16px;
@@ -16,6 +19,9 @@
 }
 
 
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='vertical'],
+/* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='vertical'] {
   min-width: 16px;
   max-width: 16px;
@@ -24,6 +30,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-ScrollBar-button, /* </DEPRECATED> */
 .lm-ScrollBar-button {
   background-color: #F0F0F0;
   background-position: center center;
@@ -34,36 +41,45 @@
 }
 
 
+/* <DEPRECATED> */ .p-ScrollBar-button:hover, /* </DEPRECATED> */
 .lm-ScrollBar-button:hover {
   background-color: #DADADA;
 }
 
 
+/* <DEPRECATED> */ .p-ScrollBar-button.p-mod-active, /* </DEPRECATED> */
 .lm-ScrollBar-button.lm-mod-active {
   background-color: #CDCDCD;
 }
 
 
+/* <DEPRECATED> */ .p-ScrollBar-track, /* </DEPRECATED> */
 .lm-ScrollBar-track {
   background: #F0F0F0;
 }
 
 
+/* <DEPRECATED> */ .p-ScrollBar-thumb, /* </DEPRECATED> */
 .lm-ScrollBar-thumb {
   background: #CDCDCD;
 }
 
 
+/* <DEPRECATED> */ .p-ScrollBar-thumb:hover, /* </DEPRECATED> */
 .lm-ScrollBar-thumb:hover {
   background: #BABABA;
 }
 
 
+/* <DEPRECATED> */ .p-ScrollBar-thumb.lm-mod-active, /* </DEPRECATED> */
 .lm-ScrollBar-thumb.lm-mod-active {
   background: #A0A0A0;
 }
 
 
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='horizontal'] .p-ScrollBar-thumb,
+/* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='horizontal'] .lm-ScrollBar-thumb {
   height: 100%;
   min-width: 15px;
@@ -72,6 +88,9 @@
 }
 
 
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='vertical'] .p-ScrollBar-thumb,
+/* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='vertical'] .lm-ScrollBar-thumb {
   width: 100%;
   min-height: 15px;
@@ -80,21 +99,33 @@
 }
 
 
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='horizontal'] .p-ScrollBar-button[data-action='decrement'],
+/* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='horizontal'] .lm-ScrollBar-button[data-action='decrement'] {
   background-image: url(../images/caretleft.png);
 }
 
 
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='horizontal'] .p-ScrollBar-button[data-action='increment'],
+/* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='horizontal'] .lm-ScrollBar-button[data-action='increment'] {
   background-image: url(../images/caretright.png);
 }
 
 
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='vertical'] .p-ScrollBar-button[data-action='decrement'],
+/* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='vertical'] .lm-ScrollBar-button[data-action='decrement'] {
   background-image: url(../images/caretup.png);
 }
 
 
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='vertical'] .p-ScrollBar-button[data-action='increment'],
+/* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='vertical'] .lm-ScrollBar-button[data-action='increment'] {
   background-image: url(../images/caretdown.png);
 }

--- a/packages/default-theme/style/scrollbar.css
+++ b/packages/default-theme/style/scrollbar.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-ScrollBar[data-orientation='horizontal'] {
+.lm-ScrollBar[data-orientation='horizontal'] {
   min-height: 16px;
   max-height: 16px;
   min-width: 45px;
@@ -16,7 +16,7 @@
 }
 
 
-.p-ScrollBar[data-orientation='vertical'] {
+.lm-ScrollBar[data-orientation='vertical'] {
   min-width: 16px;
   max-width: 16px;
   min-height: 45px;
@@ -24,7 +24,7 @@
 }
 
 
-.p-ScrollBar-button {
+.lm-ScrollBar-button {
   background-color: #F0F0F0;
   background-position: center center;
   min-height: 15px;
@@ -34,37 +34,37 @@
 }
 
 
-.p-ScrollBar-button:hover {
+.lm-ScrollBar-button:hover {
   background-color: #DADADA;
 }
 
 
-.p-ScrollBar-button.p-mod-active {
+.lm-ScrollBar-button.lm-mod-active {
   background-color: #CDCDCD;
 }
 
 
-.p-ScrollBar-track {
+.lm-ScrollBar-track {
   background: #F0F0F0;
 }
 
 
-.p-ScrollBar-thumb {
+.lm-ScrollBar-thumb {
   background: #CDCDCD;
 }
 
 
-.p-ScrollBar-thumb:hover {
+.lm-ScrollBar-thumb:hover {
   background: #BABABA;
 }
 
 
-.p-ScrollBar-thumb.p-mod-active {
+.lm-ScrollBar-thumb.lm-mod-active {
   background: #A0A0A0;
 }
 
 
-.p-ScrollBar[data-orientation='horizontal'] .p-ScrollBar-thumb {
+.lm-ScrollBar[data-orientation='horizontal'] .lm-ScrollBar-thumb {
   height: 100%;
   min-width: 15px;
   border-left: 1px solid #A0A0A0;
@@ -72,7 +72,7 @@
 }
 
 
-.p-ScrollBar[data-orientation='vertical'] .p-ScrollBar-thumb {
+.lm-ScrollBar[data-orientation='vertical'] .lm-ScrollBar-thumb {
   width: 100%;
   min-height: 15px;
   border-top: 1px solid #A0A0A0;
@@ -80,21 +80,21 @@
 }
 
 
-.p-ScrollBar[data-orientation='horizontal'] .p-ScrollBar-button[data-action='decrement'] {
+.lm-ScrollBar[data-orientation='horizontal'] .lm-ScrollBar-button[data-action='decrement'] {
   background-image: url(../images/caretleft.png);
 }
 
 
-.p-ScrollBar[data-orientation='horizontal'] .p-ScrollBar-button[data-action='increment'] {
+.lm-ScrollBar[data-orientation='horizontal'] .lm-ScrollBar-button[data-action='increment'] {
   background-image: url(../images/caretright.png);
 }
 
 
-.p-ScrollBar[data-orientation='vertical'] .p-ScrollBar-button[data-action='decrement'] {
+.lm-ScrollBar[data-orientation='vertical'] .lm-ScrollBar-button[data-action='decrement'] {
   background-image: url(../images/caretup.png);
 }
 
 
-.p-ScrollBar[data-orientation='vertical'] .p-ScrollBar-button[data-action='increment'] {
+.lm-ScrollBar[data-orientation='vertical'] .lm-ScrollBar-button[data-action='increment'] {
   background-image: url(../images/caretdown.png);
 }

--- a/packages/default-theme/style/tabbar.css
+++ b/packages/default-theme/style/tabbar.css
@@ -8,12 +8,14 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-TabBar, /* </DEPRECATED> */
 .lm-TabBar {
   min-height: 24px;
   max-height: 24px;
 }
 
 
+/* <DEPRECATED> */ .p-TabBar-content, /* </DEPRECATED> */
 .lm-TabBar-content {
   min-width: 0;
   min-height: 0;
@@ -22,6 +24,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-TabBar-tab, /* </DEPRECATED> */
 .lm-TabBar-tab {
   padding: 0px 10px;
   background: #E5E5E5;
@@ -37,21 +40,25 @@
 }
 
 
+/* <DEPRECATED> */ .p-TabBar-tab.p-mod-current, /* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-current {
   background: white;
 }
 
 
+/* <DEPRECATED> */ .p-TabBar-tab:hover:not(.p-mod-current), /* </DEPRECATED> */
 .lm-TabBar-tab:hover:not(.lm-mod-current) {
   background: #F0F0F0;
 }
 
 
+/* <DEPRECATED> */ .p-TabBar-tab:first-child, /* </DEPRECATED> */
 .lm-TabBar-tab:first-child {
   margin-left: 0;
 }
 
 
+/* <DEPRECATED> */ .p-TabBar-tab.p-mod-current, /* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-current {
   min-height: 23px;
   max-height: 23px;
@@ -59,6 +66,11 @@
 }
 
 
+/* <DEPRECATED> */
+.p-TabBar-tabIcon,
+.p-TabBar-tabLabel,
+.p-TabBar-tabCloseIcon,
+/* </DEPRECATED> */
 .lm-TabBar-tabIcon,
 .lm-TabBar-tabLabel,
 .lm-TabBar-tabCloseIcon {
@@ -66,17 +78,26 @@
 }
 
 
+/* <DEPRECATED> */
+.p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon,
+/* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon {
   margin-left: 4px;
 }
 
 
+/* <DEPRECATED> */
+.p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:before,
+/* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon:before {
   content: '\f00d';
   font-family: FontAwesome;
 }
 
 
+/* <DEPRECATED> */
+.p-TabBar-tab.p-mod-drag-image,
+/* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-drag-image {
   min-height: 23px;
   max-height: 23px;

--- a/packages/default-theme/style/tabbar.css
+++ b/packages/default-theme/style/tabbar.css
@@ -8,13 +8,13 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-TabBar {
+.lm-TabBar {
   min-height: 24px;
   max-height: 24px;
 }
 
 
-.p-TabBar-content {
+.lm-TabBar-content {
   min-width: 0;
   min-height: 0;
   align-items: flex-end;
@@ -22,7 +22,7 @@
 }
 
 
-.p-TabBar-tab {
+.lm-TabBar-tab {
   padding: 0px 10px;
   background: #E5E5E5;
   border: 1px solid #C0C0C0;
@@ -37,47 +37,47 @@
 }
 
 
-.p-TabBar-tab.p-mod-current {
+.lm-TabBar-tab.lm-mod-current {
   background: white;
 }
 
 
-.p-TabBar-tab:hover:not(.p-mod-current) {
+.lm-TabBar-tab:hover:not(.lm-mod-current) {
   background: #F0F0F0;
 }
 
 
-.p-TabBar-tab:first-child {
+.lm-TabBar-tab:first-child {
   margin-left: 0;
 }
 
 
-.p-TabBar-tab.p-mod-current {
+.lm-TabBar-tab.lm-mod-current {
   min-height: 23px;
   max-height: 23px;
   transform: translateY(1px);
 }
 
 
-.p-TabBar-tabIcon,
-.p-TabBar-tabLabel,
-.p-TabBar-tabCloseIcon {
+.lm-TabBar-tabIcon,
+.lm-TabBar-tabLabel,
+.lm-TabBar-tabCloseIcon {
   display: inline-block;
 }
 
 
-.p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon {
+.lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon {
   margin-left: 4px;
 }
 
 
-.p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:before {
+.lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon:before {
   content: '\f00d';
   font-family: FontAwesome;
 }
 
 
-.p-TabBar-tab.p-mod-drag-image {
+.lm-TabBar-tab.lm-mod-drag-image {
   min-height: 23px;
   max-height: 23px;
   min-width: 125px;

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -988,7 +988,7 @@ namespace Private {
    *
    * #### Notes
    * This largely implements the drag exit portion of the whatwg spec:
-   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drolm-processing-model
+   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
    */
   export
   function dispatchDragExit(drag: Drag, prevTarget: Element | null, currTarget: Element | null, event: MouseEvent): void {
@@ -1022,7 +1022,7 @@ namespace Private {
    *
    * #### Notes
    * This largely implements the drag leave portion of the whatwg spec:
-   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drolm-processing-model
+   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
    */
   export
   function dispatchDragLeave(drag: Drag, prevTarget: Element | null, currTarget: Element | null, event: MouseEvent): void {
@@ -1055,7 +1055,7 @@ namespace Private {
    *
    * #### Notes
    * This largely implements the drag over portion of the whatwg spec:
-   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drolm-processing-model
+   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
    */
   export
   function dispatchDragOver(drag: Drag, currTarget: Element | null, event: MouseEvent): DropAction {
@@ -1099,7 +1099,7 @@ namespace Private {
    *
    * #### Notes
    * This largely implements the drag over portion of the whatwg spec:
-   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drolm-processing-model
+   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
    */
   export
   function dispatchDrop(drag: Drag, currTarget: Element | null, event: MouseEvent): DropAction {

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -34,8 +34,8 @@ type SupportedActions = DropAction | 'copy-link' | 'copy-move' | 'link-move' | '
  * A custom event type used for drag-drop operations.
  *
  * #### Notes
- * In order to receive `'p-dragover'`, `'p-dragleave'`, or `'p-drop'`
- * events, a drop target must cancel the `'p-dragenter'` event by
+ * In order to receive `'lm-dragover'`, `'lm-dragleave'`, or `'lm-drop'`
+ * events, a drop target must cancel the `'lm-dragenter'` event by
  * calling the event's `preventDefault()` method.
  */
 export
@@ -45,7 +45,7 @@ interface IDragEvent extends MouseEvent {
    *
    * #### Notes
    * At the start of each event, this value will be `'none'`. During a
-   * `'p-dragover'` event, the drop target must set this value to one
+   * `'lm-dragover'` event, the drop target must set this value to one
    * of the supported actions, or the drop event will not occur.
    *
    * When handling the drop event, the drop target should set this
@@ -69,7 +69,7 @@ interface IDragEvent extends MouseEvent {
    *
    * #### Notes
    * If the `dropAction` is not set to one of the supported actions
-   * during the `'p-dragover'` event, the drop event will not occur.
+   * during the `'lm-dragover'` event, the drop event will not occur.
    */
   readonly supportedActions: SupportedActions;
 
@@ -99,18 +99,18 @@ interface IDragEvent extends MouseEvent {
  *
  * A drag object dispatches four different events to drop targets:
  *
- * - `'p-dragenter'` - Dispatched when the mouse enters the target
+ * - `'lm-dragenter'` - Dispatched when the mouse enters the target
  *   element. This event must be canceled in order to receive any
  *   of the other events.
  *
- * - `'p-dragover'` - Dispatched when the mouse moves over the drop
+ * - `'lm-dragover'` - Dispatched when the mouse moves over the drop
  *   target. It must cancel the event and set the `dropAction` to one
  *   of the supported actions in order to receive drop events.
  *
- * - `'p-dragleave'` - Dispatched when the mouse leaves the target
+ * - `'lm-dragleave'` - Dispatched when the mouse leaves the target
  *   element. This includes moving the mouse into child elements.
  *
- * - `'p-drop'`- Dispatched when the mouse is released over the target
+ * - `'lm-drop'`- Dispatched when the mouse is released over the target
  *   element when the target indicates an appropriate drop action. If
  *   the event is canceled, the indicated drop action is returned to
  *   the initiator through the resolved promise.
@@ -120,7 +120,7 @@ interface IDragEvent extends MouseEvent {
  *
  * A drag object has the ability to automatically scroll a scrollable
  * element when the mouse is hovered near one of its edges. To enable
- * this, add the `data-p-dragscroll` attribute to any element which
+ * this, add the `data-lm-dragscroll` attribute to any element which
  * the drag object should consider for scrolling.
  *
  * #### Notes
@@ -457,7 +457,7 @@ class Drag implements IDisposable {
     if (!this.dragImage) {
       return;
     }
-    this.dragImage.classList.add('p-mod-drag-image');
+    this.dragImage.classList.add('lm-mod-drag-image');
     let style = this.dragImage.style;
     style.pointerEvents = 'none';
     style.position = 'fixed';
@@ -635,7 +635,7 @@ namespace Drag {
      * mouse move event. A CSS transform can be used to offset the node
      * from its specified position.
      *
-     * The drag image will automatically have the `p-mod-drag-image`
+     * The drag image will automatically have the `lm-mod-drag-image`
      * class name added.
      *
      * The default value is `null`.
@@ -710,11 +710,11 @@ namespace Drag {
   function overrideCursor(cursor: string): IDisposable {
     let id = ++overrideCursorID;
     document.body.style.cursor = cursor;
-    document.body.classList.add('p-mod-override-cursor');
+    document.body.classList.add('lm-mod-override-cursor');
     return new DisposableDelegate(() => {
       if (id === overrideCursorID) {
         document.body.style.cursor = '';
-        document.body.classList.remove('p-mod-override-cursor');
+        document.body.classList.remove('lm-mod-override-cursor');
       }
     });
   }
@@ -803,7 +803,7 @@ namespace Private {
     // https://github.com/Microsoft/TypeScript/issues/14143
     for (; element; element = element!.parentElement) {
       // Ignore elements which are not marked as scrollable.
-      if (!element.hasAttribute('data-p-dragscroll')) {
+      if (!element.hasAttribute('data-lm-dragscroll')) {
         continue;
       }
 
@@ -916,7 +916,7 @@ namespace Private {
    *
    * #### Notes
    * This largely implements the drag enter portion of the whatwg spec:
-   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
+   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drolm-processing-model
    */
   export
   function dispatchDragEnter(drag: Drag, currElem: Element | null, currTarget: Element | null, event: MouseEvent): Element | null {
@@ -926,7 +926,7 @@ namespace Private {
     }
 
     // Dispatch a drag enter event to the current element.
-    let dragEvent = createDragEvent('p-dragenter', drag, event, currTarget);
+    let dragEvent = createDragEvent('lm-dragenter', drag, event, currTarget);
     let canceled = !currElem.dispatchEvent(dragEvent);
 
     // If the event was canceled, use the current element as the new target.
@@ -940,7 +940,7 @@ namespace Private {
     }
 
     // Dispatch a drag enter event on the document body.
-    dragEvent = createDragEvent('p-dragenter', drag, event, currTarget);
+    dragEvent = createDragEvent('lm-dragenter', drag, event, currTarget);
     document.body.dispatchEvent(dragEvent);
 
     // Ignore the event cancellation, and use the body as the new target.
@@ -962,7 +962,7 @@ namespace Private {
    *
    * #### Notes
    * This largely implements the drag exit portion of the whatwg spec:
-   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
+   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drolm-processing-model
    */
   export
   function dispatchDragExit(drag: Drag, prevTarget: Element | null, currTarget: Element | null, event: MouseEvent): void {
@@ -972,7 +972,7 @@ namespace Private {
     }
 
     // Dispatch the drag exit event to the previous target.
-    let dragEvent = createDragEvent('p-dragexit', drag, event, currTarget);
+    let dragEvent = createDragEvent('lm-dragexit', drag, event, currTarget);
     prevTarget.dispatchEvent(dragEvent);
   }
 
@@ -991,7 +991,7 @@ namespace Private {
    *
    * #### Notes
    * This largely implements the drag leave portion of the whatwg spec:
-   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
+   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drolm-processing-model
    */
   export
   function dispatchDragLeave(drag: Drag, prevTarget: Element | null, currTarget: Element | null, event: MouseEvent): void {
@@ -1001,7 +1001,7 @@ namespace Private {
     }
 
     // Dispatch the drag leave event to the previous target.
-    let dragEvent = createDragEvent('p-dragleave', drag, event, currTarget);
+    let dragEvent = createDragEvent('lm-dragleave', drag, event, currTarget);
     prevTarget.dispatchEvent(dragEvent);
   }
 
@@ -1019,7 +1019,7 @@ namespace Private {
    *
    * #### Notes
    * This largely implements the drag over portion of the whatwg spec:
-   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
+   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drolm-processing-model
    */
   export
   function dispatchDragOver(drag: Drag, currTarget: Element | null, event: MouseEvent): DropAction {
@@ -1029,7 +1029,7 @@ namespace Private {
     }
 
     // Dispatch the drag over event to the current target.
-    let dragEvent = createDragEvent('p-dragover', drag, event, null);
+    let dragEvent = createDragEvent('lm-dragover', drag, event, null);
     let canceled = !currTarget.dispatchEvent(dragEvent);
 
     // If the event was canceled, return the drop action result.
@@ -1055,7 +1055,7 @@ namespace Private {
    *
    * #### Notes
    * This largely implements the drag over portion of the whatwg spec:
-   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
+   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drolm-processing-model
    */
   export
   function dispatchDrop(drag: Drag, currTarget: Element | null, event: MouseEvent): DropAction {
@@ -1065,7 +1065,7 @@ namespace Private {
     }
 
     // Dispatch the drop event to the current target.
-    let dragEvent = createDragEvent('p-drop', drag, event, null);
+    let dragEvent = createDragEvent('lm-drop', drag, event, null);
     let canceled = !currTarget.dispatchEvent(dragEvent);
 
     // If the event was canceled, return the drop action result.

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -916,7 +916,7 @@ namespace Private {
    *
    * #### Notes
    * This largely implements the drag enter portion of the whatwg spec:
-   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drolm-processing-model
+   * https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model
    */
   export
   function dispatchDragEnter(drag: Drag, currElem: Element | null, currTarget: Element | null, event: MouseEvent): Element | null {

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -458,6 +458,9 @@ class Drag implements IDisposable {
       return;
     }
     this.dragImage.classList.add('lm-mod-drag-image');
+    /* <DEPRECATED> */
+    this.dragImage.classList.add('p-mod-drag-image');
+    /* </DEPRECATED> */
     let style = this.dragImage.style;
     style.pointerEvents = 'none';
     style.position = 'fixed';
@@ -711,10 +714,16 @@ namespace Drag {
     let id = ++overrideCursorID;
     document.body.style.cursor = cursor;
     document.body.classList.add('lm-mod-override-cursor');
+    /* <DEPRECATED> */
+    document.body.classList.add('p-mod-override-cursor');
+    /* </DEPRECATED> */
     return new DisposableDelegate(() => {
       if (id === overrideCursorID) {
         document.body.style.cursor = '';
         document.body.classList.remove('lm-mod-override-cursor');
+        /* <DEPRECATED> */
+        document.body.classList.remove('p-mod-override-cursor');
+        /* </DEPRECATED> */
       }
     });
   }
@@ -803,7 +812,11 @@ namespace Private {
     // https://github.com/Microsoft/TypeScript/issues/14143
     for (; element; element = element!.parentElement) {
       // Ignore elements which are not marked as scrollable.
-      if (!element.hasAttribute('data-lm-dragscroll')) {
+      let scrollable = element.hasAttribute('data-lm-dragscroll');
+      /* <DEPRECATED> */
+      scrollable = scrollable || element.hasAttribute('data-p-dragscroll');
+      /* </DEPRECATED> */
+      if (!scrollable) {
         continue;
       }
 
@@ -934,6 +947,14 @@ namespace Private {
       return currElem;
     }
 
+    /* <DEPRECATED> */
+    dragEvent = createDragEvent('p-dragenter', drag, event, currTarget);
+    canceled = !currElem.dispatchEvent(dragEvent);
+    if (canceled) {
+      return currElem;
+    }
+    /* </DEPRECATED> */
+
     // If the current element is the document body, keep the original target.
     if (currElem === document.body) {
       return currTarget;
@@ -942,6 +963,11 @@ namespace Private {
     // Dispatch a drag enter event on the document body.
     dragEvent = createDragEvent('lm-dragenter', drag, event, currTarget);
     document.body.dispatchEvent(dragEvent);
+
+    /* <DEPRECATED> */
+    dragEvent = createDragEvent('p-dragenter', drag, event, currTarget);
+    document.body.dispatchEvent(dragEvent);
+    /* </DEPRECATED> */
 
     // Ignore the event cancellation, and use the body as the new target.
     return document.body;
@@ -974,6 +1000,11 @@ namespace Private {
     // Dispatch the drag exit event to the previous target.
     let dragEvent = createDragEvent('lm-dragexit', drag, event, currTarget);
     prevTarget.dispatchEvent(dragEvent);
+
+    /* <DEPRECATED> */
+    dragEvent = createDragEvent('p-dragexit', drag, event, currTarget);
+    prevTarget.dispatchEvent(dragEvent);
+    /* </DEPRECATED> */
   }
 
   /**
@@ -1003,6 +1034,11 @@ namespace Private {
     // Dispatch the drag leave event to the previous target.
     let dragEvent = createDragEvent('lm-dragleave', drag, event, currTarget);
     prevTarget.dispatchEvent(dragEvent);
+
+    /* <DEPRECATED> */
+    dragEvent = createDragEvent('p-dragleave', drag, event, currTarget);
+    prevTarget.dispatchEvent(dragEvent);
+    /* </DEPRECATED> */
   }
 
   /**
@@ -1036,6 +1072,14 @@ namespace Private {
     if (canceled) {
       return dragEvent.dropAction;
     }
+
+    /* <DEPRECATED> */
+    dragEvent = createDragEvent('p-dragover', drag, event, null);
+    canceled = !currTarget.dispatchEvent(dragEvent);
+    if (canceled) {
+      return dragEvent.dropAction;
+    }
+    /* </DEPRECATED> */
 
     // Otherwise, the effective drop action is none.
     return 'none';
@@ -1072,6 +1116,14 @@ namespace Private {
     if (canceled) {
       return dragEvent.dropAction;
     }
+
+    /* <DEPRECATED> */
+    dragEvent = createDragEvent('p-drop', drag, event, null);
+    canceled = !currTarget.dispatchEvent(dragEvent);
+    if (canceled) {
+      return dragEvent.dropAction;
+    }
+    /* </DEPRECATED> */
 
     // Otherwise, the effective drop action is none.
     return 'none';

--- a/packages/dragdrop/style/index.css
+++ b/packages/dragdrop/style/index.css
@@ -8,6 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ body.p-mod-override-cursor *, /* </DEPRECATED> */
 body.lm-mod-override-cursor * {
   cursor: inherit !important;
 }

--- a/packages/dragdrop/style/index.css
+++ b/packages/dragdrop/style/index.css
@@ -8,6 +8,6 @@
 |----------------------------------------------------------------------------*/
 
 
-body.p-mod-override-cursor * {
+body.lm-mod-override-cursor * {
   cursor: inherit !important;
 }

--- a/packages/dragdrop/tests/src/index.spec.ts
+++ b/packages/dragdrop/tests/src/index.spec.ts
@@ -40,7 +40,7 @@ class DropTarget {
     this.node.addEventListener('lm-dragenter', this);
     this.node.addEventListener('lm-dragover', this);
     this.node.addEventListener('lm-dragleave', this);
-    this.node.addEventListener('p-drop', this);
+    this.node.addEventListener('lm-drop', this);
     document.body.appendChild(this.node);
   }
 
@@ -49,7 +49,7 @@ class DropTarget {
     this.node.removeEventListener('lm-dragenter', this);
     this.node.removeEventListener('lm-dragover', this);
     this.node.removeEventListener('lm-dragleave', this);
-    this.node.removeEventListener('p-drop', this);
+    this.node.removeEventListener('lm-drop', this);
   }
 
   handleEvent(event: Event): void {
@@ -64,7 +64,7 @@ class DropTarget {
     case 'lm-dragover':
       this._evtDragOver(event as IDragEvent);
       break;
-    case 'p-drop':
+    case 'lm-drop':
       this._evtDrop(event as IDragEvent);
       break;
     }
@@ -379,7 +379,7 @@ describe('@lumino/dragdrop', () => {
         it('should dispatch the drop event at the current target', () => {
           let rect = child0.node.getBoundingClientRect();
           simulate(child0.node, 'mouseup', { clientX: rect.left + 1, clientY: rect.top + 1 } );
-          expect(child0.events).to.contain('p-drop');
+          expect(child0.events).to.contain('lm-drop');
         });
 
         it('should resolve with the drop action', (done) => {

--- a/packages/dragdrop/tests/src/index.spec.ts
+++ b/packages/dragdrop/tests/src/index.spec.ts
@@ -525,10 +525,10 @@ describe('@lumino/dragdrop', () => {
         override.dispose();
       });
 
-      it('should add the `p-mod-override-cursor` class to the body', () => {
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(false);
+      it('should add the `lm-mod-override-cursor` class to the body', () => {
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(false);
         let override = Drag.overrideCursor('wait');
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(true);
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(true);
         override.dispose();
       });
 
@@ -540,35 +540,35 @@ describe('@lumino/dragdrop', () => {
         expect(document.body.style.cursor).to.equal('');
       });
 
-      it('should remove the `p-mod-override-cursor` class when disposed', () => {
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(false);
+      it('should remove the `lm-mod-override-cursor` class when disposed', () => {
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(false);
         let override = Drag.overrideCursor('wait');
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(true);
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(true);
         override.dispose();
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(false);
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(false);
       });
 
       it('should respect the most recent override', () => {
         expect(document.body.style.cursor).to.equal('');
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(false);
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(false);
         let one = Drag.overrideCursor('wait');
         expect(document.body.style.cursor).to.equal('wait');
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(true);
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(true);
         let two = Drag.overrideCursor('default');
         expect(document.body.style.cursor).to.equal('default');
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(true);
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(true);
         let three = Drag.overrideCursor('cell');
         expect(document.body.style.cursor).to.equal('cell');
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(true);
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(true);
         two.dispose();
         expect(document.body.style.cursor).to.equal('cell');
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(true);
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(true);
         one.dispose();
         expect(document.body.style.cursor).to.equal('cell');
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(true);
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(true);
         three.dispose();
         expect(document.body.style.cursor).to.equal('');
-        expect(document.body.classList.contains('p-mod-override-cursor')).to.equal(false);
+        expect(document.body.classList.contains('lm-mod-override-cursor')).to.equal(false);
       });
 
       it('should override the computed cursor for a node', () => {

--- a/packages/dragdrop/tests/src/index.spec.ts
+++ b/packages/dragdrop/tests/src/index.spec.ts
@@ -37,31 +37,31 @@ class DropTarget {
   constructor() {
     this.node.style.minWidth = '100px';
     this.node.style.minHeight = '100px';
-    this.node.addEventListener('p-dragenter', this);
-    this.node.addEventListener('p-dragover', this);
-    this.node.addEventListener('p-dragleave', this);
+    this.node.addEventListener('lm-dragenter', this);
+    this.node.addEventListener('lm-dragover', this);
+    this.node.addEventListener('lm-dragleave', this);
     this.node.addEventListener('p-drop', this);
     document.body.appendChild(this.node);
   }
 
   dispose(): void {
     document.body.removeChild(this.node);
-    this.node.removeEventListener('p-dragenter', this);
-    this.node.removeEventListener('p-dragover', this);
-    this.node.removeEventListener('p-dragleave', this);
+    this.node.removeEventListener('lm-dragenter', this);
+    this.node.removeEventListener('lm-dragover', this);
+    this.node.removeEventListener('lm-dragleave', this);
     this.node.removeEventListener('p-drop', this);
   }
 
   handleEvent(event: Event): void {
     this.events.push(event.type);
     switch (event.type) {
-    case 'p-dragenter':
+    case 'lm-dragenter':
       this._evtDragEnter(event as IDragEvent);
       break;
-    case 'p-dragleave':
+    case 'lm-dragleave':
       this._evtDragLeave(event as IDragEvent);
       break;
-    case 'p-dragover':
+    case 'lm-dragover':
       this._evtDragOver(event as IDragEvent);
       break;
     case 'p-drop':
@@ -307,18 +307,18 @@ describe('@lumino/dragdrop', () => {
         it('should dispatch an enter and leave events', () => {
           let rect = child0.node.getBoundingClientRect();
           simulate(child0.node, 'mousemove', { clientX: rect.left + 1, clientY: rect.top + 1 } );
-          expect(child0.events).to.contain('p-dragenter');
+          expect(child0.events).to.contain('lm-dragenter');
           child0.events = [];
           rect = child1.node.getBoundingClientRect();
           simulate(child1.node, 'mousemove', { clientX: rect.left + 1, clientY: rect.top + 1 } );
-          expect(child0.events).to.contain('p-dragleave');
-          expect(child1.events).to.contain('p-dragenter');
+          expect(child0.events).to.contain('lm-dragleave');
+          expect(child1.events).to.contain('lm-dragenter');
         });
 
         it('should dispatch drag over event', () => {
           let rect = child0.node.getBoundingClientRect();
           simulate(child0.node, 'mousemove', { clientX: rect.left + 1, clientY: rect.top + 1 } );
-          expect(child0.events).to.contain('p-dragover');
+          expect(child0.events).to.contain('lm-dragover');
         });
 
         it('should move the drag image to the client location', () => {
@@ -342,18 +342,18 @@ describe('@lumino/dragdrop', () => {
         it('should do nothing if the left button is not released', () => {
           let rect = child0.node.getBoundingClientRect();
           simulate(child0.node, 'mouseup', { clientX: rect.left + 1, clientY: rect.top + 1, button: 1 } );
-          expect(child0.events).to.not.contain('p-dragenter');
+          expect(child0.events).to.not.contain('lm-dragenter');
         });
 
         it('should dispatch enter and leave events', () => {
           let rect = child0.node.getBoundingClientRect();
           simulate(child0.node, 'mousemove', { clientX: rect.left + 1, clientY: rect.top + 1 } );
-          expect(child0.events).to.contain('p-dragenter');
+          expect(child0.events).to.contain('lm-dragenter');
           child0.events = [];
           rect = child1.node.getBoundingClientRect();
           simulate(child1.node, 'mouseup', { clientX: rect.left + 1, clientY: rect.top + 1 } );
-          expect(child0.events).to.contain('p-dragleave');
-          expect(child1.events).to.contain('p-dragenter');
+          expect(child0.events).to.contain('lm-dragleave');
+          expect(child1.events).to.contain('lm-dragenter');
         });
 
         it("should dispatch a leave event if the last drop action was `'none'", () => {
@@ -362,7 +362,7 @@ describe('@lumino/dragdrop', () => {
           drag.start(0, 0);
           let rect = child0.node.getBoundingClientRect();
           simulate(child0.node, 'mouseup', { clientX: rect.left + 1, clientY: rect.top + 1 } );
-          expect(child0.events).to.contain('p-dragleave');
+          expect(child0.events).to.contain('lm-dragleave');
         });
 
         it("should finalize the drag with `'none' if the last drop action was `'none`", (done) => {

--- a/packages/widgets/src/boxpanel.ts
+++ b/packages/widgets/src/boxpanel.ts
@@ -36,6 +36,9 @@ class BoxPanel extends Panel {
   constructor(options: BoxPanel.IOptions = {}) {
     super({ layout: Private.createLayout(options) });
     this.addClass('lm-BoxPanel');
+    /* <DEPRECATED> */
+    this.addClass('p-BoxPanel');
+    /* </DEPRECATED> */
   }
 
   /**
@@ -97,6 +100,9 @@ class BoxPanel extends Panel {
    */
   protected onChildAdded(msg: Widget.ChildMessage): void {
     msg.child.addClass('lm-BoxPanel-child');
+    /* <DEPRECATED> */
+    msg.child.addClass('p-BoxPanel-child');
+    /* </DEPRECATED> */
   }
 
   /**
@@ -104,6 +110,9 @@ class BoxPanel extends Panel {
    */
   protected onChildRemoved(msg: Widget.ChildMessage): void {
     msg.child.removeClass('lm-BoxPanel-child');
+    /* <DEPRECATED> */
+    msg.child.removeClass('p-BoxPanel-child');
+    /* </DEPRECATED> */
   }
 }
 

--- a/packages/widgets/src/boxpanel.ts
+++ b/packages/widgets/src/boxpanel.ts
@@ -35,7 +35,7 @@ class BoxPanel extends Panel {
    */
   constructor(options: BoxPanel.IOptions = {}) {
     super({ layout: Private.createLayout(options) });
-    this.addClass('p-BoxPanel');
+    this.addClass('lm-BoxPanel');
   }
 
   /**
@@ -96,14 +96,14 @@ class BoxPanel extends Panel {
    * A message handler invoked on a `'child-added'` message.
    */
   protected onChildAdded(msg: Widget.ChildMessage): void {
-    msg.child.addClass('p-BoxPanel-child');
+    msg.child.addClass('lm-BoxPanel-child');
   }
 
   /**
    * A message handler invoked on a `'child-removed'` message.
    */
   protected onChildRemoved(msg: Widget.ChildMessage): void {
-    msg.child.removeClass('p-BoxPanel-child');
+    msg.child.removeClass('lm-BoxPanel-child');
   }
 }
 

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -49,6 +49,9 @@ class CommandPalette extends Widget {
   constructor(options: CommandPalette.IOptions) {
     super({ node: Private.createNode() });
     this.addClass('lm-CommandPalette');
+    /* <DEPRECATED> */
+    this.addClass('p-CommandPalette');
+    /* </DEPRECATED> */
     this.setFlag(Widget.Flag.DisallowLayout);
     this.commands = options.commands;
     this.renderer = options.renderer || CommandPalette.defaultRenderer;
@@ -468,6 +471,9 @@ class CommandPalette extends Widget {
   private _toggleFocused(): void {
     let focused = document.activeElement === this.inputNode;
     this.toggleClass('lm-mod-focused', focused);
+    /* <DEPRECATED> */
+    this.toggleClass('p-mod-focused', focused);
+    /* </DEPRECATED> */
   }
 
   /**
@@ -720,7 +726,12 @@ namespace CommandPalette {
      */
     renderHeader(data: IHeaderRenderData): VirtualElement {
       let content = this.formatHeader(data);
-      return h.li({ className: 'lm-CommandPalette-header' }, content);
+      return h.li({ className:
+        'lm-CommandPalette-header'
+          /* <DEPRECATED> */
+          + ' p-CommandPalette-header'
+          /* </DEPRECATED> */
+      }, content);
     }
 
     /**
@@ -751,7 +762,12 @@ namespace CommandPalette {
      */
     renderEmptyMessage(data: IEmptyMessageRenderData): VirtualElement {
       let content = this.formatEmptyMessage(data);
-      return h.li({ className: 'lm-CommandPalette-emptyMessage' }, content);
+      return h.li({
+        className: 'lm-CommandPalette-emptyMessage'
+          /* <DEPRECATED> */
+          + ' p-CommandPalette-emptyMessage'
+          /* </DEPRECATED> */
+      }, content);
     }
 
     /**
@@ -775,7 +791,12 @@ namespace CommandPalette {
      */
     renderItemContent(data: IItemRenderData): VirtualElement {
       return (
-        h.div({ className: 'lm-CommandPalette-itemContent' },
+        h.div({
+          className: 'lm-CommandPalette-itemContent'
+            /* <DEPRECATED> */
+            + ' p-CommandPalette-itemContent'
+            /* </DEPRECATED> */
+        },
           this.renderItemLabel(data),
           this.renderItemCaption(data)
         )
@@ -791,7 +812,12 @@ namespace CommandPalette {
      */
     renderItemLabel(data: IItemRenderData): VirtualElement {
       let content = this.formatItemLabel(data);
-      return h.div({ className: 'lm-CommandPalette-itemLabel' }, content);
+      return h.div({
+        className: 'lm-CommandPalette-itemLabel'
+          /* <DEPRECATED> */
+          + ' p-CommandPalette-itemLabel'
+          /* </DEPRECATED> */
+      }, content);
     }
 
     /**
@@ -803,7 +829,12 @@ namespace CommandPalette {
      */
     renderItemCaption(data: IItemRenderData): VirtualElement {
       let content = this.formatItemCaption(data);
-      return h.div({ className: 'lm-CommandPalette-itemCaption' }, content);
+      return h.div({
+        className: 'lm-CommandPalette-itemCaption'
+          /* <DEPRECATED> */
+          + ' p-CommandPalette-itemCaption'
+          /* </DEPRECATED> */
+      }, content);
     }
 
     /**
@@ -815,7 +846,12 @@ namespace CommandPalette {
      */
     renderItemShortcut(data: IItemRenderData): VirtualElement {
       let content = this.formatItemShortcut(data);
-      return h.div({ className: 'lm-CommandPalette-itemShortcut' }, content);
+      return h.div({
+        className: 'lm-CommandPalette-itemShortcut'
+          /* <DEPRECATED> */
+          + ' p-CommandPalette-itemShortcut'
+          /* </DEPRECATED> */
+      }, content);
     }
 
     /**
@@ -828,16 +864,28 @@ namespace CommandPalette {
     createItemClass(data: IItemRenderData): string {
       // Set up the initial class name.
       let name = 'lm-CommandPalette-item';
+      /* <DEPRECATED> */
+      name += ' p-CommandPalette-item';
+      /* </DEPRECATED> */
 
       // Add the boolean state classes.
       if (!data.item.isEnabled) {
         name += ' lm-mod-disabled';
+        /* <DEPRECATED> */
+        name += ' p-mod-disabled';
+        /* </DEPRECATED> */
       }
       if (data.item.isToggled) {
         name += ' lm-mod-toggled';
+        /* <DEPRECATED> */
+        name += ' p-mod-toggled';
+        /* </DEPRECATED> */
       }
       if (data.active) {
         name += ' lm-mod-active';
+        /* <DEPRECATED> */
+        name += ' p-mod-active';
+        /* </DEPRECATED> */
       }
 
       // Add the extra class.
@@ -870,6 +918,9 @@ namespace CommandPalette {
      */
     createIconClass(data: IItemRenderData): string {
       let name = 'lm-CommandPalette-itemIcon';
+      /* <DEPRECATED> */
+      name += ' p-CommandPalette-itemIcon';
+      /* </DEPRECATED> */
       let extra = data.item.iconClass;
       return extra ? `${name} ${extra}` : name;
     }
@@ -963,6 +1014,12 @@ namespace Private {
     wrapper.className = 'lm-CommandPalette-wrapper';
     input.className = 'lm-CommandPalette-input';
     content.className = 'lm-CommandPalette-content';
+    /* <DEPRECATED> */
+    search.classList.add('p-CommandPalette-search');
+    wrapper.classList.add('p-CommandPalette-wrapper');
+    input.classList.add('p-CommandPalette-input');
+    content.classList.add('p-CommandPalette-content');
+    /* </DEPRECATED> */
     input.spellcheck = false;
     wrapper.appendChild(input);
     search.appendChild(wrapper);

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -48,7 +48,7 @@ class CommandPalette extends Widget {
    */
   constructor(options: CommandPalette.IOptions) {
     super({ node: Private.createNode() });
-    this.addClass('p-CommandPalette');
+    this.addClass('lm-CommandPalette');
     this.setFlag(Widget.Flag.DisallowLayout);
     this.commands = options.commands;
     this.renderer = options.renderer || CommandPalette.defaultRenderer;
@@ -82,7 +82,7 @@ class CommandPalette extends Widget {
    * This is the node which contains the search-related elements.
    */
   get searchNode(): HTMLDivElement {
-    return this.node.getElementsByClassName('p-CommandPalette-search')[0] as HTMLDivElement;
+    return this.node.getElementsByClassName('lm-CommandPalette-search')[0] as HTMLDivElement;
   }
 
   /**
@@ -92,7 +92,7 @@ class CommandPalette extends Widget {
    * This is the actual input node for the search area.
    */
   get inputNode(): HTMLInputElement {
-    return this.node.getElementsByClassName('p-CommandPalette-input')[0] as HTMLInputElement;
+    return this.node.getElementsByClassName('lm-CommandPalette-input')[0] as HTMLInputElement;
   }
 
   /**
@@ -104,7 +104,7 @@ class CommandPalette extends Widget {
    * Modifying this node directly can lead to undefined behavior.
    */
   get contentNode(): HTMLUListElement {
-    return this.node.getElementsByClassName('p-CommandPalette-content')[0] as HTMLUListElement;
+    return this.node.getElementsByClassName('lm-CommandPalette-content')[0] as HTMLUListElement;
   }
 
   /**
@@ -467,7 +467,7 @@ class CommandPalette extends Widget {
    */
   private _toggleFocused(): void {
     let focused = document.activeElement === this.inputNode;
-    this.toggleClass('p-mod-focused', focused);
+    this.toggleClass('lm-mod-focused', focused);
   }
 
   /**
@@ -720,7 +720,7 @@ namespace CommandPalette {
      */
     renderHeader(data: IHeaderRenderData): VirtualElement {
       let content = this.formatHeader(data);
-      return h.li({ className: 'p-CommandPalette-header' }, content);
+      return h.li({ className: 'lm-CommandPalette-header' }, content);
     }
 
     /**
@@ -751,7 +751,7 @@ namespace CommandPalette {
      */
     renderEmptyMessage(data: IEmptyMessageRenderData): VirtualElement {
       let content = this.formatEmptyMessage(data);
-      return h.li({ className: 'p-CommandPalette-emptyMessage' }, content);
+      return h.li({ className: 'lm-CommandPalette-emptyMessage' }, content);
     }
 
     /**
@@ -775,7 +775,7 @@ namespace CommandPalette {
      */
     renderItemContent(data: IItemRenderData): VirtualElement {
       return (
-        h.div({ className: 'p-CommandPalette-itemContent' },
+        h.div({ className: 'lm-CommandPalette-itemContent' },
           this.renderItemLabel(data),
           this.renderItemCaption(data)
         )
@@ -791,7 +791,7 @@ namespace CommandPalette {
      */
     renderItemLabel(data: IItemRenderData): VirtualElement {
       let content = this.formatItemLabel(data);
-      return h.div({ className: 'p-CommandPalette-itemLabel' }, content);
+      return h.div({ className: 'lm-CommandPalette-itemLabel' }, content);
     }
 
     /**
@@ -803,7 +803,7 @@ namespace CommandPalette {
      */
     renderItemCaption(data: IItemRenderData): VirtualElement {
       let content = this.formatItemCaption(data);
-      return h.div({ className: 'p-CommandPalette-itemCaption' }, content);
+      return h.div({ className: 'lm-CommandPalette-itemCaption' }, content);
     }
 
     /**
@@ -815,7 +815,7 @@ namespace CommandPalette {
      */
     renderItemShortcut(data: IItemRenderData): VirtualElement {
       let content = this.formatItemShortcut(data);
-      return h.div({ className: 'p-CommandPalette-itemShortcut' }, content);
+      return h.div({ className: 'lm-CommandPalette-itemShortcut' }, content);
     }
 
     /**
@@ -827,17 +827,17 @@ namespace CommandPalette {
      */
     createItemClass(data: IItemRenderData): string {
       // Set up the initial class name.
-      let name = 'p-CommandPalette-item';
+      let name = 'lm-CommandPalette-item';
 
       // Add the boolean state classes.
       if (!data.item.isEnabled) {
-        name += ' p-mod-disabled';
+        name += ' lm-mod-disabled';
       }
       if (data.item.isToggled) {
-        name += ' p-mod-toggled';
+        name += ' lm-mod-toggled';
       }
       if (data.active) {
-        name += ' p-mod-active';
+        name += ' lm-mod-active';
       }
 
       // Add the extra class.
@@ -869,7 +869,7 @@ namespace CommandPalette {
      * @returns The full class name for the item icon.
      */
     createIconClass(data: IItemRenderData): string {
-      let name = 'p-CommandPalette-itemIcon';
+      let name = 'lm-CommandPalette-itemIcon';
       let extra = data.item.iconClass;
       return extra ? `${name} ${extra}` : name;
     }
@@ -959,10 +959,10 @@ namespace Private {
     let wrapper = document.createElement('div');
     let input = document.createElement('input');
     let content = document.createElement('ul');
-    search.className = 'p-CommandPalette-search';
-    wrapper.className = 'p-CommandPalette-wrapper';
-    input.className = 'p-CommandPalette-input';
-    content.className = 'p-CommandPalette-content';
+    search.className = 'lm-CommandPalette-search';
+    wrapper.className = 'lm-CommandPalette-wrapper';
+    input.className = 'lm-CommandPalette-input';
+    content.className = 'lm-CommandPalette-content';
     input.spellcheck = false;
     wrapper.appendChild(input);
     search.appendChild(wrapper);

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -198,7 +198,7 @@ class DockLayout extends Layout {
    */
   moveHandle(handle: HTMLDivElement, offsetX: number, offsetY: number): void {
     // Bail early if there is no root or if the handle is hidden.
-    if (!this._root || handle.classList.contains('p-mod-hidden')) {
+    if (!this._root || handle.classList.contains('lm-mod-hidden')) {
       return;
     }
 
@@ -1818,9 +1818,9 @@ namespace Private {
       each(this.handles, (handle, i) => {
         handle.setAttribute('data-orientation', this.orientation);
         if (i === this.handles.length - 1) {
-          handle.classList.add('p-mod-hidden');
+          handle.classList.add('lm-mod-hidden');
         } else {
-          handle.classList.remove('p-mod-hidden');
+          handle.classList.remove('lm-mod-hidden');
         }
       });
     }

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -1819,8 +1819,14 @@ namespace Private {
         handle.setAttribute('data-orientation', this.orientation);
         if (i === this.handles.length - 1) {
           handle.classList.add('lm-mod-hidden');
+          /* <DEPRECATED> */
+          handle.classList.add('p-mod-hidden');
+          /* </DEPRECATED> */
         } else {
           handle.classList.remove('lm-mod-hidden');
+          /* <DEPRECATED> */
+          handle.classList.remove('p-mod-hidden');
+          /* </DEPRECATED> */
         }
       });
     }

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -198,7 +198,11 @@ class DockLayout extends Layout {
    */
   moveHandle(handle: HTMLDivElement, offsetX: number, offsetY: number): void {
     // Bail early if there is no root or if the handle is hidden.
-    if (!this._root || handle.classList.contains('lm-mod-hidden')) {
+    let hidden = handle.classList.contains('lm-mod-hidden');
+    /* <DEPRECATED> */
+    hidden = hidden || handle.classList.contains('p-mod-hidden');
+    /* </DEPRECATED> */
+    if (!this._root || hidden) {
       return;
     }
 

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -964,12 +964,12 @@ class DockPanel extends Widget {
     });
 
     // Hide the tab node in the original tab.
-    tab.classList.add('p-mod-hidden');
+    tab.classList.add('lm-mod-hidden');
 
     // Create the cleanup callback.
     let cleanup = (() => {
       this._drag = null;
-      tab.classList.remove('p-mod-hidden');
+      tab.classList.remove('lm-mod-hidden');
     });
 
     // Start the drag operation and cleanup when done.
@@ -1178,7 +1178,7 @@ namespace DockPanel {
     constructor() {
       this.node = document.createElement('div');
       this.node.classList.add('p-DockPanel-overlay');
-      this.node.classList.add('p-mod-hidden');
+      this.node.classList.add('lm-mod-hidden');
       this.node.style.position = 'absolute';
     }
 
@@ -1213,7 +1213,7 @@ namespace DockPanel {
       this._hidden = false;
 
       // Finally, show the overlay.
-      this.node.classList.remove('p-mod-hidden');
+      this.node.classList.remove('lm-mod-hidden');
     }
 
     /**
@@ -1233,7 +1233,7 @@ namespace DockPanel {
         clearTimeout(this._timer);
         this._timer = -1;
         this._hidden = true;
-        this.node.classList.add('p-mod-hidden');
+        this.node.classList.add('lm-mod-hidden');
         return;
       }
 
@@ -1246,7 +1246,7 @@ namespace DockPanel {
       this._timer = window.setTimeout(() => {
         this._timer = -1;
         this._hidden = true;
-        this.node.classList.add('p-mod-hidden');
+        this.node.classList.add('lm-mod-hidden');
       }, delay);
     }
 

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -397,7 +397,7 @@ class DockPanel extends Widget {
     case 'lm-dragover':
       this._evtDragOver(event as IDragEvent);
       break;
-    case 'p-drop':
+    case 'lm-drop':
       this._evtDrop(event as IDragEvent);
       break;
     case 'mousedown':
@@ -426,7 +426,7 @@ class DockPanel extends Widget {
     this.node.addEventListener('lm-dragenter', this);
     this.node.addEventListener('lm-dragleave', this);
     this.node.addEventListener('lm-dragover', this);
-    this.node.addEventListener('p-drop', this);
+    this.node.addEventListener('lm-drop', this);
     this.node.addEventListener('mousedown', this);
   }
 
@@ -437,7 +437,7 @@ class DockPanel extends Widget {
     this.node.removeEventListener('lm-dragenter', this);
     this.node.removeEventListener('lm-dragleave', this);
     this.node.removeEventListener('lm-dragover', this);
-    this.node.removeEventListener('p-drop', this);
+    this.node.removeEventListener('lm-drop', this);
     this.node.removeEventListener('mousedown', this);
     this._releaseMouse();
   }
@@ -515,7 +515,7 @@ class DockPanel extends Widget {
   }
 
   /**
-   * Handle the `'p-drop'` event for the dock panel.
+   * Handle the `'lm-drop'` event for the dock panel.
    */
   private _evtDrop(event: IDragEvent): void {
     // Mark the event as handled.

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -65,6 +65,9 @@ class DockPanel extends Widget {
   constructor(options: DockPanel.IOptions = {}) {
     super();
     this.addClass('lm-DockPanel');
+    /* <DEPRECATED> */
+    this.addClass('p-DockPanel');
+    /* </DEPRECATED> */
     this._mode = options.mode || 'multiple-document';
     this._renderer = options.renderer || DockPanel.defaultRenderer;
     this._edges = options.edges || Private.DEFAULT_EDGES;
@@ -453,6 +456,9 @@ class DockPanel extends Widget {
 
     // Add the widget class to the child.
     msg.child.addClass('lm-DockPanel-widget');
+    /* <DEPRECATED> */
+    msg.child.addClass('p-DockPanel-widget');
+    /* </DEPRECATED> */
   }
 
   /**
@@ -466,6 +472,9 @@ class DockPanel extends Widget {
 
     // Remove the widget class from the child.
     msg.child.removeClass('lm-DockPanel-widget');
+    /* <DEPRECATED> */
+    msg.child.removeClass('p-DockPanel-widget');
+    /* </DEPRECATED> */
 
     // Schedule an emit of the layout modified signal.
     MessageLoop.postMessage(this, Private.LayoutModified);
@@ -965,11 +974,17 @@ class DockPanel extends Widget {
 
     // Hide the tab node in the original tab.
     tab.classList.add('lm-mod-hidden');
+    /* <DEPRECATED> */
+    tab.classList.add('p-mod-hidden');
+    /* </DEPRECATED> */;
 
     // Create the cleanup callback.
     let cleanup = (() => {
       this._drag = null;
       tab.classList.remove('lm-mod-hidden');
+      /* <DEPRECATED> */
+      tab.classList.remove('p-mod-hidden');
+      /* </DEPRECATED> */;
     });
 
     // Start the drag operation and cleanup when done.
@@ -1179,6 +1194,10 @@ namespace DockPanel {
       this.node = document.createElement('div');
       this.node.classList.add('lm-DockPanel-overlay');
       this.node.classList.add('lm-mod-hidden');
+      /* <DEPRECATED> */
+      this.node.classList.add('p-DockPanel-overlay');
+      this.node.classList.add('p-mod-hidden');
+      /* </DEPRECATED> */;
       this.node.style.position = 'absolute';
     }
 
@@ -1214,6 +1233,9 @@ namespace DockPanel {
 
       // Finally, show the overlay.
       this.node.classList.remove('lm-mod-hidden');
+      /* <DEPRECATED> */
+      this.node.classList.remove('p-mod-hidden');
+      /* </DEPRECATED> */;
     }
 
     /**
@@ -1234,6 +1256,9 @@ namespace DockPanel {
         this._timer = -1;
         this._hidden = true;
         this.node.classList.add('lm-mod-hidden');
+        /* <DEPRECATED> */
+        this.node.classList.add('p-mod-hidden');
+        /* </DEPRECATED> */;
         return;
       }
 
@@ -1247,6 +1272,9 @@ namespace DockPanel {
         this._timer = -1;
         this._hidden = true;
         this.node.classList.add('lm-mod-hidden');
+        /* <DEPRECATED> */
+        this.node.classList.add('p-mod-hidden');
+        /* </DEPRECATED> */;
       }, delay);
     }
 
@@ -1273,6 +1301,9 @@ namespace DockPanel {
     createTabBar(): TabBar<Widget> {
       let bar = new TabBar<Widget>();
       bar.addClass('lm-DockPanel-tabBar');
+      /* <DEPRECATED> */
+      bar.addClass('p-DockPanel-tabBar');
+      /* </DEPRECATED> */
       return bar;
     }
 
@@ -1284,6 +1315,9 @@ namespace DockPanel {
     createHandle(): HTMLDivElement {
       let handle = document.createElement('div');
       handle.className = 'lm-DockPanel-handle';
+      /* <DEPRECATED> */
+      handle.classList.add('p-DockPanel-handle');
+      /* </DEPRECATED> */;
       return handle;
     }
   }

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -64,7 +64,7 @@ class DockPanel extends Widget {
    */
   constructor(options: DockPanel.IOptions = {}) {
     super();
-    this.addClass('p-DockPanel');
+    this.addClass('lm-DockPanel');
     this._mode = options.mode || 'multiple-document';
     this._renderer = options.renderer || DockPanel.defaultRenderer;
     this._edges = options.edges || Private.DEFAULT_EDGES;
@@ -452,7 +452,7 @@ class DockPanel extends Widget {
     }
 
     // Add the widget class to the child.
-    msg.child.addClass('p-DockPanel-widget');
+    msg.child.addClass('lm-DockPanel-widget');
   }
 
   /**
@@ -465,7 +465,7 @@ class DockPanel extends Widget {
     }
 
     // Remove the widget class from the child.
-    msg.child.removeClass('p-DockPanel-widget');
+    msg.child.removeClass('lm-DockPanel-widget');
 
     // Schedule an emit of the layout modified signal.
     MessageLoop.postMessage(this, Private.LayoutModified);
@@ -1177,7 +1177,7 @@ namespace DockPanel {
      */
     constructor() {
       this.node = document.createElement('div');
-      this.node.classList.add('p-DockPanel-overlay');
+      this.node.classList.add('lm-DockPanel-overlay');
       this.node.classList.add('lm-mod-hidden');
       this.node.style.position = 'absolute';
     }
@@ -1272,7 +1272,7 @@ namespace DockPanel {
      */
     createTabBar(): TabBar<Widget> {
       let bar = new TabBar<Widget>();
-      bar.addClass('p-DockPanel-tabBar');
+      bar.addClass('lm-DockPanel-tabBar');
       return bar;
     }
 
@@ -1283,7 +1283,7 @@ namespace DockPanel {
      */
     createHandle(): HTMLDivElement {
       let handle = document.createElement('div');
-      handle.className = 'p-DockPanel-handle';
+      handle.className = 'lm-DockPanel-handle';
       return handle;
     }
   }

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -388,13 +388,13 @@ class DockPanel extends Widget {
    */
   handleEvent(event: Event): void {
     switch (event.type) {
-    case 'p-dragenter':
+    case 'lm-dragenter':
       this._evtDragEnter(event as IDragEvent);
       break;
-    case 'p-dragleave':
+    case 'lm-dragleave':
       this._evtDragLeave(event as IDragEvent);
       break;
-    case 'p-dragover':
+    case 'lm-dragover':
       this._evtDragOver(event as IDragEvent);
       break;
     case 'p-drop':
@@ -423,9 +423,9 @@ class DockPanel extends Widget {
    * A message handler invoked on a `'before-attach'` message.
    */
   protected onBeforeAttach(msg: Message): void {
-    this.node.addEventListener('p-dragenter', this);
-    this.node.addEventListener('p-dragleave', this);
-    this.node.addEventListener('p-dragover', this);
+    this.node.addEventListener('lm-dragenter', this);
+    this.node.addEventListener('lm-dragleave', this);
+    this.node.addEventListener('lm-dragover', this);
     this.node.addEventListener('p-drop', this);
     this.node.addEventListener('mousedown', this);
   }
@@ -434,9 +434,9 @@ class DockPanel extends Widget {
    * A message handler invoked on an `'after-detach'` message.
    */
   protected onAfterDetach(msg: Message): void {
-    this.node.removeEventListener('p-dragenter', this);
-    this.node.removeEventListener('p-dragleave', this);
-    this.node.removeEventListener('p-dragover', this);
+    this.node.removeEventListener('lm-dragenter', this);
+    this.node.removeEventListener('lm-dragleave', this);
+    this.node.removeEventListener('lm-dragover', this);
     this.node.removeEventListener('p-drop', this);
     this.node.removeEventListener('mousedown', this);
     this._releaseMouse();
@@ -472,7 +472,7 @@ class DockPanel extends Widget {
   }
 
   /**
-   * Handle the `'p-dragenter'` event for the dock panel.
+   * Handle the `'lm-dragenter'` event for the dock panel.
    */
   private _evtDragEnter(event: IDragEvent): void {
     // If the factory mime type is present, mark the event as
@@ -484,7 +484,7 @@ class DockPanel extends Widget {
   }
 
   /**
-   * Handle the `'p-dragleave'` event for the dock panel.
+   * Handle the `'lm-dragleave'` event for the dock panel.
    */
   private _evtDragLeave(event: IDragEvent): void {
     // Mark the event as handled.
@@ -492,13 +492,13 @@ class DockPanel extends Widget {
     event.stopPropagation();
 
     // The new target might be a descendant, so we might still handle the drop.
-    // Hide asynchronously so that if a p-dragover event bubbles up to us, the
-    // hide is cancelled by the p-dragover handler's show overlay logic.
+    // Hide asynchronously so that if a lm-dragover event bubbles up to us, the
+    // hide is cancelled by the lm-dragover handler's show overlay logic.
     this.overlay.hide(1)
   }
 
   /**
-   * Handle the `'p-dragover'` event for the dock panel.
+   * Handle the `'lm-dragover'` event for the dock panel.
    */
   private _evtDragOver(event: IDragEvent): void {
     // Mark the event as handled.

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -56,7 +56,7 @@ class Menu extends Widget {
    */
   constructor(options: Menu.IOptions) {
     super({ node: Private.createNode() });
-    this.addClass('p-Menu');
+    this.addClass('lm-Menu');
     this.setFlag(Widget.Flag.DisallowLayout);
     this.commands = options.commands;
     this.renderer = options.renderer || Menu.defaultRenderer;
@@ -162,7 +162,7 @@ class Menu extends Widget {
    * Modifying this node directly can lead to undefined behavior.
    */
   get contentNode(): HTMLUListElement {
-    return this.node.getElementsByClassName('p-Menu-content')[0] as HTMLUListElement;
+    return this.node.getElementsByClassName('lm-Menu-content')[0] as HTMLUListElement;
   }
 
   /**
@@ -1176,7 +1176,7 @@ namespace Menu {
      */
     renderLabel(data: IRenderData): VirtualElement {
       let content = this.formatLabel(data);
-      return h.div({ className: 'p-Menu-itemLabel' }, content);
+      return h.div({ className: 'lm-Menu-itemLabel' }, content);
     }
 
     /**
@@ -1188,7 +1188,7 @@ namespace Menu {
      */
     renderShortcut(data: IRenderData): VirtualElement {
       let content = this.formatShortcut(data);
-      return h.div({ className: 'p-Menu-itemShortcut' }, content);
+      return h.div({ className: 'lm-Menu-itemShortcut' }, content);
     }
 
     /**
@@ -1199,7 +1199,7 @@ namespace Menu {
      * @returns A virtual element representing the submenu icon.
      */
     renderSubmenu(data: IRenderData): VirtualElement {
-      return h.div({ className: 'p-Menu-itemSubmenuIcon' });
+      return h.div({ className: 'lm-Menu-itemSubmenuIcon' });
     }
 
     /**
@@ -1211,23 +1211,23 @@ namespace Menu {
      */
     createItemClass(data: IRenderData): string {
       // Setup the initial class name.
-      let name = 'p-Menu-item';
+      let name = 'lm-Menu-item';
 
       // Add the boolean state classes.
       if (!data.item.isEnabled) {
-        name += ' p-mod-disabled';
+        name += ' lm-mod-disabled';
       }
       if (data.item.isToggled) {
-        name += ' p-mod-toggled';
+        name += ' lm-mod-toggled';
       }
       if (!data.item.isVisible) {
-        name += ' p-mod-hidden';
+        name += ' lm-mod-hidden';
       }
       if (data.active) {
-        name += ' p-mod-active';
+        name += ' lm-mod-active';
       }
       if (data.collapsed) {
-        name += ' p-mod-collapsed';
+        name += ' lm-mod-collapsed';
       }
 
       // Add the extra class.
@@ -1266,7 +1266,7 @@ namespace Menu {
      * @returns The full class name for the item icon.
      */
     createIconClass(data: IRenderData): string {
-      let name = 'p-Menu-itemIcon';
+      let name = 'lm-Menu-itemIcon';
       let extra = data.item.iconClass;
       return extra ? `${name} ${extra}` : name;
     }
@@ -1293,7 +1293,7 @@ namespace Menu {
       let char = label[mnemonic];
 
       // Wrap the mnemonic character in a span.
-      let span = h.span({ className: 'p-Menu-itemMnemonic' }, char);
+      let span = h.span({ className: 'lm-Menu-itemMnemonic' }, char);
 
       // Return the content parts.
       return [prefix, span, suffix];
@@ -1343,7 +1343,7 @@ namespace Private {
   function createNode(): HTMLDivElement {
     let node = document.createElement('div');
     let content = document.createElement('ul');
-    content.className = 'p-Menu-content';
+    content.className = 'lm-Menu-content';
     node.appendChild(content);
     node.tabIndex = -1;
     return node;

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -57,6 +57,9 @@ class Menu extends Widget {
   constructor(options: Menu.IOptions) {
     super({ node: Private.createNode() });
     this.addClass('lm-Menu');
+    /* <DEPRECATED> */
+    this.addClass('p-Menu');
+    /* </DEPRECATED> */
     this.setFlag(Widget.Flag.DisallowLayout);
     this.commands = options.commands;
     this.renderer = options.renderer || Menu.defaultRenderer;
@@ -1176,7 +1179,12 @@ namespace Menu {
      */
     renderLabel(data: IRenderData): VirtualElement {
       let content = this.formatLabel(data);
-      return h.div({ className: 'lm-Menu-itemLabel' }, content);
+      return h.div({
+        className: 'lm-Menu-itemLabel'
+          /* <DEPRECATED> */
+          + ' p-Menu-itemLabel'
+          /* </DEPRECATED> */
+      }, content);
     }
 
     /**
@@ -1188,7 +1196,12 @@ namespace Menu {
      */
     renderShortcut(data: IRenderData): VirtualElement {
       let content = this.formatShortcut(data);
-      return h.div({ className: 'lm-Menu-itemShortcut' }, content);
+      return h.div({
+        className: 'lm-Menu-itemShortcut'
+          /* <DEPRECATED> */
+          + ' p-Menu-itemShortcut'
+          /* </DEPRECATED> */
+      }, content);
     }
 
     /**
@@ -1199,7 +1212,12 @@ namespace Menu {
      * @returns A virtual element representing the submenu icon.
      */
     renderSubmenu(data: IRenderData): VirtualElement {
-      return h.div({ className: 'lm-Menu-itemSubmenuIcon' });
+      return h.div({
+        className: 'lm-Menu-itemSubmenuIcon'
+          /* <DEPRECATED> */
+          + ' p-Menu-itemSubmenuIcon'
+          /* </DEPRECATED> */
+      });
     }
 
     /**
@@ -1212,22 +1230,40 @@ namespace Menu {
     createItemClass(data: IRenderData): string {
       // Setup the initial class name.
       let name = 'lm-Menu-item';
+      /* <DEPRECATED> */
+      name += ' p-Menu-item';
+      /* </DEPRECATED> */
 
       // Add the boolean state classes.
       if (!data.item.isEnabled) {
         name += ' lm-mod-disabled';
+        /* <DEPRECATED> */
+        name += ' p-mod-disabled';
+        /* </DEPRECATED> */
       }
       if (data.item.isToggled) {
         name += ' lm-mod-toggled';
+        /* <DEPRECATED> */
+        name += ' p-mod-toggled';
+        /* </DEPRECATED> */
       }
       if (!data.item.isVisible) {
         name += ' lm-mod-hidden';
+        /* <DEPRECATED> */
+        name += ' p-mod-hidden';
+        /* </DEPRECATED> */
       }
       if (data.active) {
         name += ' lm-mod-active';
+        /* <DEPRECATED> */
+        name += ' p-mod-active';
+        /* </DEPRECATED> */
       }
       if (data.collapsed) {
         name += ' lm-mod-collapsed';
+        /* <DEPRECATED> */
+        name += ' p-mod-collapsed';
+        /* </DEPRECATED> */
       }
 
       // Add the extra class.
@@ -1267,6 +1303,9 @@ namespace Menu {
      */
     createIconClass(data: IRenderData): string {
       let name = 'lm-Menu-itemIcon';
+      /* <DEPRECATED> */
+      name += ' p-Menu-itemIcon';
+      /* </DEPRECATED> */
       let extra = data.item.iconClass;
       return extra ? `${name} ${extra}` : name;
     }
@@ -1293,7 +1332,12 @@ namespace Menu {
       let char = label[mnemonic];
 
       // Wrap the mnemonic character in a span.
-      let span = h.span({ className: 'lm-Menu-itemMnemonic' }, char);
+      let span = h.span({
+        className: 'lm-Menu-itemMnemonic'
+          /* <DEPRECATED> */
+          + ' p-Menu-itemMnemonic'
+          /* </DEPRECATED> */
+      }, char);
 
       // Return the content parts.
       return [prefix, span, suffix];
@@ -1344,6 +1388,9 @@ namespace Private {
     let node = document.createElement('div');
     let content = document.createElement('ul');
     content.className = 'lm-Menu-content';
+    /* <DEPRECATED> */
+    content.classList.add('p-Menu-content');
+    /* </DEPRECATED> */
     node.appendChild(content);
     node.tabIndex = -1;
     return node;

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -52,7 +52,7 @@ class MenuBar extends Widget {
    */
   constructor(options: MenuBar.IOptions = {}) {
     super({ node: Private.createNode() });
-    this.addClass('p-MenuBar');
+    this.addClass('lm-MenuBar');
     this.setFlag(Widget.Flag.DisallowLayout);
     this.renderer = options.renderer || MenuBar.defaultRenderer;
   }
@@ -90,7 +90,7 @@ class MenuBar extends Widget {
    * Modifying this node directly can lead to undefined behavior.
    */
   get contentNode(): HTMLUListElement {
-    return this.node.getElementsByClassName('p-MenuBar-content')[0] as HTMLUListElement;
+    return this.node.getElementsByClassName('lm-MenuBar-content')[0] as HTMLUListElement;
   }
 
   /**
@@ -213,7 +213,7 @@ class MenuBar extends Widget {
       ArrayExt.insert(this._menus, j, menu);
 
       // Add the styling class to the menu.
-      menu.addClass('p-MenuBar-menu');
+      menu.addClass('lm-MenuBar-menu');
 
       // Connect to the menu signals.
       menu.aboutToClose.connect(this._onMenuAboutToClose, this);
@@ -284,7 +284,7 @@ class MenuBar extends Widget {
     menu.title.changed.disconnect(this._onTitleChanged, this);
 
     // Remove the styling class from the menu.
-    menu.removeClass('p-MenuBar-menu');
+    menu.removeClass('lm-MenuBar-menu');
 
     // Schedule an update of the items.
     this.update();
@@ -307,7 +307,7 @@ class MenuBar extends Widget {
       menu.aboutToClose.disconnect(this._onMenuAboutToClose, this);
       menu.menuRequested.disconnect(this._onMenuMenuRequested, this);
       menu.title.changed.disconnect(this._onTitleChanged, this);
-      menu.removeClass('p-MenuBar-menu');
+      menu.removeClass('lm-MenuBar-menu');
     }
 
     // Clear the menus array.
@@ -778,7 +778,7 @@ namespace MenuBar {
      */
     renderLabel(data: IRenderData): VirtualElement {
       let content = this.formatLabel(data);
-      return h.div({ className: 'p-MenuBar-itemLabel' }, content);
+      return h.div({ className: 'lm-MenuBar-itemLabel' }, content);
     }
 
     /**
@@ -789,7 +789,7 @@ namespace MenuBar {
      * @returns The full class name for the menu item.
      */
     createItemClass(data: IRenderData): string {
-      let name = 'p-MenuBar-item';
+      let name = 'lm-MenuBar-item';
       if (data.title.className) {
         name += ` ${data.title.className}`;
       }
@@ -818,7 +818,7 @@ namespace MenuBar {
      * @returns The full class name for the item icon.
      */
     createIconClass(data: IRenderData): string {
-      let name = 'p-MenuBar-itemIcon';
+      let name = 'lm-MenuBar-itemIcon';
       let extra = data.title.iconClass;
       return extra ? `${name} ${extra}` : name;
     }
@@ -845,7 +845,7 @@ namespace MenuBar {
       let char = label[mnemonic];
 
       // Wrap the mnemonic character in a span.
-      let span = h.span({ className: 'p-MenuBar-itemMnemonic' }, char);
+      let span = h.span({ className: 'lm-MenuBar-itemMnemonic' }, char);
 
       // Return the content parts.
       return [prefix, span, suffix];
@@ -871,7 +871,7 @@ namespace Private {
   function createNode(): HTMLDivElement {
     let node = document.createElement('div');
     let content = document.createElement('ul');
-    content.className = 'p-MenuBar-content';
+    content.className = 'lm-MenuBar-content';
     node.appendChild(content);
     node.tabIndex = -1;
     return node;

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -572,7 +572,7 @@ class MenuBar extends Widget {
     if (oldMenu) {
       oldMenu.close();
     } else {
-      this.addClass('p-mod-active');
+      this.addClass('lm-mod-active');
       document.addEventListener('mousedown', this, true);
     }
 
@@ -599,7 +599,7 @@ class MenuBar extends Widget {
     }
 
     // Remove the active class from the menu bar.
-    this.removeClass('p-mod-active');
+    this.removeClass('lm-mod-active');
 
     // Remove the document listeners.
     document.removeEventListener('mousedown', this, true);
@@ -625,7 +625,7 @@ class MenuBar extends Widget {
     }
 
     // Remove the active class from the menu bar.
-    this.removeClass('p-mod-active');
+    this.removeClass('lm-mod-active');
 
     // Remove the document listeners.
     document.removeEventListener('mousedown', this, true);
@@ -794,7 +794,7 @@ namespace MenuBar {
         name += ` ${data.title.className}`;
       }
       if (data.active) {
-        name += ' p-mod-active';
+        name += ' lm-mod-active';
       }
       return name;
     }

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -53,6 +53,9 @@ class MenuBar extends Widget {
   constructor(options: MenuBar.IOptions = {}) {
     super({ node: Private.createNode() });
     this.addClass('lm-MenuBar');
+    /* <DEPRECATED> */
+    this.addClass('p-MenuBar');
+    /* </DEPRECATED> */
     this.setFlag(Widget.Flag.DisallowLayout);
     this.renderer = options.renderer || MenuBar.defaultRenderer;
   }
@@ -214,6 +217,9 @@ class MenuBar extends Widget {
 
       // Add the styling class to the menu.
       menu.addClass('lm-MenuBar-menu');
+      /* <DEPRECATED> */
+      menu.addClass('p-MenuBar-menu');
+      /* </DEPRECATED> */
 
       // Connect to the menu signals.
       menu.aboutToClose.connect(this._onMenuAboutToClose, this);
@@ -285,6 +291,9 @@ class MenuBar extends Widget {
 
     // Remove the styling class from the menu.
     menu.removeClass('lm-MenuBar-menu');
+    /* <DEPRECATED> */
+    menu.removeClass('p-MenuBar-menu');
+    /* </DEPRECATED> */
 
     // Schedule an update of the items.
     this.update();
@@ -308,6 +317,9 @@ class MenuBar extends Widget {
       menu.menuRequested.disconnect(this._onMenuMenuRequested, this);
       menu.title.changed.disconnect(this._onTitleChanged, this);
       menu.removeClass('lm-MenuBar-menu');
+      /* <DEPRECATED> */
+      menu.removeClass('p-MenuBar-menu');
+      /* </DEPRECATED> */
     }
 
     // Clear the menus array.
@@ -573,6 +585,9 @@ class MenuBar extends Widget {
       oldMenu.close();
     } else {
       this.addClass('lm-mod-active');
+      /* <DEPRECATED> */
+      this.addClass('p-mod-active');
+      /* </DEPRECATED> */
       document.addEventListener('mousedown', this, true);
     }
 
@@ -600,6 +615,9 @@ class MenuBar extends Widget {
 
     // Remove the active class from the menu bar.
     this.removeClass('lm-mod-active');
+    /* <DEPRECATED> */
+    this.removeClass('p-mod-active');
+    /* </DEPRECATED> */
 
     // Remove the document listeners.
     document.removeEventListener('mousedown', this, true);
@@ -626,6 +644,9 @@ class MenuBar extends Widget {
 
     // Remove the active class from the menu bar.
     this.removeClass('lm-mod-active');
+    /* <DEPRECATED> */
+    this.removeClass('p-mod-active');
+    /* </DEPRECATED> */
 
     // Remove the document listeners.
     document.removeEventListener('mousedown', this, true);
@@ -778,7 +799,12 @@ namespace MenuBar {
      */
     renderLabel(data: IRenderData): VirtualElement {
       let content = this.formatLabel(data);
-      return h.div({ className: 'lm-MenuBar-itemLabel' }, content);
+      return h.div({ className:
+        'lm-MenuBar-itemLabel'
+          /* <DEPRECATED> */
+            + ' p-MenuBar-itemLabel'
+          /* </DEPRECATED> */
+      }, content);
     }
 
     /**
@@ -790,11 +816,17 @@ namespace MenuBar {
      */
     createItemClass(data: IRenderData): string {
       let name = 'lm-MenuBar-item';
+      /* <DEPRECATED> */
+      name += ' p-MenuBar-item';
+      /* </DEPRECATED> */
       if (data.title.className) {
         name += ` ${data.title.className}`;
       }
       if (data.active) {
         name += ' lm-mod-active';
+      /* <DEPRECATED> */
+      name += ' p-mod-active';
+      /* </DEPRECATED> */
       }
       return name;
     }
@@ -819,6 +851,9 @@ namespace MenuBar {
      */
     createIconClass(data: IRenderData): string {
       let name = 'lm-MenuBar-itemIcon';
+      /* <DEPRECATED> */
+      name += ' p-MenuBar-itemIcon';
+      /* </DEPRECATED> */
       let extra = data.title.iconClass;
       return extra ? `${name} ${extra}` : name;
     }
@@ -845,7 +880,12 @@ namespace MenuBar {
       let char = label[mnemonic];
 
       // Wrap the mnemonic character in a span.
-      let span = h.span({ className: 'lm-MenuBar-itemMnemonic' }, char);
+      let span = h.span({
+        className: 'lm-MenuBar-itemMnemonic'
+          /* <DEPRECATED> */
+          + ' p-MenuBar-itemMnemonic'
+          /* </DEPRECATED> */
+      }, char);
 
       // Return the content parts.
       return [prefix, span, suffix];
@@ -872,6 +912,9 @@ namespace Private {
     let node = document.createElement('div');
     let content = document.createElement('ul');
     content.className = 'lm-MenuBar-content';
+    /* <DEPRECATED> */
+    content.classList.add('p-MenuBar-content');
+    /* </DEPRECATED> */
     node.appendChild(content);
     node.tabIndex = -1;
     return node;

--- a/packages/widgets/src/panel.ts
+++ b/packages/widgets/src/panel.ts
@@ -36,6 +36,9 @@ class Panel extends Widget {
   constructor(options: Panel.IOptions = {}) {
     super();
     this.addClass('lm-Panel');
+    /* <DEPRECATED> */
+    this.addClass('p-Panel');
+    /* </DEPRECATED> */
     this.layout = Private.createLayout(options);
   }
 

--- a/packages/widgets/src/panel.ts
+++ b/packages/widgets/src/panel.ts
@@ -35,7 +35,7 @@ class Panel extends Widget {
    */
   constructor(options: Panel.IOptions = {}) {
     super();
-    this.addClass('p-Panel');
+    this.addClass('lm-Panel');
     this.layout = Private.createLayout(options);
   }
 

--- a/packages/widgets/src/scrollbar.ts
+++ b/packages/widgets/src/scrollbar.ts
@@ -422,7 +422,7 @@ class ScrollBar extends Widget {
       }
 
       // Add the active class to the thumb node.
-      thumbNode.classList.add('p-mod-active');
+      thumbNode.classList.add('lm-mod-active');
 
       // Store the current value in the press data.
       this._pressData.value = this._value;
@@ -457,7 +457,7 @@ class ScrollBar extends Widget {
     // Handle a decrement button press.
     if (part === 'decrement') {
       // Add the active class to the decrement node.
-      this.decrementNode.classList.add('p-mod-active');
+      this.decrementNode.classList.add('lm-mod-active');
 
       // Start the repeat timer.
       this._repeatTimer = window.setTimeout(this._onRepeat, 350);
@@ -473,7 +473,7 @@ class ScrollBar extends Widget {
     if (part === 'increment') {
 
       // Add the active class to the increment node.
-      this.incrementNode.classList.add('p-mod-active');
+      this.incrementNode.classList.add('lm-mod-active');
 
       // Start the repeat timer.
       this._repeatTimer = window.setTimeout(this._onRepeat, 350);
@@ -571,9 +571,9 @@ class ScrollBar extends Widget {
     document.removeEventListener('contextmenu', this, true);
 
     // Remove the active classes from the nodes.
-    this.thumbNode.classList.remove('p-mod-active');
-    this.decrementNode.classList.remove('p-mod-active');
-    this.incrementNode.classList.remove('p-mod-active');
+    this.thumbNode.classList.remove('lm-mod-active');
+    this.decrementNode.classList.remove('lm-mod-active');
+    this.incrementNode.classList.remove('lm-mod-active');
   }
 
   /**

--- a/packages/widgets/src/scrollbar.ts
+++ b/packages/widgets/src/scrollbar.ts
@@ -44,7 +44,7 @@ class ScrollBar extends Widget {
    */
   constructor(options: ScrollBar.IOptions = {}) {
     super({ node: Private.createNode() });
-    this.addClass('p-ScrollBar');
+    this.addClass('lm-ScrollBar');
     this.setFlag(Widget.Flag.DisallowLayout);
 
     // Set the orientation.
@@ -222,7 +222,7 @@ class ScrollBar extends Widget {
    * Modifying this node directly can lead to undefined behavior.
    */
   get decrementNode(): HTMLDivElement {
-    return this.node.getElementsByClassName('p-ScrollBar-button')[0] as HTMLDivElement;
+    return this.node.getElementsByClassName('lm-ScrollBar-button')[0] as HTMLDivElement;
   }
 
   /**
@@ -232,7 +232,7 @@ class ScrollBar extends Widget {
    * Modifying this node directly can lead to undefined behavior.
    */
   get incrementNode(): HTMLDivElement {
-    return this.node.getElementsByClassName('p-ScrollBar-button')[1] as HTMLDivElement;
+    return this.node.getElementsByClassName('lm-ScrollBar-button')[1] as HTMLDivElement;
   }
 
   /**
@@ -242,7 +242,7 @@ class ScrollBar extends Widget {
    * Modifying this node directly can lead to undefined behavior.
    */
   get trackNode(): HTMLDivElement {
-    return this.node.getElementsByClassName('p-ScrollBar-track')[0] as HTMLDivElement;
+    return this.node.getElementsByClassName('lm-ScrollBar-track')[0] as HTMLDivElement;
   }
 
   /**
@@ -252,7 +252,7 @@ class ScrollBar extends Widget {
    * Modifying this node directly can lead to undefined behavior.
    */
   get thumbNode(): HTMLDivElement {
-    return this.node.getElementsByClassName('p-ScrollBar-thumb')[0] as HTMLDivElement;
+    return this.node.getElementsByClassName('lm-ScrollBar-thumb')[0] as HTMLDivElement;
   }
 
   /**
@@ -802,12 +802,12 @@ namespace Private {
     let increment = document.createElement('div');
     let track = document.createElement('div');
     let thumb = document.createElement('div');
-    decrement.className = 'p-ScrollBar-button';
-    increment.className = 'p-ScrollBar-button';
+    decrement.className = 'lm-ScrollBar-button';
+    increment.className = 'lm-ScrollBar-button';
     decrement.dataset['action'] = 'decrement';
     increment.dataset['action'] = 'increment';
-    track.className = 'p-ScrollBar-track';
-    thumb.className = 'p-ScrollBar-thumb';
+    track.className = 'lm-ScrollBar-track';
+    thumb.className = 'lm-ScrollBar-thumb';
     track.appendChild(thumb);
     node.appendChild(decrement);
     node.appendChild(track);

--- a/packages/widgets/src/scrollbar.ts
+++ b/packages/widgets/src/scrollbar.ts
@@ -45,6 +45,9 @@ class ScrollBar extends Widget {
   constructor(options: ScrollBar.IOptions = {}) {
     super({ node: Private.createNode() });
     this.addClass('lm-ScrollBar');
+    /* <DEPRECATED> */
+    this.addClass('p-ScrollBar');
+    /* </DEPRECATED> */
     this.setFlag(Widget.Flag.DisallowLayout);
 
     // Set the orientation.
@@ -423,6 +426,9 @@ class ScrollBar extends Widget {
 
       // Add the active class to the thumb node.
       thumbNode.classList.add('lm-mod-active');
+      /* <DEPRECATED> */
+      thumbNode.classList.add('p-mod-active');
+      /* </DEPRECATED> */
 
       // Store the current value in the press data.
       this._pressData.value = this._value;
@@ -458,6 +464,9 @@ class ScrollBar extends Widget {
     if (part === 'decrement') {
       // Add the active class to the decrement node.
       this.decrementNode.classList.add('lm-mod-active');
+      /* <DEPRECATED> */
+      this.decrementNode.classList.add('p-mod-active');
+      /* </DEPRECATED> */
 
       // Start the repeat timer.
       this._repeatTimer = window.setTimeout(this._onRepeat, 350);
@@ -474,6 +483,9 @@ class ScrollBar extends Widget {
 
       // Add the active class to the increment node.
       this.incrementNode.classList.add('lm-mod-active');
+      /* <DEPRECATED> */
+      this.incrementNode.classList.add('p-mod-active');
+      /* </DEPRECATED> */
 
       // Start the repeat timer.
       this._repeatTimer = window.setTimeout(this._onRepeat, 350);
@@ -574,6 +586,11 @@ class ScrollBar extends Widget {
     this.thumbNode.classList.remove('lm-mod-active');
     this.decrementNode.classList.remove('lm-mod-active');
     this.incrementNode.classList.remove('lm-mod-active');
+    /* <DEPRECATED> */
+    this.thumbNode.classList.remove('p-mod-active');
+    this.decrementNode.classList.remove('p-mod-active');
+    this.incrementNode.classList.remove('p-mod-active');
+    /* </DEPRECATED> */
   }
 
   /**
@@ -808,6 +825,12 @@ namespace Private {
     increment.dataset['action'] = 'increment';
     track.className = 'lm-ScrollBar-track';
     thumb.className = 'lm-ScrollBar-thumb';
+    /* <DEPRECATED> */
+    decrement.classList.add('p-ScrollBar-button');
+    increment.classList.add('p-ScrollBar-button');
+    track.classList.add('p-ScrollBar-track');
+    thumb.classList.add('p-ScrollBar-thumb');
+    /* </DEPRECATED> */
     track.appendChild(thumb);
     node.appendChild(decrement);
     node.appendChild(track);

--- a/packages/widgets/src/splitlayout.ts
+++ b/packages/widgets/src/splitlayout.ts
@@ -447,8 +447,14 @@ class SplitLayout extends PanelLayout {
     for (let i = 0, n = this._items.length; i < n; ++i) {
       if (this._items[i].isHidden) {
         this._handles[i].classList.add('lm-mod-hidden');
+        /* <DEPRECATED> */
+        this._handles[i].classList.add('p-mod-hidden');
+        /* </DEPRECATED> */
       } else {
         this._handles[i].classList.remove('lm-mod-hidden');
+        /* <DEPRECATED> */
+        this._handles[i].classList.remove('p-mod-hidden');
+        /* </DEPRECATED> */
         lastHandleIndex = i;
         nVisible++;
       }
@@ -457,6 +463,9 @@ class SplitLayout extends PanelLayout {
     // Hide the handle for the last visible widget.
     if (lastHandleIndex !== -1) {
       this._handles[lastHandleIndex].classList.add('lm-mod-hidden');
+      /* <DEPRECATED> */
+      this._handles[lastHandleIndex].classList.add('p-mod-hidden');
+      /* </DEPRECATED> */
     }
 
     // Update the fixed space for the visible items.

--- a/packages/widgets/src/splitlayout.ts
+++ b/packages/widgets/src/splitlayout.ts
@@ -239,7 +239,7 @@ class SplitLayout extends PanelLayout {
   moveHandle(index: number, position: number): void {
     // Bail if the index is invalid or the handle is hidden.
     let handle = this._handles[index];
-    if (!handle || handle.classList.contains('p-mod-hidden')) {
+    if (!handle || handle.classList.contains('lm-mod-hidden')) {
       return;
     }
 
@@ -446,9 +446,9 @@ class SplitLayout extends PanelLayout {
     let lastHandleIndex = -1;
     for (let i = 0, n = this._items.length; i < n; ++i) {
       if (this._items[i].isHidden) {
-        this._handles[i].classList.add('p-mod-hidden');
+        this._handles[i].classList.add('lm-mod-hidden');
       } else {
-        this._handles[i].classList.remove('p-mod-hidden');
+        this._handles[i].classList.remove('lm-mod-hidden');
         lastHandleIndex = i;
         nVisible++;
       }
@@ -456,7 +456,7 @@ class SplitLayout extends PanelLayout {
 
     // Hide the handle for the last visible widget.
     if (lastHandleIndex !== -1) {
-      this._handles[lastHandleIndex].classList.add('p-mod-hidden');
+      this._handles[lastHandleIndex].classList.add('lm-mod-hidden');
     }
 
     // Update the fixed space for the visible items.

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -51,7 +51,7 @@ class SplitPanel extends Panel {
    */
   constructor(options: SplitPanel.IOptions = {}) {
     super({ layout: Private.createLayout(options) });
-    this.addClass('p-SplitPanel');
+    this.addClass('lm-SplitPanel');
   }
 
   /**
@@ -209,7 +209,7 @@ class SplitPanel extends Panel {
    * A message handler invoked on a `'child-added'` message.
    */
   protected onChildAdded(msg: Widget.ChildMessage): void {
-    msg.child.addClass('p-SplitPanel-child');
+    msg.child.addClass('lm-SplitPanel-child');
     this._releaseMouse();
   }
 
@@ -217,7 +217,7 @@ class SplitPanel extends Panel {
    * A message handler invoked on a `'child-removed'` message.
    */
   protected onChildRemoved(msg: Widget.ChildMessage): void {
-    msg.child.removeClass('p-SplitPanel-child');
+    msg.child.removeClass('lm-SplitPanel-child');
     this._releaseMouse();
   }
 
@@ -422,7 +422,7 @@ namespace SplitPanel {
      */
     createHandle(): HTMLDivElement {
       let handle = document.createElement('div');
-      handle.className = 'p-SplitPanel-handle';
+      handle.className = 'lm-SplitPanel-handle';
       return handle;
     }
   }

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -52,6 +52,9 @@ class SplitPanel extends Panel {
   constructor(options: SplitPanel.IOptions = {}) {
     super({ layout: Private.createLayout(options) });
     this.addClass('lm-SplitPanel');
+    /* <DEPRECATED> */
+    this.addClass('p-SplitPanel');
+    /* </DEPRECATED> */
   }
 
   /**
@@ -210,6 +213,9 @@ class SplitPanel extends Panel {
    */
   protected onChildAdded(msg: Widget.ChildMessage): void {
     msg.child.addClass('lm-SplitPanel-child');
+    /* <DEPRECATED> */
+    msg.child.addClass('p-SplitPanel-child');
+    /* </DEPRECATED> */
     this._releaseMouse();
   }
 
@@ -218,6 +224,9 @@ class SplitPanel extends Panel {
    */
   protected onChildRemoved(msg: Widget.ChildMessage): void {
     msg.child.removeClass('lm-SplitPanel-child');
+    /* <DEPRECATED> */
+    msg.child.removeClass('p-SplitPanel-child');
+    /* </DEPRECATED> */
     this._releaseMouse();
   }
 
@@ -423,6 +432,9 @@ namespace SplitPanel {
     createHandle(): HTMLDivElement {
       let handle = document.createElement('div');
       handle.className = 'lm-SplitPanel-handle';
+      /* <DEPRECATED> */
+      handle.classList.add('p-SplitPanel-handle');
+      /* </DEPRECATED> */
       return handle;
     }
   }

--- a/packages/widgets/src/stackedpanel.ts
+++ b/packages/widgets/src/stackedpanel.ts
@@ -40,6 +40,9 @@ class StackedPanel extends Panel {
   constructor(options: StackedPanel.IOptions = {}) {
     super({ layout: Private.createLayout(options) });
     this.addClass('lm-StackedPanel');
+    /* <DEPRECATED> */
+    this.addClass('p-StackedPanel');
+    /* </DEPRECATED> */
   }
 
   /**
@@ -54,6 +57,9 @@ class StackedPanel extends Panel {
    */
   protected onChildAdded(msg: Widget.ChildMessage): void {
     msg.child.addClass('lm-StackedPanel-child');
+    /* <DEPRECATED> */
+    msg.child.addClass('p-StackedPanel-child');
+    /* </DEPRECATED> */
   }
 
   /**
@@ -61,6 +67,9 @@ class StackedPanel extends Panel {
    */
   protected onChildRemoved(msg: Widget.ChildMessage): void {
     msg.child.removeClass('lm-StackedPanel-child');
+    /* <DEPRECATED> */
+    msg.child.removeClass('p-StackedPanel-child');
+    /* </DEPRECATED> */
     this._widgetRemoved.emit(msg.child);
   }
 

--- a/packages/widgets/src/stackedpanel.ts
+++ b/packages/widgets/src/stackedpanel.ts
@@ -39,7 +39,7 @@ class StackedPanel extends Panel {
    */
   constructor(options: StackedPanel.IOptions = {}) {
     super({ layout: Private.createLayout(options) });
-    this.addClass('p-StackedPanel');
+    this.addClass('lm-StackedPanel');
   }
 
   /**
@@ -53,14 +53,14 @@ class StackedPanel extends Panel {
    * A message handler invoked on a `'child-added'` message.
    */
   protected onChildAdded(msg: Widget.ChildMessage): void {
-    msg.child.addClass('p-StackedPanel-child');
+    msg.child.addClass('lm-StackedPanel-child');
   }
 
   /**
    * A message handler invoked on a `'child-removed'` message.
    */
   protected onChildRemoved(msg: Widget.ChildMessage): void {
-    msg.child.removeClass('p-StackedPanel-child');
+    msg.child.removeClass('lm-StackedPanel-child');
     this._widgetRemoved.emit(msg.child);
   }
 

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1308,7 +1308,7 @@ namespace TabBar {
     /**
      * A selector which matches the close icon node in a tab.
      */
-    readonly closeIconSelector = '.p-TabBar-tabCloseIcon';
+    readonly closeIconSelector = '.lm-TabBar-tabCloseIcon';
 
     /**
      * Render the virtual element for a tab.

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -61,7 +61,7 @@ class TabBar<T> extends Widget {
    */
   constructor(options: TabBar.IOptions<T> = {}) {
     super({ node: Private.createNode() });
-    this.addClass('p-TabBar');
+    this.addClass('lm-TabBar');
     this.setFlag(Widget.Flag.DisallowLayout);
     this.tabsMovable = options.tabsMovable || false;
     this.allowDeselect = options.allowDeselect || false;
@@ -294,7 +294,7 @@ class TabBar<T> extends Widget {
    * Modifying this node directly can lead to undefined behavior.
    */
   get contentNode(): HTMLUListElement {
-    return this.node.getElementsByClassName('p-TabBar-content')[0] as HTMLUListElement;
+    return this.node.getElementsByClassName('lm-TabBar-content')[0] as HTMLUListElement;
   }
 
   /**
@@ -1358,7 +1358,7 @@ namespace TabBar {
      * @returns A virtual element representing the tab label.
      */
     renderLabel(data: IRenderData<any>): VirtualElement {
-      return h.div({ className: 'p-TabBar-tabLabel' }, data.title.label);
+      return h.div({ className: 'lm-TabBar-tabLabel' }, data.title.label);
     }
 
     /**
@@ -1369,7 +1369,7 @@ namespace TabBar {
      * @returns A virtual element representing the tab close icon.
      */
     renderCloseIcon(data: IRenderData<any>): VirtualElement {
-      return h.div({ className: 'p-TabBar-tabCloseIcon' });
+      return h.div({ className: 'lm-TabBar-tabCloseIcon' });
     }
 
     /**
@@ -1412,7 +1412,7 @@ namespace TabBar {
      * @returns The full class name for the tab.
      */
     createTabClass(data: IRenderData<any>): string {
-      let name = 'p-TabBar-tab';
+      let name = 'lm-TabBar-tab';
       if (data.title.className) {
         name += ` ${data.title.className}`;
       }
@@ -1444,7 +1444,7 @@ namespace TabBar {
      * @returns The full class name for the tab icon.
      */
     createIconClass(data: IRenderData<any>): string {
-      let name = 'p-TabBar-tabIcon';
+      let name = 'lm-TabBar-tabIcon';
       let extra = data.title.iconClass;
       return extra ? `${name} ${extra}` : name;
     }
@@ -1595,7 +1595,7 @@ namespace Private {
   function createNode(): HTMLDivElement {
     let node = document.createElement('div');
     let content = document.createElement('ul');
-    content.className = 'p-TabBar-content';
+    content.className = 'lm-TabBar-content';
     node.appendChild(content);
     return node;
   }

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -690,8 +690,8 @@ class TabBar<T> extends Widget {
       data.override = Drag.overrideCursor('default');
 
       // Add the dragging style classes.
-      data.tab.classList.add('p-mod-dragging');
-      this.addClass('p-mod-dragging');
+      data.tab.classList.add('lm-mod-dragging');
+      this.addClass('lm-mod-dragging');
 
       // Mark the drag as active.
       data.dragActive = true;
@@ -797,7 +797,7 @@ class TabBar<T> extends Widget {
     Private.finalizeTabPosition(data, this._orientation);
 
     // Remove the dragging class from the tab so it can be transitioned.
-    data.tab.classList.remove('p-mod-dragging');
+    data.tab.classList.remove('lm-mod-dragging');
 
     // Parse the transition duration for releasing the tab.
     let duration = Private.parseTransitionDuration(data.tab);
@@ -819,7 +819,7 @@ class TabBar<T> extends Widget {
       data.override!.dispose();
 
       // Remove the remaining dragging style.
-      this.removeClass('p-mod-dragging');
+      this.removeClass('lm-mod-dragging');
 
       // If the tab was not moved, there is nothing else to do.
       let i = data.index;
@@ -879,8 +879,8 @@ class TabBar<T> extends Widget {
     data.override!.dispose();
 
     // Clear the dragging style classes.
-    data.tab.classList.remove('p-mod-dragging');
-    this.removeClass('p-mod-dragging');
+    data.tab.classList.remove('lm-mod-dragging');
+    this.removeClass('lm-mod-dragging');
   }
 
   /**
@@ -1417,10 +1417,10 @@ namespace TabBar {
         name += ` ${data.title.className}`;
       }
       if (data.title.closable) {
-        name += ' p-mod-closable';
+        name += ' lm-mod-closable';
       }
       if (data.current) {
-        name += ' p-mod-current';
+        name += ' lm-mod-current';
       }
       return name;
     }

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -62,6 +62,9 @@ class TabBar<T> extends Widget {
   constructor(options: TabBar.IOptions<T> = {}) {
     super({ node: Private.createNode() });
     this.addClass('lm-TabBar');
+    /* <DEPRECATED> */
+    this.addClass('p-TabBar');
+    /* </DEPRECATED> */
     this.setFlag(Widget.Flag.DisallowLayout);
     this.tabsMovable = options.tabsMovable || false;
     this.allowDeselect = options.allowDeselect || false;
@@ -692,6 +695,10 @@ class TabBar<T> extends Widget {
       // Add the dragging style classes.
       data.tab.classList.add('lm-mod-dragging');
       this.addClass('lm-mod-dragging');
+      /* <DEPRECATED> */
+      data.tab.classList.add('p-mod-dragging');
+      this.addClass('p-mod-dragging');
+      /* </DEPRECATED> */
 
       // Mark the drag as active.
       data.dragActive = true;
@@ -798,6 +805,9 @@ class TabBar<T> extends Widget {
 
     // Remove the dragging class from the tab so it can be transitioned.
     data.tab.classList.remove('lm-mod-dragging');
+    /* <DEPRECATED> */
+    data.tab.classList.remove('p-mod-dragging');
+    /* </DEPRECATED> */
 
     // Parse the transition duration for releasing the tab.
     let duration = Private.parseTransitionDuration(data.tab);
@@ -820,6 +830,9 @@ class TabBar<T> extends Widget {
 
       // Remove the remaining dragging style.
       this.removeClass('lm-mod-dragging');
+      /* <DEPRECATED> */
+      this.removeClass('p-mod-dragging');
+      /* </DEPRECATED> */
 
       // If the tab was not moved, there is nothing else to do.
       let i = data.index;
@@ -881,6 +894,10 @@ class TabBar<T> extends Widget {
     // Clear the dragging style classes.
     data.tab.classList.remove('lm-mod-dragging');
     this.removeClass('lm-mod-dragging');
+    /* <DEPRECATED> */
+    data.tab.classList.remove('p-mod-dragging');
+    this.removeClass('p-mod-dragging');
+    /* </DEPRECATED> */
   }
 
   /**
@@ -1358,7 +1375,12 @@ namespace TabBar {
      * @returns A virtual element representing the tab label.
      */
     renderLabel(data: IRenderData<any>): VirtualElement {
-      return h.div({ className: 'lm-TabBar-tabLabel' }, data.title.label);
+      return h.div({
+        className: 'lm-TabBar-tabLabel'
+          /* <DEPRECATED> */
+          + ' p-TabBar-tabLabel'
+          /* </DEPRECATED> */
+      }, data.title.label);
     }
 
     /**
@@ -1369,7 +1391,12 @@ namespace TabBar {
      * @returns A virtual element representing the tab close icon.
      */
     renderCloseIcon(data: IRenderData<any>): VirtualElement {
-      return h.div({ className: 'lm-TabBar-tabCloseIcon' });
+      return h.div({
+        className: 'lm-TabBar-tabCloseIcon'
+          /* <DEPRECATED> */
+          + ' p-TabBar-tabCloseIcon'
+          /* </DEPRECATED> */
+      });
     }
 
     /**
@@ -1413,14 +1440,23 @@ namespace TabBar {
      */
     createTabClass(data: IRenderData<any>): string {
       let name = 'lm-TabBar-tab';
+      /* <DEPRECATED> */
+      name += ' p-TabBar-tab';
+      /* </DEPRECATED> */
       if (data.title.className) {
         name += ` ${data.title.className}`;
       }
       if (data.title.closable) {
         name += ' lm-mod-closable';
+        /* <DEPRECATED> */
+        name += ' p-mod-closable';
+        /* </DEPRECATED> */
       }
       if (data.current) {
         name += ' lm-mod-current';
+        /* <DEPRECATED> */
+        name += ' p-mod-current';
+        /* </DEPRECATED> */
       }
       return name;
     }
@@ -1445,6 +1481,9 @@ namespace TabBar {
      */
     createIconClass(data: IRenderData<any>): string {
       let name = 'lm-TabBar-tabIcon';
+      /* <DEPRECATED> */
+      name += ' p-TabBar-tabIcon';
+      /* </DEPRECATED> */
       let extra = data.title.iconClass;
       return extra ? `${name} ${extra}` : name;
     }
@@ -1596,6 +1635,9 @@ namespace Private {
     let node = document.createElement('div');
     let content = document.createElement('ul');
     content.className = 'lm-TabBar-content';
+    /* <DEPRECATED> */
+    content.classList.add('p-TabBar-content');
+    /* </DEPRECATED> */
     node.appendChild(content);
     return node;
   }

--- a/packages/widgets/src/tabpanel.ts
+++ b/packages/widgets/src/tabpanel.ts
@@ -56,13 +56,13 @@ class TabPanel extends Widget {
    */
   constructor(options: TabPanel.IOptions = {}) {
     super();
-    this.addClass('p-TabPanel');
+    this.addClass('lm-TabPanel');
 
     // Create the tab bar and stacked panel.
     this.tabBar = new TabBar<Widget>(options);
-    this.tabBar.addClass('p-TabPanel-tabBar');
+    this.tabBar.addClass('lm-TabPanel-tabBar');
     this.stackedPanel = new StackedPanel();
-    this.stackedPanel.addClass('p-TabPanel-stackedPanel');
+    this.stackedPanel.addClass('lm-TabPanel-stackedPanel');
 
     // Connect the tab bar signal handlers.
     this.tabBar.tabMoved.connect(this._onTabMoved, this);

--- a/packages/widgets/src/tabpanel.ts
+++ b/packages/widgets/src/tabpanel.ts
@@ -57,12 +57,19 @@ class TabPanel extends Widget {
   constructor(options: TabPanel.IOptions = {}) {
     super();
     this.addClass('lm-TabPanel');
+    /* <DEPRECATED> */
+    this.addClass('p-TabPanel');
+    /* </DEPRECATED> */
 
     // Create the tab bar and stacked panel.
     this.tabBar = new TabBar<Widget>(options);
     this.tabBar.addClass('lm-TabPanel-tabBar');
     this.stackedPanel = new StackedPanel();
     this.stackedPanel.addClass('lm-TabPanel-stackedPanel');
+    /* <DEPRECATED> */
+    this.tabBar.addClass('p-TabPanel-tabBar');
+    this.stackedPanel.addClass('p-TabPanel-stackedPanel');
+    /* </DEPRECATED> */
 
     // Connect the tab bar signal handlers.
     this.tabBar.tabMoved.connect(this._onTabMoved, this);

--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -54,6 +54,9 @@ class Widget implements IMessageHandler, IObservableDisposable {
   constructor(options: Widget.IOptions = {}) {
     this.node = Private.createNode(options);
     this.addClass('lm-Widget');
+    /* <DEPRECATED> */
+    this.addClass('p-Widget');
+    /* </DEPRECATED> */
   }
 
   /**
@@ -397,6 +400,9 @@ class Widget implements IMessageHandler, IObservableDisposable {
     }
     this.clearFlag(Widget.Flag.IsHidden);
     this.removeClass('lm-mod-hidden');
+    /* <DEPRECATED> */
+    this.removeClass('p-mod-hidden');
+    /* </DEPRECATED> */
     if (this.isAttached && (!this.parent || this.parent.isVisible)) {
       MessageLoop.sendMessage(this, Widget.Msg.AfterShow);
     }
@@ -423,6 +429,9 @@ class Widget implements IMessageHandler, IObservableDisposable {
     }
     this.setFlag(Widget.Flag.IsHidden);
     this.addClass('lm-mod-hidden');
+    /* <DEPRECATED> */
+    this.addClass('p-mod-hidden');
+    /* </DEPRECATED> */
     if (this.isAttached && (!this.parent || this.parent.isVisible)) {
       MessageLoop.sendMessage(this, Widget.Msg.AfterHide);
     }

--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -53,7 +53,7 @@ class Widget implements IMessageHandler, IObservableDisposable {
    */
   constructor(options: Widget.IOptions = {}) {
     this.node = Private.createNode(options);
-    this.addClass('p-Widget');
+    this.addClass('lm-Widget');
   }
 
   /**
@@ -396,7 +396,7 @@ class Widget implements IMessageHandler, IObservableDisposable {
       MessageLoop.sendMessage(this, Widget.Msg.BeforeShow);
     }
     this.clearFlag(Widget.Flag.IsHidden);
-    this.removeClass('p-mod-hidden');
+    this.removeClass('lm-mod-hidden');
     if (this.isAttached && (!this.parent || this.parent.isVisible)) {
       MessageLoop.sendMessage(this, Widget.Msg.AfterShow);
     }
@@ -422,7 +422,7 @@ class Widget implements IMessageHandler, IObservableDisposable {
       MessageLoop.sendMessage(this, Widget.Msg.BeforeHide);
     }
     this.setFlag(Widget.Flag.IsHidden);
-    this.addClass('p-mod-hidden');
+    this.addClass('lm-mod-hidden');
     if (this.isAttached && (!this.parent || this.parent.isVisible)) {
       MessageLoop.sendMessage(this, Widget.Msg.AfterHide);
     }

--- a/packages/widgets/style/commandpalette.css
+++ b/packages/widgets/style/commandpalette.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-CommandPalette {
+.lm-CommandPalette {
   display: flex;
   flex-direction: column;
   -webkit-user-select: none;
@@ -18,12 +18,12 @@
 }
 
 
-.p-CommandPalette-search {
+.lm-CommandPalette-search {
   flex: 0 0 auto;
 }
 
 
-.p-CommandPalette-content {
+.lm-CommandPalette-content {
   flex: 1 1 auto;
   margin: 0;
   padding: 0;
@@ -33,36 +33,36 @@
 }
 
 
-.p-CommandPalette-header {
+.lm-CommandPalette-header {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
 
-.p-CommandPalette-item {
+.lm-CommandPalette-item {
   display: flex;
   flex-direction: row;
 }
 
 
-.p-CommandPalette-itemIcon {
+.lm-CommandPalette-itemIcon {
   flex: 0 0 auto;
 }
 
 
-.p-CommandPalette-itemContent {
+.lm-CommandPalette-itemContent {
   flex: 1 1 auto;
   overflow: hidden;
 }
 
 
-.p-CommandPalette-itemShortcut {
+.lm-CommandPalette-itemShortcut {
   flex: 0 0 auto;
 }
 
 
-.p-CommandPalette-itemLabel {
+.lm-CommandPalette-itemLabel {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/packages/widgets/style/commandpalette.css
+++ b/packages/widgets/style/commandpalette.css
@@ -8,6 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-CommandPalette, /* </DEPRECATED> */
 .lm-CommandPalette {
   display: flex;
   flex-direction: column;
@@ -18,11 +19,13 @@
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-search, /* </DEPRECATED> */
 .lm-CommandPalette-search {
   flex: 0 0 auto;
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-content, /* </DEPRECATED> */
 .lm-CommandPalette-content {
   flex: 1 1 auto;
   margin: 0;
@@ -33,6 +36,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-header, /* </DEPRECATED> */
 .lm-CommandPalette-header {
   overflow: hidden;
   white-space: nowrap;
@@ -40,28 +44,33 @@
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-item, /* </DEPRECATED> */
 .lm-CommandPalette-item {
   display: flex;
   flex-direction: row;
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-itemIcon, /* </DEPRECATED> */
 .lm-CommandPalette-itemIcon {
   flex: 0 0 auto;
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-itemContent, /* </DEPRECATED> */
 .lm-CommandPalette-itemContent {
   flex: 1 1 auto;
   overflow: hidden;
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-itemShortcut, /* </DEPRECATED> */
 .lm-CommandPalette-itemShortcut {
   flex: 0 0 auto;
 }
 
 
+/* <DEPRECATED> */ .p-CommandPalette-itemLabel, /* </DEPRECATED> */
 .lm-CommandPalette-itemLabel {
   overflow: hidden;
   white-space: nowrap;

--- a/packages/widgets/style/dockpanel.css
+++ b/packages/widgets/style/dockpanel.css
@@ -8,32 +8,32 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-DockPanel {
+.lm-DockPanel {
   z-index: 0;
 }
 
 
-.p-DockPanel-widget {
+.lm-DockPanel-widget {
   z-index: 0;
 }
 
 
-.p-DockPanel-tabBar {
+.lm-DockPanel-tabBar {
   z-index: 1;
 }
 
 
-.p-DockPanel-handle {
+.lm-DockPanel-handle {
   z-index: 2;
 }
 
 
-.p-DockPanel-handle.p-mod-hidden {
+.lm-DockPanel-handle.lm-mod-hidden {
   display: none !important;
 }
 
 
-.p-DockPanel-handle:after {
+.lm-DockPanel-handle:after {
   position: absolute;
   top: 0;
   left: 0;
@@ -43,37 +43,37 @@
 }
 
 
-.p-DockPanel-handle[data-orientation='horizontal'] {
+.lm-DockPanel-handle[data-orientation='horizontal'] {
   cursor: ew-resize;
 }
 
 
-.p-DockPanel-handle[data-orientation='vertical'] {
+.lm-DockPanel-handle[data-orientation='vertical'] {
   cursor: ns-resize;
 }
 
 
-.p-DockPanel-handle[data-orientation='horizontal']:after {
+.lm-DockPanel-handle[data-orientation='horizontal']:after {
   left: 50%;
   min-width: 8px;
   transform: translateX(-50%);
 }
 
 
-.p-DockPanel-handle[data-orientation='vertical']:after {
+.lm-DockPanel-handle[data-orientation='vertical']:after {
   top: 50%;
   min-height: 8px;
   transform: translateY(-50%);
 }
 
 
-.p-DockPanel-overlay {
+.lm-DockPanel-overlay {
   z-index: 3;
   box-sizing: border-box;
   pointer-events: none;
 }
 
 
-.p-DockPanel-overlay.p-mod-hidden {
+.lm-DockPanel-overlay.lm-mod-hidden {
   display: none !important;
 }

--- a/packages/widgets/style/dockpanel.css
+++ b/packages/widgets/style/dockpanel.css
@@ -8,31 +8,37 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-DockPanel, /* </DEPRECATED> */
 .lm-DockPanel {
   z-index: 0;
 }
 
 
+/* <DEPRECATED> */ .p-DockPanel-widget, /* </DEPRECATED> */
 .lm-DockPanel-widget {
   z-index: 0;
 }
 
 
+/* <DEPRECATED> */ .p-DockPanel-tabBar, /* </DEPRECATED> */
 .lm-DockPanel-tabBar {
   z-index: 1;
 }
 
 
+/* <DEPRECATED> */ .p-DockPanel-handle, /* </DEPRECATED> */
 .lm-DockPanel-handle {
   z-index: 2;
 }
 
 
+/* <DEPRECATED> */ .p-DockPanel-handle.p-mod-hidden, /* </DEPRECATED> */
 .lm-DockPanel-handle.lm-mod-hidden {
   display: none !important;
 }
 
 
+/* <DEPRECATED> */ .p-DockPanel-handle:after, /* </DEPRECATED> */
 .lm-DockPanel-handle:after {
   position: absolute;
   top: 0;
@@ -43,16 +49,25 @@
 }
 
 
+/* <DEPRECATED> */
+.p-DockPanel-handle[data-orientation='horizontal'],
+/* </DEPRECATED> */
 .lm-DockPanel-handle[data-orientation='horizontal'] {
   cursor: ew-resize;
 }
 
 
+/* <DEPRECATED> */
+.p-DockPanel-handle[data-orientation='vertical'],
+/* </DEPRECATED> */
 .lm-DockPanel-handle[data-orientation='vertical'] {
   cursor: ns-resize;
 }
 
 
+/* <DEPRECATED> */
+.p-DockPanel-handle[data-orientation='horizontal']:after,
+/* </DEPRECATED> */
 .lm-DockPanel-handle[data-orientation='horizontal']:after {
   left: 50%;
   min-width: 8px;
@@ -60,6 +75,9 @@
 }
 
 
+/* <DEPRECATED> */
+.p-DockPanel-handle[data-orientation='vertical']:after,
+/* </DEPRECATED> */
 .lm-DockPanel-handle[data-orientation='vertical']:after {
   top: 50%;
   min-height: 8px;
@@ -67,6 +85,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-DockPanel-overlay, /* </DEPRECATED> */
 .lm-DockPanel-overlay {
   z-index: 3;
   box-sizing: border-box;
@@ -74,6 +93,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-DockPanel-overlay.p-mod-hidden, /* </DEPRECATED> */
 .lm-DockPanel-overlay.lm-mod-hidden {
   display: none !important;
 }

--- a/packages/widgets/style/menu.css
+++ b/packages/widgets/style/menu.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-Menu {
+.lm-Menu {
   z-index: 10000;
   position: absolute;
   white-space: nowrap;
@@ -22,7 +22,7 @@
 }
 
 
-.p-Menu-content {
+.lm-Menu-content {
   margin: 0;
   padding: 0;
   display: table;
@@ -30,31 +30,31 @@
 }
 
 
-.p-Menu-item {
+.lm-Menu-item {
   display: table-row;
 }
 
 
-.p-Menu-item.p-mod-hidden,
-.p-Menu-item.p-mod-collapsed {
+.lm-Menu-item.lm-mod-hidden,
+.lm-Menu-item.lm-mod-collapsed {
   display: none !important;
 }
 
 
-.p-Menu-itemIcon,
-.p-Menu-itemSubmenuIcon {
+.lm-Menu-itemIcon,
+.lm-Menu-itemSubmenuIcon {
   display: table-cell;
   text-align: center;
 }
 
 
-.p-Menu-itemLabel {
+.lm-Menu-itemLabel {
   display: table-cell;
   text-align: left;
 }
 
 
-.p-Menu-itemShortcut {
+.lm-Menu-itemShortcut {
   display: table-cell;
   text-align: right;
 }

--- a/packages/widgets/style/menu.css
+++ b/packages/widgets/style/menu.css
@@ -8,6 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-Menu, /* </DEPRECATED> */
 .lm-Menu {
   z-index: 10000;
   position: absolute;
@@ -22,6 +23,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-Menu-content, /* </DEPRECATED> */
 .lm-Menu-content {
   margin: 0;
   padding: 0;
@@ -30,17 +32,26 @@
 }
 
 
+/* <DEPRECATED> */ .p-Menu-item, /* </DEPRECATED> */
 .lm-Menu-item {
   display: table-row;
 }
 
 
+/* <DEPRECATED> */
+.p-Menu-item.p-mod-hidden,
+.p-Menu-item.p-mod-collapsed,
+/* </DEPRECATED> */
 .lm-Menu-item.lm-mod-hidden,
 .lm-Menu-item.lm-mod-collapsed {
   display: none !important;
 }
 
 
+/* <DEPRECATED> */
+.p-Menu-itemIcon,
+.p-Menu-itemSubmenuIcon,
+/* </DEPRECATED> */
 .lm-Menu-itemIcon,
 .lm-Menu-itemSubmenuIcon {
   display: table-cell;
@@ -48,12 +59,14 @@
 }
 
 
+/* <DEPRECATED> */ .p-Menu-itemLabel, /* </DEPRECATED> */
 .lm-Menu-itemLabel {
   display: table-cell;
   text-align: left;
 }
 
 
+/* <DEPRECATED> */ .p-Menu-itemShortcut, /* </DEPRECATED> */
 .lm-Menu-itemShortcut {
   display: table-cell;
   text-align: right;

--- a/packages/widgets/style/menubar.css
+++ b/packages/widgets/style/menubar.css
@@ -8,6 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-MenuBar, /* </DEPRECATED> */
 .lm-MenuBar {
   outline: none;
   -webkit-user-select: none;
@@ -17,6 +18,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-MenuBar-content, /* </DEPRECATED> */
 .lm-MenuBar-content {
   margin: 0;
   padding: 0;
@@ -26,11 +28,16 @@
 }
 
 
+/* <DEPRECATED> */ .p--MenuBar-item, /* </DEPRECATED> */
 .lm-MenuBar-item {
   box-sizing: border-box;
 }
 
 
+/* <DEPRECATED> */
+.p-MenuBar-itemIcon,
+.p-MenuBar-itemLabel,
+/* </DEPRECATED> */
 .lm-MenuBar-itemIcon,
 .lm-MenuBar-itemLabel {
   display: inline-block;

--- a/packages/widgets/style/menubar.css
+++ b/packages/widgets/style/menubar.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-MenuBar {
+.lm-MenuBar {
   outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -17,7 +17,7 @@
 }
 
 
-.p-MenuBar-content {
+.lm-MenuBar-content {
   margin: 0;
   padding: 0;
   display: flex;
@@ -26,12 +26,12 @@
 }
 
 
-.p-MenuBar-item {
+.lm-MenuBar-item {
   box-sizing: border-box;
 }
 
 
-.p-MenuBar-itemIcon,
-.p-MenuBar-itemLabel {
+.lm-MenuBar-itemIcon,
+.lm-MenuBar-itemLabel {
   display: inline-block;
 }

--- a/packages/widgets/style/scrollbar.css
+++ b/packages/widgets/style/scrollbar.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-ScrollBar {
+.lm-ScrollBar {
   display: flex;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -17,23 +17,23 @@
 }
 
 
-.p-ScrollBar[data-orientation='horizontal'] {
+.lm-ScrollBar[data-orientation='horizontal'] {
   flex-direction: row;
 }
 
 
-.p-ScrollBar[data-orientation='vertical'] {
+.lm-ScrollBar[data-orientation='vertical'] {
   flex-direction: column;
 }
 
 
-.p-ScrollBar-button {
+.lm-ScrollBar-button {
   box-sizing: border-box;
   flex: 0 0 auto;
 }
 
 
-.p-ScrollBar-track {
+.lm-ScrollBar-track {
   box-sizing: border-box;
   position: relative;
   overflow: hidden;
@@ -41,7 +41,7 @@
 }
 
 
-.p-ScrollBar-thumb {
+.lm-ScrollBar-thumb {
   box-sizing: border-box;
   position: absolute;
 }

--- a/packages/widgets/style/scrollbar.css
+++ b/packages/widgets/style/scrollbar.css
@@ -8,6 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-ScrollBar, /* </DEPRECATED> */
 .lm-ScrollBar {
   display: flex;
   -webkit-user-select: none;
@@ -17,22 +18,30 @@
 }
 
 
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='horizontal'],
+/* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='horizontal'] {
   flex-direction: row;
 }
 
 
+/* <DEPRECATED> */
+.p-ScrollBar[data-orientation='vertical'],
+/* </DEPRECATED> */
 .lm-ScrollBar[data-orientation='vertical'] {
   flex-direction: column;
 }
 
 
+/* <DEPRECATED> */ .p-ScrollBar-button, /* </DEPRECATED> */
 .lm-ScrollBar-button {
   box-sizing: border-box;
   flex: 0 0 auto;
 }
 
 
+/* <DEPRECATED> */ .p-ScrollBar-track, /* </DEPRECATED> */
 .lm-ScrollBar-track {
   box-sizing: border-box;
   position: relative;
@@ -41,6 +50,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-ScrollBar-thumb, /* </DEPRECATED> */
 .lm-ScrollBar-thumb {
   box-sizing: border-box;
   position: absolute;

--- a/packages/widgets/style/splitpanel.css
+++ b/packages/widgets/style/splitpanel.css
@@ -8,21 +8,25 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-SplitPanel-child, /* </DEPRECATED> */
 .lm-SplitPanel-child {
   z-index: 0;
 }
 
 
+/* <DEPRECATED> */ .p-SplitPanel-handle, /* </DEPRECATED> */
 .lm-SplitPanel-handle {
   z-index: 1;
 }
 
 
+/* <DEPRECATED> */ .p-SplitPanel-handle.p-mod-hidden, /* </DEPRECATED> */
 .lm-SplitPanel-handle.lm-mod-hidden {
   display: none !important;
 }
 
 
+/* <DEPRECATED> */ .p-SplitPanel-handle:after, /* </DEPRECATED> */
 .lm-SplitPanel-handle:after {
   position: absolute;
   top: 0;
@@ -33,16 +37,25 @@
 }
 
 
+/* <DEPRECATED> */
+.p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle,
+/* </DEPRECATED> */
 .lm-SplitPanel[data-orientation='horizontal'] > .lm-SplitPanel-handle {
   cursor: ew-resize;
 }
 
 
+/* <DEPRECATED> */
+.p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle,
+/* </DEPRECATED> */
 .lm-SplitPanel[data-orientation='vertical'] > .lm-SplitPanel-handle {
   cursor: ns-resize;
 }
 
 
+/* <DEPRECATED> */
+.p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle:after,
+/* </DEPRECATED> */
 .lm-SplitPanel[data-orientation='horizontal'] > .lm-SplitPanel-handle:after {
   left: 50%;
   min-width: 8px;
@@ -50,6 +63,9 @@
 }
 
 
+/* <DEPRECATED> */
+.p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle:after,
+/* </DEPRECATED> */
 .lm-SplitPanel[data-orientation='vertical'] > .lm-SplitPanel-handle:after {
   top: 50%;
   min-height: 8px;

--- a/packages/widgets/style/splitpanel.css
+++ b/packages/widgets/style/splitpanel.css
@@ -8,22 +8,22 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-SplitPanel-child {
+.lm-SplitPanel-child {
   z-index: 0;
 }
 
 
-.p-SplitPanel-handle {
+.lm-SplitPanel-handle {
   z-index: 1;
 }
 
 
-.p-SplitPanel-handle.p-mod-hidden {
+.lm-SplitPanel-handle.lm-mod-hidden {
   display: none !important;
 }
 
 
-.p-SplitPanel-handle:after {
+.lm-SplitPanel-handle:after {
   position: absolute;
   top: 0;
   left: 0;
@@ -33,24 +33,24 @@
 }
 
 
-.p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle {
+.lm-SplitPanel[data-orientation='horizontal'] > .lm-SplitPanel-handle {
   cursor: ew-resize;
 }
 
 
-.p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle {
+.lm-SplitPanel[data-orientation='vertical'] > .lm-SplitPanel-handle {
   cursor: ns-resize;
 }
 
 
-.p-SplitPanel[data-orientation='horizontal'] > .p-SplitPanel-handle:after {
+.lm-SplitPanel[data-orientation='horizontal'] > .lm-SplitPanel-handle:after {
   left: 50%;
   min-width: 8px;
   transform: translateX(-50%);
 }
 
 
-.p-SplitPanel[data-orientation='vertical'] > .p-SplitPanel-handle:after {
+.lm-SplitPanel[data-orientation='vertical'] > .lm-SplitPanel-handle:after {
   top: 50%;
   min-height: 8px;
   transform: translateY(-50%);

--- a/packages/widgets/style/tabbar.css
+++ b/packages/widgets/style/tabbar.css
@@ -8,6 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-TabBar, /* </DEPRECATED> */
 .lm-TabBar {
   display: flex;
   -webkit-user-select: none;
@@ -17,16 +18,19 @@
 }
 
 
+/* <DEPRECATED> */ .p-TabBar[data-orientation='horizontal'], /* </DEPRECATED> */
 .lm-TabBar[data-orientation='horizontal'] {
   flex-direction: row;
 }
 
 
+/* <DEPRECATED> */ .p-TabBar[data-orientation='vertical'], /* </DEPRECATED> */
 .lm-TabBar[data-orientation='vertical'] {
   flex-direction: column;
 }
 
 
+/* <DEPRECATED> */ .p-TabBar-content, /* </DEPRECATED> */
 .lm-TabBar-content {
   margin: 0;
   padding: 0;
@@ -36,16 +40,23 @@
 }
 
 
+/* <DEPRECATED> */
+.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content,
+/* </DEPRECATED> */
 .lm-TabBar[data-orientation='horizontal'] > .lm-TabBar-content {
   flex-direction: row;
 }
 
 
+/* <DEPRECATED> */
+.p-TabBar[data-orientation='vertical'] > .p-TabBar-content,
+/* </DEPRECATED> */
 .lm-TabBar[data-orientation='vertical'] > .lm-TabBar-content {
   flex-direction: column;
 }
 
 
+/* <DEPRECATED> */ .p-TabBar-tab, /* </DEPRECATED> */
 .lm-TabBar-tab {
   display: flex;
   flex-direction: row;
@@ -54,12 +65,17 @@
 }
 
 
+/* <DEPRECATED> */
+.p-TabBar-tabIcon,
+.p-TabBar-tabCloseIcon,
+/* </DEPRECATED> */
 .lm-TabBar-tabIcon,
 .lm-TabBar-tabCloseIcon {
   flex: 0 0 auto;
 }
 
 
+/* <DEPRECATED> */ .p-TabBar-tabLabel, /* </DEPRECATED> */
 .lm-TabBar-tabLabel {
   flex: 1 1 auto;
   overflow: hidden;
@@ -67,28 +83,39 @@
 }
 
 
+/* <DEPRECATED> */ .p-TabBar-tab.p-mod-hidden, /* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-hidden {
   display: none !important;
 }
 
 
+/* <DEPRECATED> */ .p-TabBar.p-mod-dragging .p-TabBar-tab, /* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging .lm-TabBar-tab {
   position: relative;
 }
 
 
+/* <DEPRECATED> */
+.p-TabBar.p-mod-dragging[data-orientation='horizontal'] .p-TabBar-tab,
+/* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging[data-orientation='horizontal'] .lm-TabBar-tab {
   left: 0;
   transition: left 150ms ease;
 }
 
 
+/* <DEPRECATED> */
+.p-TabBar.p-mod-dragging[data-orientation='vertical'] .p-TabBar-tab,
+/* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging[data-orientation='vertical'] .lm-TabBar-tab {
   top: 0;
   transition: top 150ms ease;
 }
 
 
+/* <DEPRECATED> */
+.p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging
+/* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging .lm-TabBar-tab.lm-mod-dragging {
   transition: none;
 }

--- a/packages/widgets/style/tabbar.css
+++ b/packages/widgets/style/tabbar.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-TabBar {
+.lm-TabBar {
   display: flex;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -17,17 +17,17 @@
 }
 
 
-.p-TabBar[data-orientation='horizontal'] {
+.lm-TabBar[data-orientation='horizontal'] {
   flex-direction: row;
 }
 
 
-.p-TabBar[data-orientation='vertical'] {
+.lm-TabBar[data-orientation='vertical'] {
   flex-direction: column;
 }
 
 
-.p-TabBar-content {
+.lm-TabBar-content {
   margin: 0;
   padding: 0;
   display: flex;
@@ -36,17 +36,17 @@
 }
 
 
-.p-TabBar[data-orientation='horizontal'] > .p-TabBar-content {
+.lm-TabBar[data-orientation='horizontal'] > .lm-TabBar-content {
   flex-direction: row;
 }
 
 
-.p-TabBar[data-orientation='vertical'] > .p-TabBar-content {
+.lm-TabBar[data-orientation='vertical'] > .lm-TabBar-content {
   flex-direction: column;
 }
 
 
-.p-TabBar-tab {
+.lm-TabBar-tab {
   display: flex;
   flex-direction: row;
   box-sizing: border-box;
@@ -54,41 +54,41 @@
 }
 
 
-.p-TabBar-tabIcon,
-.p-TabBar-tabCloseIcon {
+.lm-TabBar-tabIcon,
+.lm-TabBar-tabCloseIcon {
   flex: 0 0 auto;
 }
 
 
-.p-TabBar-tabLabel {
+.lm-TabBar-tabLabel {
   flex: 1 1 auto;
   overflow: hidden;
   white-space: nowrap;
 }
 
 
-.p-TabBar-tab.p-mod-hidden {
+.lm-TabBar-tab.lm-mod-hidden {
   display: none !important;
 }
 
 
-.p-TabBar.p-mod-dragging .p-TabBar-tab {
+.lm-TabBar.lm-mod-dragging .lm-TabBar-tab {
   position: relative;
 }
 
 
-.p-TabBar.p-mod-dragging[data-orientation='horizontal'] .p-TabBar-tab {
+.lm-TabBar.lm-mod-dragging[data-orientation='horizontal'] .lm-TabBar-tab {
   left: 0;
   transition: left 150ms ease;
 }
 
 
-.p-TabBar.p-mod-dragging[data-orientation='vertical'] .p-TabBar-tab {
+.lm-TabBar.lm-mod-dragging[data-orientation='vertical'] .lm-TabBar-tab {
   top: 0;
   transition: top 150ms ease;
 }
 
 
-.p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging {
+.lm-TabBar.lm-mod-dragging .lm-TabBar-tab.lm-mod-dragging {
   transition: none;
 }

--- a/packages/widgets/style/tabpanel.css
+++ b/packages/widgets/style/tabpanel.css
@@ -8,11 +8,13 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-TabPanel-tabBar, /* </DEPRECATED> */
 .lm-TabPanel-tabBar {
   z-index: 1;
 }
 
 
+/* <DEPRECATED> */ .p-TabPanel-stackedPanel, /* </DEPRECATED> */
 .lm-TabPanel-stackedPanel {
   z-index: 0;
 }

--- a/packages/widgets/style/tabpanel.css
+++ b/packages/widgets/style/tabpanel.css
@@ -8,11 +8,11 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-TabPanel-tabBar {
+.lm-TabPanel-tabBar {
   z-index: 1;
 }
 
 
-.p-TabPanel-stackedPanel {
+.lm-TabPanel-stackedPanel {
   z-index: 0;
 }

--- a/packages/widgets/style/widget.css
+++ b/packages/widgets/style/widget.css
@@ -8,6 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
+/* <DEPRECATED> */ .p-Widget, /* </DEPRECATED> */
 .lm-Widget {
   box-sizing: border-box;
   position: relative;
@@ -16,6 +17,7 @@
 }
 
 
+/* <DEPRECATED> */ .p-Widget.p-mod-hidden, /* </DEPRECATED> */
 .lm-Widget.lm-mod-hidden {
   display: none !important;
 }

--- a/packages/widgets/style/widget.css
+++ b/packages/widgets/style/widget.css
@@ -8,7 +8,7 @@
 |----------------------------------------------------------------------------*/
 
 
-.p-Widget {
+.lm-Widget {
   box-sizing: border-box;
   position: relative;
   overflow: hidden;
@@ -16,6 +16,6 @@
 }
 
 
-.p-Widget.p-mod-hidden {
+.lm-Widget.lm-mod-hidden {
   display: none !important;
 }

--- a/packages/widgets/tests/src/boxpanel.spec.ts
+++ b/packages/widgets/tests/src/boxpanel.spec.ts
@@ -49,9 +49,9 @@ describe('@lumino/widgets', () => {
         expect(panel.spacing).to.equal(4);
       });
 
-      it('should add the `p-BoxPanel` class', () => {
+      it('should add the `lm-BoxPanel` class', () => {
         let panel = new BoxPanel();
-        expect(panel.hasClass('p-BoxPanel')).to.equal(true);
+        expect(panel.hasClass('lm-BoxPanel')).to.equal(true);
       });
 
     });
@@ -92,7 +92,7 @@ describe('@lumino/widgets', () => {
         let panel = new BoxPanel();
         let widget = new Widget();
         panel.addWidget(widget);
-        expect(widget.hasClass('p-BoxPanel-child')).to.equal(true);
+        expect(widget.hasClass('lm-BoxPanel-child')).to.equal(true);
       });
 
     });
@@ -104,7 +104,7 @@ describe('@lumino/widgets', () => {
         let widget = new Widget();
         panel.addWidget(widget);
         widget.parent = null;
-        expect(widget.hasClass('p-BoxPanel-child')).to.equal(false);
+        expect(widget.hasClass('lm-BoxPanel-child')).to.equal(false);
       });
 
     });

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -685,14 +685,22 @@ describe('@lumino/widgets', () => {
 
         it('should create the full class name for the item node', () => {
           let name = renderer.createItemClass({ item, indices: null, active: false });
-          expect(name).to.equal('lm-CommandPalette-item testClass');
+          let expected = 'lm-CommandPalette-item testClass';
+          /* <DEPRECATED> */
+          expected = 'lm-CommandPalette-item p-CommandPalette-item testClass';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
         });
 
         it('should handle the boolean states', () => {
           enabledFlag = false;
           toggledFlag = true;
           let name = renderer.createItemClass({ item, indices: null, active: true });
-          expect(name).to.equal('lm-CommandPalette-item lm-mod-disabled lm-mod-toggled lm-mod-active testClass');
+          let expected = 'lm-CommandPalette-item lm-mod-disabled lm-mod-toggled lm-mod-active testClass';
+          /* <DEPRECATED> */
+          expected = 'lm-CommandPalette-item p-CommandPalette-item lm-mod-disabled p-mod-disabled lm-mod-toggled p-mod-toggled lm-mod-active p-mod-active testClass';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
         });
 
       });

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -75,7 +75,7 @@ describe('@lumino/widgets', () => {
 
       it('should accept command palette instantiation options', () => {
         expect(palette).to.be.an.instanceof(CommandPalette);
-        expect(palette.node.classList.contains('p-CommandPalette')).to.equal(true);
+        expect(palette.node.classList.contains('lm-CommandPalette')).to.equal(true);
       });
 
     });
@@ -110,7 +110,7 @@ describe('@lumino/widgets', () => {
     describe('#searchNode', () => {
 
       it('should return the search node of a command palette', () => {
-        expect(palette.searchNode.classList.contains('p-CommandPalette-search')).to.equal(true);
+        expect(palette.searchNode.classList.contains('lm-CommandPalette-search')).to.equal(true);
       });
 
     });
@@ -118,7 +118,7 @@ describe('@lumino/widgets', () => {
     describe('#inputNode', () => {
 
       it('should return the input node of a command palette', () => {
-        expect(palette.inputNode.classList.contains('p-CommandPalette-input')).to.equal(true);
+        expect(palette.inputNode.classList.contains('lm-CommandPalette-input')).to.equal(true);
       });
 
     });
@@ -126,7 +126,7 @@ describe('@lumino/widgets', () => {
     describe('#contentNode', () => {
 
       it('should return the content node of a command palette', () => {
-        expect(palette.contentNode.classList.contains('p-CommandPalette-content')).to.equal(true);
+        expect(palette.contentNode.classList.contains('lm-CommandPalette-content')).to.equal(true);
       });
 
     });
@@ -354,7 +354,7 @@ describe('@lumino/widgets', () => {
         MessageLoop.flush();
 
         let content = palette.contentNode;
-        let itemClass = '.p-CommandPalette-item';
+        let itemClass = '.lm-CommandPalette-item';
         let items = () => content.querySelectorAll(itemClass);
 
         expect(items()).to.have.length(1);
@@ -388,7 +388,7 @@ describe('@lumino/widgets', () => {
           Widget.attach(palette, document.body);
           MessageLoop.flush();
 
-          let node = palette.contentNode.querySelector('.p-CommandPalette-item')!;
+          let node = palette.contentNode.querySelector('.lm-CommandPalette-item')!;
           simulate(node, 'click');
           expect(called).to.equal(true);
         });
@@ -401,7 +401,7 @@ describe('@lumino/widgets', () => {
           Widget.attach(palette, document.body);
           MessageLoop.flush();
 
-          let node = palette.contentNode.querySelector('.p-CommandPalette-item')!;
+          let node = palette.contentNode.querySelector('.lm-CommandPalette-item')!;
           simulate(node, 'click', { button: 1 });
           expect(called).to.equal(false);
         });
@@ -418,11 +418,11 @@ describe('@lumino/widgets', () => {
           Widget.attach(palette, document.body);
           MessageLoop.flush();
 
-          let node = content.querySelector('.p-mod-active');
+          let node = content.querySelector('.lm-mod-active');
           expect(node).to.equal(null);
           simulate(palette.node, 'keydown', { keyCode: 40 }); // Down arrow
           MessageLoop.flush();
-          node = content.querySelector('.p-CommandPalette-item.p-mod-active');
+          node = content.querySelector('.lm-CommandPalette-item.lm-mod-active');
           expect(node).to.not.equal(null);
         });
 
@@ -434,11 +434,11 @@ describe('@lumino/widgets', () => {
           Widget.attach(palette, document.body);
           MessageLoop.flush();
 
-          let node = content.querySelector('.p-mod-active');
+          let node = content.querySelector('.lm-mod-active');
           expect(node).to.equal(null);
           simulate(palette.node, 'keydown', { keyCode: 38 }); // Up arrow
           MessageLoop.flush();
-          node = content.querySelector('.p-CommandPalette-item.p-mod-active');
+          node = content.querySelector('.lm-CommandPalette-item.lm-mod-active');
           expect(node).to.not.equal(null);
         });
 
@@ -451,14 +451,14 @@ describe('@lumino/widgets', () => {
           Widget.attach(palette, document.body);
           MessageLoop.flush();
 
-          let node = content.querySelector('.p-mod-active');
+          let node = content.querySelector('.lm-mod-active');
 
           expect(node).to.equal(null);
           ['altKey', 'ctrlKey', 'shiftKey', 'metaKey'].forEach(key => {
             let options: any = { keyCode: 38 };
             options[key] = true;
             simulate(palette.node, 'keydown', options);
-            node = content.querySelector('.p-CommandPalette-item.p-mod-active');
+            node = content.querySelector('.lm-CommandPalette-item.lm-mod-active');
             expect(node).to.equal(null);
           });
           expect(called).to.be.false;
@@ -475,7 +475,7 @@ describe('@lumino/widgets', () => {
           Widget.attach(palette, document.body);
           MessageLoop.flush();
 
-          expect(content.querySelector('.p-mod-active')).to.equal(null);
+          expect(content.querySelector('.lm-mod-active')).to.equal(null);
           simulate(palette.node, 'keydown', { keyCode: 40 });  // Down arrow
           simulate(palette.node, 'keydown', { keyCode: 13 });  // Enter
           expect(called).to.equal(true);
@@ -495,7 +495,7 @@ describe('@lumino/widgets', () => {
           MessageLoop.flush();
 
           let content = palette.contentNode;
-          let itemClass = '.p-CommandPalette-item';
+          let itemClass = '.lm-CommandPalette-item';
           let items = () => content.querySelectorAll(itemClass);
 
           expect(items()).to.have.length(5);
@@ -521,8 +521,8 @@ describe('@lumino/widgets', () => {
           Widget.attach(palette, document.body);
           MessageLoop.flush();
 
-          let headers = () => palette.node.querySelectorAll('.p-CommandPalette-header');
-          let items = () => palette.node.querySelectorAll('.p-CommandPalette-item');
+          let headers = () => palette.node.querySelectorAll('.lm-CommandPalette-header');
+          let items = () => palette.node.querySelectorAll('.lm-CommandPalette-item');
           let input = (value: string) => {
             palette.inputNode.value = value;
             palette.refresh();
@@ -582,14 +582,14 @@ describe('@lumino/widgets', () => {
         it('should render a header node for the palette', () => {
           let vNode = renderer.renderHeader({ category: 'Test Category', indices: null });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-CommandPalette-header')).to.equal(true);
+          expect(node.classList.contains('lm-CommandPalette-header')).to.equal(true);
           expect(node.innerHTML).to.equal('Test Category');
         });
 
         it('should mark the matching indices', () => {
           let vNode = renderer.renderHeader({ category: 'Test Category', indices: [1, 2, 6, 7, 8] });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-CommandPalette-header')).to.equal(true);
+          expect(node.classList.contains('lm-CommandPalette-header')).to.equal(true);
           expect(node.innerHTML).to.equal('T<mark>es</mark>t C<mark>ate</mark>gory');
         });
 
@@ -600,35 +600,35 @@ describe('@lumino/widgets', () => {
         it('should render an item node for the palette', () => {
           let vNode = renderer.renderItem({ item, indices: null, active: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-CommandPalette-item')).to.equal(true);
-          expect(node.classList.contains('p-mod-disabled')).to.equal(false);
-          expect(node.classList.contains('p-mod-toggled')).to.equal(false);
-          expect(node.classList.contains('p-mod-active')).to.equal(false);
+          expect(node.classList.contains('lm-CommandPalette-item')).to.equal(true);
+          expect(node.classList.contains('lm-mod-disabled')).to.equal(false);
+          expect(node.classList.contains('lm-mod-toggled')).to.equal(false);
+          expect(node.classList.contains('lm-mod-active')).to.equal(false);
           expect(node.classList.contains('testClass')).to.equal(true);
           expect(node.getAttribute('data-command')).to.equal('test');
-          expect(node.querySelector('.p-CommandPalette-itemShortcut')).to.not.equal(null);
-          expect(node.querySelector('.p-CommandPalette-itemLabel')).to.not.equal(null);
-          expect(node.querySelector('.p-CommandPalette-itemCaption')).to.not.equal(null);
+          expect(node.querySelector('.lm-CommandPalette-itemShortcut')).to.not.equal(null);
+          expect(node.querySelector('.lm-CommandPalette-itemLabel')).to.not.equal(null);
+          expect(node.querySelector('.lm-CommandPalette-itemCaption')).to.not.equal(null);
         });
 
         it('should handle the disabled item state', () => {
           enabledFlag = false;
           let vNode = renderer.renderItem({ item, indices: null, active: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-mod-disabled')).to.equal(true);
+          expect(node.classList.contains('lm-mod-disabled')).to.equal(true);
         });
 
         it('should handle the toggled item state', () => {
           toggledFlag = true;
           let vNode = renderer.renderItem({ item, indices: null, active: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-mod-toggled')).to.equal(true);
+          expect(node.classList.contains('lm-mod-toggled')).to.equal(true);
         });
 
         it('should handle the active state', () => {
           let vNode = renderer.renderItem({ item, indices: null, active: true });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-mod-active')).to.equal(true);
+          expect(node.classList.contains('lm-mod-active')).to.equal(true);
         });
 
       });
@@ -638,7 +638,7 @@ describe('@lumino/widgets', () => {
         it('should render an empty message node for the palette', () => {
           let vNode = renderer.renderEmptyMessage({ query: 'foo' });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-CommandPalette-emptyMessage')).to.equal(true);
+          expect(node.classList.contains('lm-CommandPalette-emptyMessage')).to.equal(true);
           expect(node.innerHTML).to.equal("No commands found that match 'foo'");
         });
 
@@ -649,7 +649,7 @@ describe('@lumino/widgets', () => {
         it('should render an item shortcut node', () => {
           let vNode = renderer.renderItemShortcut({ item, indices: null, active: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-CommandPalette-itemShortcut')).to.equal(true);
+          expect(node.classList.contains('lm-CommandPalette-itemShortcut')).to.equal(true);
           if (Platform.IS_MAC) {
             expect(node.innerHTML).to.equal('\u2303 A');
           } else {
@@ -664,7 +664,7 @@ describe('@lumino/widgets', () => {
         it('should render an item label node', () => {
           let vNode = renderer.renderItemLabel({ item, indices: [1, 2, 3], active: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-CommandPalette-itemLabel')).to.equal(true);
+          expect(node.classList.contains('lm-CommandPalette-itemLabel')).to.equal(true);
           expect(node.innerHTML).to.equal('T<mark>est</mark> Command');
         });
 
@@ -675,7 +675,7 @@ describe('@lumino/widgets', () => {
         it('should render an item caption node', () => {
           let vNode = renderer.renderItemCaption({ item, indices: null, active: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-CommandPalette-itemCaption')).to.equal(true);
+          expect(node.classList.contains('lm-CommandPalette-itemCaption')).to.equal(true);
           expect(node.innerHTML).to.equal('A simple test command');
         });
 
@@ -685,14 +685,14 @@ describe('@lumino/widgets', () => {
 
         it('should create the full class name for the item node', () => {
           let name = renderer.createItemClass({ item, indices: null, active: false });
-          expect(name).to.equal('p-CommandPalette-item testClass');
+          expect(name).to.equal('lm-CommandPalette-item testClass');
         });
 
         it('should handle the boolean states', () => {
           enabledFlag = false;
           toggledFlag = true;
           let name = renderer.createItemClass({ item, indices: null, active: true });
-          expect(name).to.equal('p-CommandPalette-item p-mod-disabled p-mod-toggled p-mod-active testClass');
+          expect(name).to.equal('lm-CommandPalette-item lm-mod-disabled lm-mod-toggled p-mod-active testClass');
         });
 
       });

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -692,7 +692,7 @@ describe('@lumino/widgets', () => {
           enabledFlag = false;
           toggledFlag = true;
           let name = renderer.createItemClass({ item, indices: null, active: true });
-          expect(name).to.equal('lm-CommandPalette-item lm-mod-disabled lm-mod-toggled p-mod-active testClass');
+          expect(name).to.equal('lm-CommandPalette-item lm-mod-disabled lm-mod-toggled lm-mod-active testClass');
         });
 
       });

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -150,9 +150,9 @@ describe('@lumino/widgets', () => {
         expect(menu).to.be.an.instanceof(Menu);
       });
 
-      it('should add the `p-Menu` class', () => {
+      it('should add the `lm-Menu` class', () => {
         let menu = new Menu({ commands });
-        expect(menu.hasClass('p-Menu')).to.equal(true);
+        expect(menu.hasClass('lm-Menu')).to.equal(true);
       });
 
     });
@@ -363,7 +363,7 @@ describe('@lumino/widgets', () => {
 
       it('should get the menu content node', () => {
         let content = menu.contentNode;
-        expect(content.classList.contains('p-Menu-content')).to.equal(true);
+        expect(content.classList.contains('lm-Menu-content')).to.equal(true);
       });
 
     });
@@ -761,7 +761,7 @@ describe('@lumino/widgets', () => {
         it('should set the active index', () => {
           menu.addItem({ command: 'test' });
           menu.open(0, 0);
-          let node = menu.node.getElementsByClassName('p-Menu-item')[0];
+          let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
           let rect = node.getBoundingClientRect();
           simulate(menu.node, 'mousemove', { clientX: rect.left, clientY: rect.top });
           expect(menu.activeIndex).to.equal(0);
@@ -773,7 +773,7 @@ describe('@lumino/widgets', () => {
           submenu.title.label = 'Test Label';
           menu.addItem({ type: 'submenu', submenu });
           menu.open(0, 0);
-          let node = menu.node.getElementsByClassName('p-Menu-item')[0];
+          let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
           let rect = node.getBoundingClientRect();
           simulate(menu.node, 'mousemove', { clientX: rect.left, clientY: rect.top });
           expect(menu.activeIndex).to.equal(0);
@@ -793,7 +793,7 @@ describe('@lumino/widgets', () => {
           menu.open(0, 0);
           menu.activeIndex = 1;
           menu.triggerActiveItem();
-          let node = menu.node.getElementsByClassName('p-Menu-item')[0];
+          let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
           let rect = node.getBoundingClientRect();
           simulate(menu.node, 'mousemove', { clientX: rect.left, clientY: rect.top });
           expect(menu.activeIndex).to.equal(0);
@@ -814,7 +814,7 @@ describe('@lumino/widgets', () => {
           submenu.title.label = 'Test Label';
           menu.addItem({ type: 'submenu', submenu });
           menu.open(0, 0);
-          let node = menu.node.getElementsByClassName('p-Menu-item')[0];
+          let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
           let rect = node.getBoundingClientRect();
           simulate(menu.node, 'mousemove', { clientX: rect.left, clientY: rect.top });
           expect(menu.activeIndex).to.equal(0);
@@ -928,12 +928,12 @@ describe('@lumino/widgets', () => {
         menu.addItem({ type: 'submenu', submenu: new Menu({ commands }) });
         menu.addItem({ type: 'separator' });
         menu.open(0, 0);
-        let elements = menu.node.querySelectorAll('.p-Menu-item[data-type="separator"');
+        let elements = menu.node.querySelectorAll('.lm-Menu-item[data-type="separator"');
         expect(elements.length).to.equal(4);
-        expect(elements[0].classList.contains('p-mod-collapsed')).to.equal(true);
-        expect(elements[1].classList.contains('p-mod-collapsed')).to.equal(false);
-        expect(elements[2].classList.contains('p-mod-collapsed')).to.equal(true);
-        expect(elements[3].classList.contains('p-mod-collapsed')).to.equal(true);
+        expect(elements[0].classList.contains('lm-mod-collapsed')).to.equal(true);
+        expect(elements[1].classList.contains('lm-mod-collapsed')).to.equal(false);
+        expect(elements[2].classList.contains('lm-mod-collapsed')).to.equal(true);
+        expect(elements[3].classList.contains('lm-mod-collapsed')).to.equal(true);
       });
 
     });
@@ -1268,52 +1268,52 @@ describe('@lumino/widgets', () => {
           let item = menu.addItem({ command: 'test' });
           let vNode = renderer.renderItem({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-Menu-item')).to.equal(true);
-          expect(node.classList.contains('p-mod-hidden')).to.equal(false);
-          expect(node.classList.contains('p-mod-disabled')).to.equal(false);
-          expect(node.classList.contains('p-mod-toggled')).to.equal(false);
-          expect(node.classList.contains('p-mod-active')).to.equal(false);
-          expect(node.classList.contains('p-mod-collapsed')).to.equal(false);
+          expect(node.classList.contains('lm-Menu-item')).to.equal(true);
+          expect(node.classList.contains('lm-mod-hidden')).to.equal(false);
+          expect(node.classList.contains('lm-mod-disabled')).to.equal(false);
+          expect(node.classList.contains('lm-mod-toggled')).to.equal(false);
+          expect(node.classList.contains('lm-mod-active')).to.equal(false);
+          expect(node.classList.contains('lm-mod-collapsed')).to.equal(false);
           expect(node.getAttribute('data-command')).to.equal('test');
           expect(node.getAttribute('data-type')).to.equal('command');
-          expect(node.querySelector('.p-Menu-itemIcon')).to.not.equal(null);
-          expect(node.querySelector('.p-Menu-itemLabel')).to.not.equal(null);
-          expect(node.querySelector('.p-Menu-itemSubmenuIcon')).to.not.equal(null);
+          expect(node.querySelector('.lm-Menu-itemIcon')).to.not.equal(null);
+          expect(node.querySelector('.lm-Menu-itemLabel')).to.not.equal(null);
+          expect(node.querySelector('.lm-Menu-itemSubmenuIcon')).to.not.equal(null);
         });
 
         it('should handle the hidden item state', () => {
           let item = menu.addItem({ command: 'test-hidden' });
           let vNode = renderer.renderItem({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-mod-hidden')).to.equal(true);
+          expect(node.classList.contains('lm-mod-hidden')).to.equal(true);
         });
 
         it('should handle the disabled item state', () => {
           let item = menu.addItem({ command: 'test-disabled' });
           let vNode = renderer.renderItem({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-mod-disabled')).to.equal(true);
+          expect(node.classList.contains('lm-mod-disabled')).to.equal(true);
         });
 
         it('should handle the toggled item state', () => {
           let item = menu.addItem({ command: 'test-toggled' });
           let vNode = renderer.renderItem({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-mod-toggled')).to.equal(true);
+          expect(node.classList.contains('lm-mod-toggled')).to.equal(true);
         });
 
         it('should handle the active item state', () => {
           let item = menu.addItem({ command: 'test' });
           let vNode = renderer.renderItem({ item, active: true, collapsed: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-mod-active')).to.equal(true);
+          expect(node.classList.contains('lm-mod-active')).to.equal(true);
         });
 
         it('should handle the collapsed item state', () => {
           let item = menu.addItem({ command: 'test-collapsed' });
           let vNode = renderer.renderItem({ item, active: false, collapsed: true });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-mod-collapsed')).to.equal(true);
+          expect(node.classList.contains('lm-mod-collapsed')).to.equal(true);
         });
 
       });
@@ -1324,7 +1324,7 @@ describe('@lumino/widgets', () => {
           let item = menu.addItem({ command: 'test' });
           let vNode = renderer.renderIcon({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-Menu-itemIcon')).to.equal(true);
+          expect(node.classList.contains('lm-Menu-itemIcon')).to.equal(true);
           expect(node.classList.contains('foo')).to.equal(true);
         });
 
@@ -1336,8 +1336,8 @@ describe('@lumino/widgets', () => {
           let item = menu.addItem({ command: 'test' });
           let vNode = renderer.renderLabel({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-Menu-itemLabel')).to.equal(true);
-          expect(node.innerHTML).to.equal('<span class="p-Menu-itemMnemonic">T</span>est Label');
+          expect(node.classList.contains('lm-Menu-itemLabel')).to.equal(true);
+          expect(node.innerHTML).to.equal('<span class="lm-Menu-itemMnemonic">T</span>est Label');
         });
 
       });
@@ -1348,7 +1348,7 @@ describe('@lumino/widgets', () => {
           let item = menu.addItem({ command: 'test' });
           let vNode = renderer.renderShortcut({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-Menu-itemShortcut')).to.equal(true);
+          expect(node.classList.contains('lm-Menu-itemShortcut')).to.equal(true);
           if (Platform.IS_MAC) {
             expect(node.innerHTML).to.equal('\u2303 T');
           } else {
@@ -1364,7 +1364,7 @@ describe('@lumino/widgets', () => {
           let item = menu.addItem({ command: 'test' });
           let vNode = renderer.renderSubmenu({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('p-Menu-itemSubmenuIcon')).to.equal(true);
+          expect(node.classList.contains('lm-Menu-itemSubmenuIcon')).to.equal(true);
         });
 
       });
@@ -1375,31 +1375,31 @@ describe('@lumino/widgets', () => {
           let item = menu.addItem({ command: 'test' });
 
           let name = renderer.createItemClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('p-Menu-item testClass');
+          expect(name).to.equal('lm-Menu-item testClass');
 
           name = renderer.createItemClass({ item, active: true, collapsed: false });
-          expect(name).to.equal('p-Menu-item p-mod-active testClass');
+          expect(name).to.equal('lm-Menu-item lm-mod-active testClass');
 
           name = renderer.createItemClass({ item, active: false, collapsed: true });
-          expect(name).to.equal('p-Menu-item p-mod-collapsed testClass');
+          expect(name).to.equal('lm-Menu-item lm-mod-collapsed testClass');
 
           item = menu.addItem({ command: 'test-disabled' });
           name = renderer.createItemClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('p-Menu-item p-mod-disabled testClass');
+          expect(name).to.equal('lm-Menu-item lm-mod-disabled testClass');
 
           item = menu.addItem({ command: 'test-toggled' });
           name = renderer.createItemClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('p-Menu-item p-mod-toggled testClass');
+          expect(name).to.equal('lm-Menu-item lm-mod-toggled testClass');
 
           item = menu.addItem({ command: 'test-hidden' });
           name = renderer.createItemClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('p-Menu-item p-mod-hidden testClass');
+          expect(name).to.equal('lm-Menu-item lm-mod-hidden testClass');
 
           let submenu = new Menu({ commands });
           submenu.title.className = 'fooClass';
           item = menu.addItem({ type: 'submenu', submenu });
           name = renderer.createItemClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('p-Menu-item fooClass');
+          expect(name).to.equal('lm-Menu-item fooClass');
         });
 
       });
@@ -1428,17 +1428,17 @@ describe('@lumino/widgets', () => {
         it('should create the icon class name', () => {
           let item = menu.addItem({ command: 'test' });
           let name = renderer.createIconClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('p-Menu-itemIcon foo');
+          expect(name).to.equal('lm-Menu-itemIcon foo');
 
           item = menu.addItem({ type: 'separator' });
           name = renderer.createIconClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('p-Menu-itemIcon');
+          expect(name).to.equal('lm-Menu-itemIcon');
 
           let submenu = new Menu({ commands });
           submenu.title.icon = 'bar';
           item = menu.addItem({ type: 'submenu', submenu });
           name = renderer.createIconClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('p-Menu-itemIcon bar');
+          expect(name).to.equal('lm-Menu-itemIcon bar');
         });
 
       });
@@ -1449,7 +1449,7 @@ describe('@lumino/widgets', () => {
           let item = menu.addItem({ command: 'test' });
           let child = renderer.formatLabel({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(h.div(child));
-          expect(node.innerHTML).to.equal('<span class="p-Menu-itemMnemonic">T</span>est Label');
+          expect(node.innerHTML).to.equal('<span class="lm-Menu-itemMnemonic">T</span>est Label');
 
           item = menu.addItem({ type: 'separator' });
           child = renderer.formatLabel({ item, active: false, collapsed: false });

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -1336,8 +1336,12 @@ describe('@lumino/widgets', () => {
           let item = menu.addItem({ command: 'test' });
           let vNode = renderer.renderLabel({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(vNode);
+          let span = '<span class="lm-Menu-itemMnemonic">T</span>est Label';
+          /* <DEPRECATED> */
+          span = '<span class="lm-Menu-itemMnemonic p-Menu-itemMnemonic">T</span>est Label';
+          /* </DEPRECATED> */
           expect(node.classList.contains('lm-Menu-itemLabel')).to.equal(true);
-          expect(node.innerHTML).to.equal('<span class="lm-Menu-itemMnemonic">T</span>est Label');
+          expect(node.innerHTML).to.equal(span);
         });
 
       });
@@ -1375,31 +1379,59 @@ describe('@lumino/widgets', () => {
           let item = menu.addItem({ command: 'test' });
 
           let name = renderer.createItemClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('lm-Menu-item testClass');
+          let expected = 'lm-Menu-item testClass';
+          /* <DEPRECATED> */
+          expected = 'lm-Menu-item p-Menu-item testClass';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
 
           name = renderer.createItemClass({ item, active: true, collapsed: false });
-          expect(name).to.equal('lm-Menu-item lm-mod-active testClass');
+          expected = 'lm-Menu-item lm-mod-active testClass';
+          /* <DEPRECATED> */
+          expected = 'lm-Menu-item p-Menu-item lm-mod-active p-mod-active testClass';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
 
           name = renderer.createItemClass({ item, active: false, collapsed: true });
-          expect(name).to.equal('lm-Menu-item lm-mod-collapsed testClass');
+          expected = 'lm-Menu-item lm-mod-collapsed testClass';
+          /* <DEPRECATED> */
+          expected = 'lm-Menu-item p-Menu-item lm-mod-collapsed p-mod-collapsed testClass';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
 
           item = menu.addItem({ command: 'test-disabled' });
           name = renderer.createItemClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('lm-Menu-item lm-mod-disabled testClass');
+          expected = 'lm-Menu-item lm-mod-disabled testClass';
+          /* <DEPRECATED> */
+          expected = 'lm-Menu-item p-Menu-item lm-mod-disabled p-mod-disabled testClass';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
 
           item = menu.addItem({ command: 'test-toggled' });
           name = renderer.createItemClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('lm-Menu-item lm-mod-toggled testClass');
+          expected = 'lm-Menu-item lm-mod-toggled testClass';
+          /* <DEPRECATED> */
+          expected = 'lm-Menu-item p-Menu-item lm-mod-toggled p-mod-toggled testClass';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
 
           item = menu.addItem({ command: 'test-hidden' });
           name = renderer.createItemClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('lm-Menu-item lm-mod-hidden testClass');
+          expected = 'lm-Menu-item lm-mod-hidden testClass';
+          /* <DEPRECATED> */
+          expected = 'lm-Menu-item p-Menu-item lm-mod-hidden p-mod-hidden testClass';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
 
           let submenu = new Menu({ commands });
           submenu.title.className = 'fooClass';
           item = menu.addItem({ type: 'submenu', submenu });
           name = renderer.createItemClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('lm-Menu-item fooClass');
+          expected = 'lm-Menu-item fooClass';
+          /* <DEPRECATED> */
+          expected = 'lm-Menu-item p-Menu-item fooClass';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
         });
 
       });
@@ -1428,17 +1460,29 @@ describe('@lumino/widgets', () => {
         it('should create the icon class name', () => {
           let item = menu.addItem({ command: 'test' });
           let name = renderer.createIconClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('lm-Menu-itemIcon foo');
+          let expected = 'lm-Menu-itemIcon foo';
+          /* <DEPRECATED> */
+          expected = 'lm-Menu-itemIcon p-Menu-itemIcon foo';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
 
           item = menu.addItem({ type: 'separator' });
           name = renderer.createIconClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('lm-Menu-itemIcon');
+          expected = 'lm-Menu-itemIcon';
+          /* <DEPRECATED> */
+          expected = 'lm-Menu-itemIcon p-Menu-itemIcon';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
 
           let submenu = new Menu({ commands });
           submenu.title.icon = 'bar';
           item = menu.addItem({ type: 'submenu', submenu });
           name = renderer.createIconClass({ item, active: false, collapsed: false });
-          expect(name).to.equal('lm-Menu-itemIcon bar');
+          expected = 'lm-Menu-itemIcon bar';
+          /* <DEPRECATED> */
+          expected = 'lm-Menu-itemIcon p-Menu-itemIcon bar';
+          /* </DEPRECATED> */
+          expect(name).to.equal(expected);
         });
 
       });
@@ -1449,7 +1493,11 @@ describe('@lumino/widgets', () => {
           let item = menu.addItem({ command: 'test' });
           let child = renderer.formatLabel({ item, active: false, collapsed: false });
           let node = VirtualDOM.realize(h.div(child));
-          expect(node.innerHTML).to.equal('<span class="lm-Menu-itemMnemonic">T</span>est Label');
+          let span = '<span class="lm-Menu-itemMnemonic">T</span>est Label';
+          /* <DEPRECATED> */
+          span = '<span class="lm-Menu-itemMnemonic p-Menu-itemMnemonic">T</span>est Label';
+          /* </DEPRECATED> */
+          expect(node.innerHTML).to.equal(span);
 
           item = menu.addItem({ type: 'separator' });
           child = renderer.formatLabel({ item, active: false, collapsed: false });

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -131,9 +131,9 @@ describe('@lumino/widgets', () => {
         expect(bar).to.be.an.instanceof(MenuBar);
       });
 
-      it('should add the `p-MenuBar` class', () => {
+      it('should add the `lm-MenuBar` class', () => {
         let bar = new MenuBar();
-        expect(bar.hasClass('p-MenuBar')).to.equal(true);
+        expect(bar.hasClass('lm-MenuBar')).to.equal(true);
       });
 
     });
@@ -189,7 +189,7 @@ describe('@lumino/widgets', () => {
       it('should get the menu content node', () => {
         let bar = new MenuBar();
         let content = bar.contentNode;
-        expect(content.classList.contains('p-MenuBar-content')).to.equal(true);
+        expect(content.classList.contains('lm-MenuBar-content')).to.equal(true);
       });
 
     });
@@ -271,10 +271,10 @@ describe('@lumino/widgets', () => {
         bar.dispose();
       });
 
-      it('should add `p-mod-active` to the active node', () => {
+      it('should add `lm-mod-active` to the active node', () => {
         let bar = createMenuBar();
         let node = bar.contentNode.firstChild as HTMLElement;
-        expect(node.classList.contains('p-mod-active')).to.equal(true);
+        expect(node.classList.contains('lm-mod-active')).to.equal(true);
         expect(bar.activeIndex).to.equal(0);
         bar.dispose();
       });
@@ -591,7 +591,7 @@ describe('@lumino/widgets', () => {
         it('should close an active menu', () => {
           bar.openActiveMenu();
           let menu = bar.activeMenu!;
-          let node = bar.node.getElementsByClassName('p-MenuBar-item')[0] as HTMLElement;
+          let node = bar.node.getElementsByClassName('lm-MenuBar-item')[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           simulate(bar.node, 'mousedown', { clientX: rect.left, clientY: rect.top });
           expect(bar.activeIndex).to.equal(0);
@@ -600,7 +600,7 @@ describe('@lumino/widgets', () => {
 
         it('should open an active menu', () => {
           let menu = bar.activeMenu!;
-          let node = bar.node.getElementsByClassName('p-MenuBar-item')[0] as HTMLElement;
+          let node = bar.node.getElementsByClassName('lm-MenuBar-item')[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           simulate(bar.node, 'mousedown', { clientX: rect.left, clientY: rect.top });
           expect(bar.activeIndex).to.equal(0);
@@ -610,7 +610,7 @@ describe('@lumino/widgets', () => {
         it('should not close an active menu if not a left mouse press', () => {
           bar.openActiveMenu();
           let menu = bar.activeMenu!;
-          let node = bar.node.getElementsByClassName('p-MenuBar-item')[0] as HTMLElement;
+          let node = bar.node.getElementsByClassName('lm-MenuBar-item')[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           simulate(bar.node, 'mousedown', { button: 1, clientX: rect.left, clientY: rect.top });
           expect(bar.activeIndex).to.equal(0);
@@ -624,7 +624,7 @@ describe('@lumino/widgets', () => {
         it('should open a new menu if a menu is already open', () => {
           bar.openActiveMenu();
           let menu = bar.activeMenu!;
-          let node = bar.node.getElementsByClassName('p-MenuBar-item')[1] as HTMLElement;
+          let node = bar.node.getElementsByClassName('lm-MenuBar-item')[1] as HTMLElement;
           let rect = node.getBoundingClientRect();
           simulate(node, 'mousemove', { clientX: rect.left + 1, clientY: rect.top });
           expect(bar.activeIndex).to.equal(1);
@@ -635,7 +635,7 @@ describe('@lumino/widgets', () => {
         it('should be a no-op if the active index will not change', () => {
           bar.openActiveMenu();
           let menu = bar.activeMenu!;
-          let node = bar.node.getElementsByClassName('p-MenuBar-item')[0] as HTMLElement;
+          let node = bar.node.getElementsByClassName('lm-MenuBar-item')[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           simulate(bar.node, 'mousemove', { clientX: rect.left, clientY: rect.top + 1 });
           expect(bar.activeIndex).to.equal(0);
@@ -767,7 +767,7 @@ describe('@lumino/widgets', () => {
         expect(bar.contentNode.children.length).to.equal(0);
         MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
         let child = bar.contentNode.firstChild as HTMLElement;
-        expect(child.className).to.contain('p-MenuBar-item');
+        expect(child.className).to.contain('lm-MenuBar-item');
       });
 
     });
@@ -820,9 +820,9 @@ describe('@lumino/widgets', () => {
 
         it('should render the virtual element for a menu bar item', () => {
           let node = VirtualDOM.realize(renderer.renderItem(data));
-          expect(node.classList.contains('p-MenuBar-item')).to.equal(true);
-          expect(node.getElementsByClassName('p-MenuBar-itemIcon').length).to.equal(1);
-          expect(node.getElementsByClassName('p-MenuBar-itemLabel').length).to.equal(1);
+          expect(node.classList.contains('lm-MenuBar-item')).to.equal(true);
+          expect(node.getElementsByClassName('lm-MenuBar-itemIcon').length).to.equal(1);
+          expect(node.getElementsByClassName('lm-MenuBar-itemLabel').length).to.equal(1);
         });
 
       });
@@ -831,7 +831,7 @@ describe('@lumino/widgets', () => {
 
         it('should render the icon element for a menu bar item', () => {
           let node = VirtualDOM.realize(renderer.renderIcon(data));
-          expect(node.className).to.contain('p-MenuBar-itemIcon');
+          expect(node.className).to.contain('lm-MenuBar-itemIcon');
           expect(node.className).to.contain('bar');
         });
 
@@ -841,7 +841,7 @@ describe('@lumino/widgets', () => {
 
         it('should render the label element for a menu item', () => {
           let node = VirtualDOM.realize(renderer.renderLabel(data));
-          expect(node.className).to.contain('p-MenuBar-itemLabel');
+          expect(node.className).to.contain('lm-MenuBar-itemLabel');
           expect(node.textContent).to.equal('foo');
         });
 
@@ -852,7 +852,7 @@ describe('@lumino/widgets', () => {
         it('should create the class name for the menu bar item', () => {
           let itemClass = renderer.createItemClass(data);
           expect(itemClass).to.contain('baz');
-          expect(itemClass).to.contain('p-mod-active');
+          expect(itemClass).to.contain('lm-mod-active');
         });
 
       });
@@ -861,7 +861,7 @@ describe('@lumino/widgets', () => {
 
         it('should create the class name for the menu bar item icon', () => {
           let iconClass = renderer.createIconClass(data);
-          expect(iconClass).to.contain('p-MenuBar-itemIcon');
+          expect(iconClass).to.contain('lm-MenuBar-itemIcon');
           expect(iconClass).to.contain('bar');
         });
 
@@ -874,7 +874,7 @@ describe('@lumino/widgets', () => {
           let label = renderer.formatLabel(data);
           expect((label as any)[0]).to.equal('f');
           let node = VirtualDOM.realize(((label as any)[1]) as VirtualElement);
-          expect(node.className).to.contain('p-MenuBar-itemMnemonic');
+          expect(node.className).to.contain('lm-MenuBar-itemMnemonic');
           expect(node.textContent).to.equal('o');
           expect((label as any)[2]).to.equal('o');
         });

--- a/packages/widgets/tests/src/panel.spec.ts
+++ b/packages/widgets/tests/src/panel.spec.ts
@@ -33,9 +33,9 @@ describe('@lumino/widgets', () => {
         expect(panel.layout).to.equal(layout);
       });
 
-      it('should add the `p-Panel` class', () => {
+      it('should add the `lm-Panel` class', () => {
         let panel = new Panel();
-        expect(panel.hasClass('p-Panel')).to.equal(true);
+        expect(panel.hasClass('lm-Panel')).to.equal(true);
       });
 
     });

--- a/packages/widgets/tests/src/splitpanel.spec.ts
+++ b/packages/widgets/tests/src/splitpanel.spec.ts
@@ -82,9 +82,9 @@ describe('@lumino/widgets', () => {
         expect(panel.renderer).to.equal(renderer);
       });
 
-      it('should add the `p-SplitPanel` class', () => {
+      it('should add the `lm-SplitPanel` class', () => {
         let panel = new SplitPanel();
-        expect(panel.hasClass('p-SplitPanel')).to.equal(true);
+        expect(panel.hasClass('lm-SplitPanel')).to.equal(true);
       });
 
     });
@@ -354,7 +354,7 @@ describe('@lumino/widgets', () => {
         let panel = new SplitPanel();
         let widget = new Widget();
         panel.addWidget(widget);
-        expect(widget.hasClass('p-SplitPanel-child')).to.equal(true);
+        expect(widget.hasClass('lm-SplitPanel-child')).to.equal(true);
       });
 
     });
@@ -366,7 +366,7 @@ describe('@lumino/widgets', () => {
         let widget = new Widget();
         panel.addWidget(widget);
         widget.parent = null;
-        expect(widget.hasClass('p-SplitPanel-child')).to.equal(false);
+        expect(widget.hasClass('lm-SplitPanel-child')).to.equal(false);
       });
 
     });
@@ -384,10 +384,10 @@ describe('@lumino/widgets', () => {
           expect(node1).to.not.equal(node2);
         });
 
-        it('should add the "p-SplitPanel-handle" class', () => {
+        it('should add the "lm-SplitPanel-handle" class', () => {
           let renderer = new SplitPanel.Renderer();
           let node = renderer.createHandle();
-          expect(node.classList.contains('p-SplitPanel-handle')).to.equal(true);
+          expect(node.classList.contains('lm-SplitPanel-handle')).to.equal(true);
         });
 
       });

--- a/packages/widgets/tests/src/stackedpanel.spec.ts
+++ b/packages/widgets/tests/src/stackedpanel.spec.ts
@@ -33,9 +33,9 @@ describe('@lumino/widgets', () => {
         expect(panel.layout).to.equal(layout);
       });
 
-      it('should add the `p-StackedPanel` class', () => {
+      it('should add the `lm-StackedPanel` class', () => {
         let panel = new StackedPanel();
-        expect(panel.hasClass('p-StackedPanel')).to.equal(true);
+        expect(panel.hasClass('lm-StackedPanel')).to.equal(true);
       });
 
     });
@@ -61,7 +61,7 @@ describe('@lumino/widgets', () => {
         let panel = new StackedPanel();
         let widget = new Widget();
         panel.addWidget(widget);
-        expect(widget.hasClass('p-StackedPanel-child')).to.equal(true);
+        expect(widget.hasClass('lm-StackedPanel-child')).to.equal(true);
       });
 
     });
@@ -73,7 +73,7 @@ describe('@lumino/widgets', () => {
         let widget = new Widget();
         panel.addWidget(widget);
         widget.parent = null;
-        expect(widget.hasClass('p-StackedPanel-child')).to.equal(false);
+        expect(widget.hasClass('lm-StackedPanel-child')).to.equal(false);
       });
 
     });

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -425,12 +425,12 @@ describe('@lumino/widgets', () => {
         expect(called).to.equal(1);
       });
 
-      it('should add the `p-mod-dragging` class to the tab and the bar', () => {
+      it('should add the `lm-mod-dragging` class to the tab and the bar', () => {
         simulateOnNode(tab, 'mousedown');
         let called = false;
         bar.tabDetachRequested.connect((sender, args) => {
-          expect(tab.classList.contains('p-mod-dragging')).to.equal(true);
-          expect(bar.hasClass('p-mod-dragging')).to.equal(true);
+          expect(tab.classList.contains('lm-mod-dragging')).to.equal(true);
+          expect(bar.hasClass('lm-mod-dragging')).to.equal(true);
           called = true;
         });
         let rect = bar.contentNode.getBoundingClientRect();
@@ -1249,7 +1249,7 @@ describe('@lumino/widgets', () => {
           let label = tab.getElementsByClassName('lm-TabBar-tabLabel')[0] as HTMLElement;
           expect(label.textContent).to.equal(title.label);
           let current = i === 0;
-          expect(tab.classList.contains('p-mod-current')).to.equal(current);
+          expect(tab.classList.contains('lm-mod-current')).to.equal(current);
         });
       });
 
@@ -1293,8 +1293,8 @@ describe('@lumino/widgets', () => {
 
           expect(node.classList.contains('lm-TabBar-tab')).to.equal(true);
           expect(node.classList.contains(title.className)).to.equal(true);
-          expect(node.classList.contains('p-mod-current')).to.equal(true);
-          expect(node.classList.contains('p-mod-closable')).to.equal(true);
+          expect(node.classList.contains('lm-mod-current')).to.equal(true);
+          expect(node.classList.contains('lm-mod-closable')).to.equal(true);
           expect(node.title).to.equal(title.caption);
 
           let icon = node.getElementsByClassName('lm-TabBar-tabIcon')[0] as HTMLElement;
@@ -1369,8 +1369,8 @@ describe('@lumino/widgets', () => {
             title, current: true, zIndex: 1
           });
           expect(className).to.contain('lm-TabBar-tab');
-          expect(className).to.contain('p-mod-closable');
-          expect(className).to.contain('p-mod-current');
+          expect(className).to.contain('lm-mod-closable');
+          expect(className).to.contain('lm-mod-current');
         });
 
       });

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1273,9 +1273,9 @@ describe('@lumino/widgets', () => {
 
       describe('#closeIconSelector', () => {
 
-        it('should be `.p-TabBar-tabCloseIcon`', () => {
+        it('should be `.lm-TabBar-tabCloseIcon`', () => {
           let renderer = new TabBar.Renderer();
-          expect(renderer.closeIconSelector).to.equal('.p-TabBar-tabCloseIcon');
+          expect(renderer.closeIconSelector).to.equal('.lm-TabBar-tabCloseIcon');
         });
 
       });

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -156,9 +156,9 @@ describe('@lumino/widgets', () => {
         expect(newBar.renderer).to.equal(renderer);
       });
 
-      it('should add the `p-TabBar` class', () => {
+      it('should add the `lm-TabBar` class', () => {
         let newBar = new TabBar<Widget>();
-        expect(newBar.hasClass('p-TabBar')).to.equal(true);
+        expect(newBar.hasClass('lm-TabBar')).to.equal(true);
       });
 
     });
@@ -267,7 +267,7 @@ describe('@lumino/widgets', () => {
       beforeEach(() => {
         populateBar(bar);
         bar.tabsMovable = false;
-        tab = bar.contentNode.getElementsByClassName('p-TabBar-tab')[2] as HTMLElement;
+        tab = bar.contentNode.getElementsByClassName('lm-TabBar-tab')[2] as HTMLElement;
       });
 
       it('should be emitted when a tab is left pressed by the user', () => {
@@ -486,7 +486,7 @@ describe('@lumino/widgets', () => {
         bar.currentIndex = 2;
         // Force the tabs to render
         MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
-        let tab = bar.contentNode.getElementsByClassName('p-TabBar-tab')[2] as HTMLElement;
+        let tab = bar.contentNode.getElementsByClassName('lm-TabBar-tab')[2] as HTMLElement;
         simulateOnNode(tab, 'mousedown');
         expect(bar.currentIndex).to.equal(2);
         simulateOnNode(tab, 'mouseup');
@@ -724,7 +724,7 @@ describe('@lumino/widgets', () => {
     describe('#contentNode', () => {
 
       it('should get the tab bar content node', () => {
-        expect(bar.contentNode.classList.contains('p-TabBar-content')).to.equal(true);
+        expect(bar.contentNode.classList.contains('lm-TabBar-content')).to.equal(true);
       });
 
     });
@@ -1246,7 +1246,7 @@ describe('@lumino/widgets', () => {
         expect(bar.methods.indexOf('onUpdateRequest')).to.not.equal(-1);
         each(bar.titles, (title, i) => {
           let tab = bar.contentNode.children[i] as HTMLElement;
-          let label = tab.getElementsByClassName('p-TabBar-tabLabel')[0] as HTMLElement;
+          let label = tab.getElementsByClassName('lm-TabBar-tabLabel')[0] as HTMLElement;
           expect(label.textContent).to.equal(title.label);
           let current = i === 0;
           expect(tab.classList.contains('p-mod-current')).to.equal(current);
@@ -1287,18 +1287,18 @@ describe('@lumino/widgets', () => {
           let vNode = renderer.renderTab({ title, current: true, zIndex: 1 });
           let node = VirtualDOM.realize(vNode);
 
-          expect(node.getElementsByClassName('p-TabBar-tabIcon').length).to.equal(1);
-          expect(node.getElementsByClassName('p-TabBar-tabLabel').length).to.equal(1);
-          expect(node.getElementsByClassName('p-TabBar-tabCloseIcon').length).to.equal(1);
+          expect(node.getElementsByClassName('lm-TabBar-tabIcon').length).to.equal(1);
+          expect(node.getElementsByClassName('lm-TabBar-tabLabel').length).to.equal(1);
+          expect(node.getElementsByClassName('lm-TabBar-tabCloseIcon').length).to.equal(1);
 
-          expect(node.classList.contains('p-TabBar-tab')).to.equal(true);
+          expect(node.classList.contains('lm-TabBar-tab')).to.equal(true);
           expect(node.classList.contains(title.className)).to.equal(true);
           expect(node.classList.contains('p-mod-current')).to.equal(true);
           expect(node.classList.contains('p-mod-closable')).to.equal(true);
           expect(node.title).to.equal(title.caption);
 
-          let icon = node.getElementsByClassName('p-TabBar-tabIcon')[0] as HTMLElement;
-          let label = node.getElementsByClassName('p-TabBar-tabLabel')[0] as HTMLElement;
+          let icon = node.getElementsByClassName('lm-TabBar-tabIcon')[0] as HTMLElement;
+          let label = node.getElementsByClassName('lm-TabBar-tabLabel')[0] as HTMLElement;
           expect(icon.classList.contains(title.icon)).to.equal(true);
           expect(label.textContent).to.equal(title.label);
         });
@@ -1311,7 +1311,7 @@ describe('@lumino/widgets', () => {
           let renderer = new TabBar.Renderer();
           let vNode = renderer.renderIcon({ title, current: true, zIndex: 1 });
           let node = VirtualDOM.realize(vNode as VirtualElement);
-          expect(node.className).to.contain('p-TabBar-tabIcon');
+          expect(node.className).to.contain('lm-TabBar-tabIcon');
           expect(node.classList.contains(title.icon)).to.equal(true);
         });
 
@@ -1323,7 +1323,7 @@ describe('@lumino/widgets', () => {
           let renderer = new TabBar.Renderer();
           let vNode = renderer.renderLabel({ title, current: true, zIndex: 1 });
           let label = VirtualDOM.realize(vNode);
-          expect(label.className).to.contain('p-TabBar-tabLabel');
+          expect(label.className).to.contain('lm-TabBar-tabLabel');
           expect(label.textContent).to.equal(title.label);
         });
 
@@ -1335,7 +1335,7 @@ describe('@lumino/widgets', () => {
           let renderer = new TabBar.Renderer();
           let vNode = renderer.renderCloseIcon({ title, current: true, zIndex: 1 });
           let icon = VirtualDOM.realize(vNode);
-          expect(icon.className).to.contain('p-TabBar-tabCloseIcon');
+          expect(icon.className).to.contain('lm-TabBar-tabCloseIcon');
         });
 
       });
@@ -1368,7 +1368,7 @@ describe('@lumino/widgets', () => {
           let className = renderer.createTabClass({
             title, current: true, zIndex: 1
           });
-          expect(className).to.contain('p-TabBar-tab');
+          expect(className).to.contain('lm-TabBar-tab');
           expect(className).to.contain('p-mod-closable');
           expect(className).to.contain('p-mod-current');
         });
@@ -1382,7 +1382,7 @@ describe('@lumino/widgets', () => {
           let className = renderer.createIconClass({
             title, current: true, zIndex: 1
           });
-          expect(className).to.contain('p-TabBar-tabIcon');
+          expect(className).to.contain('lm-TabBar-tabIcon');
           expect(className).to.contain(title.icon);
         });
 

--- a/packages/widgets/tests/src/tabpanel.spec.ts
+++ b/packages/widgets/tests/src/tabpanel.spec.ts
@@ -46,9 +46,9 @@ describe('@lumino/widgets', () => {
         expect(panel.tabBar.renderer).to.equal(renderer);
       });
 
-      it('should add a `p-TabPanel` class', () => {
+      it('should add a `lm-TabPanel` class', () => {
         let panel = new TabPanel();
-        expect(panel.hasClass('p-TabPanel')).to.equal(true);
+        expect(panel.hasClass('lm-TabPanel')).to.equal(true);
       });
 
     });
@@ -227,10 +227,10 @@ describe('@lumino/widgets', () => {
         expect(bar).to.be.an.instanceof(TabBar);
       });
 
-      it('should have the "p-TabPanel-tabBar" class', () => {
+      it('should have the "lm-TabPanel-tabBar" class', () => {
         let panel = new TabPanel();
         let bar = panel.tabBar;
-        expect(bar.hasClass('p-TabPanel-tabBar')).to.equal(true);
+        expect(bar.hasClass('lm-TabPanel-tabBar')).to.equal(true);
       });
 
       it('should move the widget in the stacked panel when a tab is moved', () => {
@@ -294,10 +294,10 @@ describe('@lumino/widgets', () => {
         expect(stack).to.be.an.instanceof(StackedPanel);
       });
 
-      it('should have the "p-TabPanel-stackedPanel" class', () => {
+      it('should have the "lm-TabPanel-stackedPanel" class', () => {
         let panel = new TabPanel();
         let stack = panel.stackedPanel;
-        expect(stack.hasClass('p-TabPanel-stackedPanel')).to.equal(true);
+        expect(stack.hasClass('lm-TabPanel-stackedPanel')).to.equal(true);
       });
 
       it('remove a tab when a widget is removed from the stacked panel', () => {

--- a/packages/widgets/tests/src/widget.spec.ts
+++ b/packages/widgets/tests/src/widget.spec.ts
@@ -135,9 +135,9 @@ describe('@lumino/widgets', () => {
         expect(widget.node).to.equal(span);
       });
 
-      it('should add the `p-Widget` class', () => {
+      it('should add the `lm-Widget` class', () => {
         let widget = new Widget();
-        expect(widget.hasClass('p-Widget')).to.equal(true);
+        expect(widget.hasClass('lm-Widget')).to.equal(true);
       });
 
     });
@@ -657,12 +657,12 @@ describe('@lumino/widgets', () => {
         expect(widget.isHidden).to.equal(false);
       });
 
-      it('should remove the "p-mod-hidden" class', () => {
+      it('should remove the "lm-mod-hidden" class', () => {
         let widget = new Widget();
         widget.hide();
-        expect(widget.hasClass('p-mod-hidden')).to.equal(true);
+        expect(widget.hasClass('lm-mod-hidden')).to.equal(true);
         widget.show();
-        expect(widget.hasClass('p-mod-hidden')).to.equal(false);
+        expect(widget.hasClass('lm-mod-hidden')).to.equal(false);
       });
 
       it('should send an `after-show` message if applicable', () => {
@@ -701,10 +701,10 @@ describe('@lumino/widgets', () => {
         expect(widget.isHidden).to.equal(true);
       });
 
-      it('should add the `p-mod-hidden` class', () => {
+      it('should add the `lm-mod-hidden` class', () => {
         let widget = new Widget();
         widget.hide();
-        expect(widget.hasClass('p-mod-hidden')).to.equal(true);
+        expect(widget.hasClass('lm-mod-hidden')).to.equal(true);
       });
 
       it('should send a `before-hide` message if applicable', () => {


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/lumino/issues/9

All of the legacy `p-*` CSS selectors should be renamed to `lm-*` and the `p-*` classes should continue to work but be deprecated until the next major release.