### PR TITLE
Enable / disable runtime tab dragging in DockPanel

### DIFF
--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -68,13 +68,16 @@ class DockPanel extends Widget {
     this._mode = options.mode || 'multiple-document';
     this._renderer = options.renderer || DockPanel.defaultRenderer;
     this._edges = options.edges || Private.DEFAULT_EDGES;
+    if (options.tabsMovable !== undefined) {
+      this._tabsMovable = options.tabsMovable;
+    }
 
     // Toggle the CSS mode attribute.
     this.dataset['mode'] = this._mode;
 
     // Create the delegate renderer for the layout.
     let renderer: DockPanel.IRenderer = {
-      createTabBar: () => this._createTabBar(),
+      createTabBar: () => this._createTabBar(this._tabsMovable),
       createHandle: () => this._createHandle()
     };
 
@@ -190,6 +193,21 @@ class DockPanel extends Widget {
 
     // Schedule an emit of the layout modified signal.
     MessageLoop.postMessage(this, Private.LayoutModified);
+  }
+
+  /**
+   * Whether the tabs can be dragged / moved at runtime.
+   */
+  get tabsMovable(): boolean {
+    return this._tabsMovable;
+  }
+
+  /**
+   * Enable / Disable draggable / movable tabs.
+   */
+  set tabsMovable(value: boolean) {
+    this._tabsMovable = value;
+    each(this.tabBars(), (tabbar) => tabbar.tabsMovable = value);
   }
 
   /**
@@ -831,7 +849,7 @@ class DockPanel extends Widget {
   /**
    * Create a new tab bar for use by the panel.
    */
-  private _createTabBar(): TabBar<Widget> {
+  private _createTabBar(tabsMovable: boolean): TabBar<Widget> {
     // Create the tab bar.
     let tabBar = this._renderer.createTabBar();
 
@@ -845,7 +863,7 @@ class DockPanel extends Widget {
 
     // Enforce necessary tab bar behavior.
     // TODO do we really want to enforce *all* of these?
-    tabBar.tabsMovable = true;
+    tabBar.tabsMovable = tabsMovable;
     tabBar.allowDeselect = false;
     tabBar.removeBehavior = 'select-previous-tab';
     tabBar.insertBehavior = 'select-tab-if-needed';
@@ -962,6 +980,7 @@ class DockPanel extends Widget {
   private _mode: DockPanel.Mode;
   private _drag: Drag | null = null;
   private _renderer: DockPanel.IRenderer;
+  private _tabsMovable: boolean = true;
   private _pressData: Private.IPressData | null = null;
   private _layoutModified = new Signal<this, void>(this);
 }
@@ -1010,6 +1029,13 @@ namespace DockPanel {
      * If not given, default values will be used.
      */
     edges?: IEdges;
+
+    /**
+     * Allow tabs to be draggable / movable by user.
+     *
+     * The default is `'true'`.
+     */
+    tabsMovable?: boolean;
   }
 
   /**


### PR DESCRIPTION
Allow user to enable / disable tab dragging at runtime.

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>