### PR TITLE
Adds a "pass thru" virtual element

### DIFF
--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -36,6 +36,9 @@
     "docs": "typedoc --options tdoptions.json src",
     "test": "npm run test:firefox",
     "test:chrome": "cd tests && karma start --browsers=Chrome",
+    "test:chrome-headless": "cd tests && karma start --browsers=ChromeHeadless",
+    "test:debug": "cd tests && karma start --browsers=Chrome --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
+    "test:debug:chrome-headless": "cd tests && karma start  --browsers=ChromeHeadless --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
     "test:firefox": "cd tests && karma start --browsers=Firefox",
     "test:ie": "cd tests && karma start --browsers=IE",
     "watch": "tsc --build --watch"

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -1019,14 +1019,12 @@ namespace Private {
   /**
    * A weak mapping of host element to virtual DOM content.
    */
-  export
-  const hostMap = new WeakMap<HTMLElement, ReadonlyArray<VirtualNode>>();
+  export const hostMap = new WeakMap<HTMLElement, ReadonlyArray<VirtualNode>>();
 
   /**
    * Cast a content value to a content array.
    */
-  export
-  function asContentArray(value: VirtualNode | ReadonlyArray<VirtualNode> | null): ReadonlyArray<VirtualNode> {
+  export function asContentArray(value: VirtualNode | ReadonlyArray<VirtualNode> | null): ReadonlyArray<VirtualNode> {
     if (!value) {
       return [];
     }
@@ -1039,20 +1037,13 @@ namespace Private {
   /**
    * Create a new DOM element for a virtual node.
    */
-  export
-  function createDOMNode(node: VirtualText): Text;
-  export
-  function createDOMNode(node: VirtualElement): HTMLElement;
-  export
-  function createDOMNode(node: VirtualElementPass): HTMLElement;
-  export
-  function createDOMNode(node: VirtualNode): HTMLElement | Text;
-  export
-  function createDOMNode(node: VirtualNode, host: HTMLElement | null): HTMLElement | Text;
-  export
-  function createDOMNode(node: VirtualNode, host: HTMLElement | null, before: Node | null): HTMLElement | Text;
-  export
-  function createDOMNode(node: VirtualNode): HTMLElement | Text {
+  export function createDOMNode(node: VirtualText): Text;
+  export function createDOMNode(node: VirtualElement): HTMLElement;
+  export function createDOMNode(node: VirtualElementPass): HTMLElement;
+  export function createDOMNode(node: VirtualNode): HTMLElement | Text;
+  export function createDOMNode(node: VirtualNode, host: HTMLElement | null): HTMLElement | Text;
+  export function createDOMNode(node: VirtualNode, host: HTMLElement | null, before: Node | null): HTMLElement | Text;
+  export function createDOMNode(node: VirtualNode): HTMLElement | Text {
     let host = arguments[1] || null;
     const before = arguments[2] || null;
 
@@ -1090,8 +1081,7 @@ namespace Private {
    * This is the core "diff" algorithm. There is no explicit "patch"
    * phase. The host is patched at each step as the diff progresses.
    */
-  export
-  function updateContent(host: HTMLElement, oldContent: ReadonlyArray<VirtualNode>, newContent: ReadonlyArray<VirtualNode>): void {
+  export function updateContent(host: HTMLElement, oldContent: ReadonlyArray<VirtualNode>, newContent: ReadonlyArray<VirtualNode>): void {
     // Bail early if the content is identical.
     if (oldContent === newContent) {
       return;
@@ -1204,23 +1194,25 @@ namespace Private {
     }
 
     // Cleanup stale DOM
-    removeContent(host, oldCopy, newCount);
+    removeContent(host, oldCopy, newCount, true);
   }
 
-  function removeContent(host: HTMLElement, oldContent: ReadonlyArray<VirtualNode>, newCount: number) {
+  function removeContent(host: HTMLElement, oldContent: ReadonlyArray<VirtualNode>, newCount: number, _sentinel = false) {
     // Dispose of the old nodes pushed to the end of the host.
     for (let i = oldContent.length - 1; i >= newCount; --i) {
       const oldNode = oldContent[i];
+      const child = (_sentinel ? host.lastChild : host.childNodes[i]) as HTMLElement;
 
       // recursively clean up host children
       if (oldNode.type === 'text') {} else if (oldNode.type === 'passthru') {
-        oldNode.renderer.unrender!(host.lastChild as HTMLElement);
+        oldNode.renderer.unrender!(child!);
       } else {
-        removeContent((host.lastChild as HTMLElement)!, oldNode.children, 0);
+        removeContent(child!, oldNode.children, 0);
       }
 
-
-      host.removeChild(host.lastChild!);
+      if (_sentinel) {
+        host.removeChild(child!);
+      }
     }
   }
 

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -1064,12 +1064,24 @@ namespace Private {
   export
   function createDOMNode(node: VirtualNode): HTMLElement | Text;
   export
-  function createDOMNode(node: VirtualNode, host: HTMLElement): HTMLElement | Text;
+  function createDOMNode(node: VirtualNode, host: HTMLElement | null): HTMLElement | Text;
   export
-  function createDOMNode(node: VirtualNode, host: HTMLElement, before: Node | null): HTMLElement | Text;
+  function createDOMNode(node: VirtualNode, host: HTMLElement | null, before: Node | null): HTMLElement | Text;
   export
   function createDOMNode(node: VirtualNode): HTMLElement | Text {
-    if (arguments.length === 1) {
+    const host = arguments[1] || null;
+    const before = arguments[2] || null;
+
+    if (host) {
+      if (node.type === 'passthru') {
+        // TODO: figure out how to do an "insert before" with a passthru node
+        node.render(host);
+      } else {
+        host.insertBefore(createDOMNode(node), before);
+      }
+
+      return host;
+    } else {
       // Create a text node for a virtual text node.
       if (node.type === 'text') {
         return document.createTextNode(node.content);
@@ -1085,39 +1097,11 @@ namespace Private {
 
       // Recursively populate the element with child content.
       for (let i = 0, n = node.children.length; i < n; ++i) {
-        const child = node.children[i];
-
-        if (child.type === 'passthru') {
-          child.render(element);
-        } else {
-          element.appendChild(createDOMNode(child));
-        }
+        createDOMNode(node.children[i], element);
       }
 
       // Return the populated element.
       return element;
-    } else if (arguments.length === 2) {
-      const host = arguments[1];
-
-      if (node.type === 'passthru') {
-        node.render(host);
-      } else {
-        host.appendChild(createDOMNode(node));
-      }
-
-      return host;
-    } else {
-      const host = arguments[1];
-      const before = arguments[2];
-
-      if (node.type === 'passthru') {
-        // TODO: figure out how to do an "insert before" with a passthru node
-        node.render(host);
-      } else {
-        host.insertBefore(createDOMNode(node), before);
-      }
-
-      return host;
     }
   }
 

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -765,11 +765,11 @@ class VirtualElementPass{
    *
    * @param render - a function that takes a host HTMLElement and returns void
    */
-  constructor(readonly render: VirtualElementPass.IRender, readonly tag: string, readonly attrs: ElementAttrs) {}
+  constructor(readonly renderer: VirtualElementPass.IRenderer, readonly tag: string, readonly attrs: ElementAttrs) {}
 }
 
 export namespace VirtualElementPass {
-  export type IRender = (host: HTMLElement) => void;
+  export type IRenderer = {render: (host: HTMLElement) => void, unrender: (host: HTMLElement) => void};
 }
 
 /**
@@ -959,7 +959,7 @@ namespace h {
   export const wbr: IFactory = h.bind(undefined, 'wbr');
 }
 
-export function hpass(render: VirtualElementPass.IRender, tag: string, attrs: ElementAttrs = {}): VirtualElementPass {
+export function hpass(render: VirtualElementPass.IRenderer, tag: string, attrs: ElementAttrs = {}): VirtualElementPass {
   return new VirtualElementPass(render, tag, attrs);
 }
 
@@ -1071,7 +1071,7 @@ namespace Private {
       addAttrs(host, node.attrs);
 
       if (node.type === 'passthru') {
-        node.render(host);
+        node.renderer.render(host);
         return host;
       }
 
@@ -1137,7 +1137,7 @@ namespace Private {
 
       // Handle the case of passthru update.
       if (oldVNode.type === 'passthru' && newVNode.type === 'passthru') {
-        newVNode.render(currElem as HTMLElement);
+        newVNode.renderer.render(currElem as HTMLElement);
         currElem = currElem!.nextSibling;
         continue;
       }
@@ -1203,8 +1203,23 @@ namespace Private {
       currElem = currElem!.nextSibling;
     }
 
+    // Cleanup stale DOM
+    removeContent(host, oldCopy, newCount);
+  }
+
+  function removeContent(host: HTMLElement, oldContent: ReadonlyArray<VirtualNode>, newCount: number) {
     // Dispose of the old nodes pushed to the end of the host.
-    for (let i = oldCopy.length - newCount; i > 0; --i) {
+    for (let i = oldContent.length - 1; i >= newCount; --i) {
+      const oldNode = oldContent[i];
+
+      // recursively clean up host children
+      if (oldNode.type === 'text') {} else if (oldNode.type === 'passthru') {
+        oldNode.renderer.unrender!(host.lastChild as HTMLElement);
+      } else {
+        removeContent((host.lastChild as HTMLElement)!, oldNode.children, 0);
+      }
+
+
       host.removeChild(host.lastChild!);
     }
   }

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -749,6 +749,17 @@ class VirtualElement {
   }
 }
 
+
+/**
+ * A "pass thru" virtual node whose children are managed by a render and an
+ * unrender callback. The intent of this flavor of virtual node is to make
+ * it easy to blend other kinds of virtualdom (eg React) into Phosphor's
+ * virtualdom.
+ *
+ * #### Notes
+ * User code will not typically create a `VirtualElementPass` node directly.
+ * Instead, the `hpass()` function will be used to create an element tree.
+ */
 export
 class VirtualElementPass{
 
@@ -763,14 +774,28 @@ class VirtualElementPass{
   /**
    * Construct a new virtual element pass thru node.
    *
-   * @param render - a function that takes a host HTMLElement and returns void
+   * @param renderer - an object with render and unrender functions,
+   * each of which should take a single argument of type HTMLElement
+   * and return nothing
+   *
+   * @param tag - the tag of the parent element of this node. Once the parent
+   * element is rendered, it will be passed as an argument to
+   * renderer.render
+   *
+   * @param attrs - optional attributes that will assigned to the
+   * parent element
    */
   constructor(readonly renderer: VirtualElementPass.IRenderer, readonly tag: string, readonly attrs: ElementAttrs) {}
 }
 
+
+/**
+ * The namespace for the VirtualElementPass class statics.
+ */
 export namespace VirtualElementPass {
   export type IRenderer = {render: (host: HTMLElement) => void, unrender: (host: HTMLElement) => void};
 }
+
 
 /**
  * A type alias for a general virtual node.
@@ -959,9 +984,23 @@ namespace h {
   export const wbr: IFactory = h.bind(undefined, 'wbr');
 }
 
-export function hpass(render: VirtualElementPass.IRenderer, tag: string, attrs: ElementAttrs = {}): VirtualElementPass {
-  return new VirtualElementPass(render, tag, attrs);
+
+/**
+ * Create a new "pass thru" virtual element node.
+ *
+ * @param renderer - an object with render and unrender functions.
+ *
+ * @param tag - The tag name for the parent element.
+ *
+ * @param attrs - The attributes for the parent element, if any.
+ *
+ * @returns A new "pass thru" virtual element node for the given parameters.
+ *
+ */
+export function hpass(renderer: VirtualElementPass.IRenderer, tag: string, attrs: ElementAttrs = {}): VirtualElementPass {
+  return new VirtualElementPass(renderer, tag, attrs);
 }
+
 
 /**
  * The namespace for the virtual DOM rendering functions.
@@ -1199,6 +1238,12 @@ namespace Private {
     removeContent(host, oldCopy, newCount, true);
   }
 
+  /**
+   * Handle cleanup of stale vdom and its associated DOM. Stale nodes are
+   * traversed recursively and any needed explicit cleanup is carried out (
+   * in particular, the unrender callback of VirtualElementPass nodes). The
+   * stale children of the top level node are removed using removeChild.
+   */
   function removeContent(host: HTMLElement, oldContent: ReadonlyArray<VirtualNode>, newCount: number, _sentinel = false) {
     // Dispose of the old nodes pushed to the end of the host.
     for (let i = oldContent.length - 1; i >= newCount; --i) {

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -1064,34 +1064,61 @@ namespace Private {
   export
   function createDOMNode(node: VirtualNode): HTMLElement | Text;
   export
+  function createDOMNode(node: VirtualNode, host: HTMLElement): HTMLElement | Text;
+  export
+  function createDOMNode(node: VirtualNode, host: HTMLElement, before: Node | null): HTMLElement | Text;
+  export
   function createDOMNode(node: VirtualNode): HTMLElement | Text {
-    // Create a text node for a virtual text node.
-    if (node.type === 'text') {
-      return document.createTextNode(node.content);
-    } else if (node.type === 'passthru') {
-      console.error("createDOMNode should not be called on vdom nodes of type === 'passthru'");
-      return node.realize();
-    }
-
-    // Create the HTML element with the specified tag.
-    let element = document.createElement(node.tag);
-
-    // Add the attributes for the new element.
-    addAttrs(element, node.attrs);
-
-    // Recursively populate the element with child content.
-    for (let i = 0, n = node.children.length; i < n; ++i) {
-      const child = node.children[i];
-
-      if (child.type === 'passthru') {
-        child.render(element);
-      } else {
-        element.appendChild(createDOMNode(child));
+    if (arguments.length === 1) {
+      // Create a text node for a virtual text node.
+      if (node.type === 'text') {
+        return document.createTextNode(node.content);
+      } else if (node.type === 'passthru') {
+        throw new Error("createDOMNode should not be called with only one argument on vdom nodes of type === 'passthru'");
       }
-    }
 
-    // Return the populated element.
-    return element;
+      // Create the HTML element with the specified tag.
+      let element = document.createElement(node.tag);
+
+      // Add the attributes for the new element.
+      addAttrs(element, node.attrs);
+
+      // Recursively populate the element with child content.
+      for (let i = 0, n = node.children.length; i < n; ++i) {
+        const child = node.children[i];
+
+        if (child.type === 'passthru') {
+          child.render(element);
+        } else {
+          element.appendChild(createDOMNode(child));
+        }
+      }
+
+      // Return the populated element.
+      return element;
+    } else if (arguments.length === 2) {
+      const host = arguments[1];
+
+      if (node.type === 'passthru') {
+        node.render(host);
+      } else {
+        host.appendChild(createDOMNode(node));
+      }
+
+      return host;
+    } else {
+      const host = arguments[1];
+      const before = arguments[2];
+
+      if (node.type === 'passthru') {
+        // TODO: figure out how to do an "insert before" with a passthru node
+        node.render(host);
+      } else {
+        host.insertBefore(createDOMNode(node), before);
+      }
+
+      return host;
+    }
   }
 
   /**
@@ -1121,21 +1148,16 @@ namespace Private {
     let currElem = host.firstChild;
     let newCount = newContent.length;
     for (let i = 0; i < newCount; ++i) {
-      // Lookup the new virtual node.
-      let newVNode = newContent[i];
 
       // If the old content is exhausted, create a new node.
       if (i >= oldCopy.length) {
-        if (newVNode.type === 'passthru') {
-          newVNode.render(host);
-        } else {
-          host.appendChild(createDOMNode(newVNode));
-        }
+        createDOMNode(newContent[i], host);
         continue;
       }
 
-      // Lookup the old virtual node.
+      // Lookup the old and new virtual nodes.
       let oldVNode = oldCopy[i];
+      let newVNode = newContent[i];
 
       // If both elements are identical, there is nothing to do.
       if (oldVNode === newVNode) {
@@ -1162,15 +1184,11 @@ namespace Private {
       if (oldVNode.type === 'text' || newVNode.type === 'text' ||
         oldVNode.type === 'passthru' || newVNode.type === 'passthru') {
         ArrayExt.insert(oldCopy, i, newVNode);
-        if (newVNode.type === 'passthru') {
-          newVNode.render(host);
-        } else {
-          host.insertBefore(createDOMNode(newVNode), currElem);
-        }
+        createDOMNode(newVNode, host, currElem);
         continue;
       }
 
-      // At this point, both nodes are known to be of type element.
+      // At this point, both nodes are known to be element nodes.
 
       // If the new elem is keyed, move an old keyed elem to the proper
       // location before proceeding with the diff. The search can start
@@ -1199,14 +1217,14 @@ namespace Private {
       let oldKey = oldVNode.attrs.key;
       if (oldKey && oldKey !== newKey) {
         ArrayExt.insert(oldCopy, i, newVNode);
-        host.insertBefore(createDOMNode(newVNode), currElem);
+        createDOMNode(newVNode, host, currElem);
         continue;
       }
 
       // If the tags are different, create a new node.
       if (oldVNode.tag !== newVNode.tag) {
         ArrayExt.insert(oldCopy, i, newVNode);
-        host.insertBefore(createDOMNode(newVNode), currElem);
+        createDOMNode(newVNode, host, currElem);
         continue;
       }
 

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -749,12 +749,33 @@ class VirtualElement {
   }
 }
 
+export
+class VirtualElementPass {
+  /**
+   * The type of the node.
+   *
+   * This value can be used as a type guard for discriminating the
+   * `VirtualNode` union type.
+   */
+  readonly type: 'passthru' = 'passthru';
+
+  /**
+   * Construct a new virtual element pass thru node.
+   *
+   * @param callback - a function that takes a host HTMLElement and returns void
+   */
+  constructor(readonly callback: VirtualElementPass.ICallBack) {}
+}
+
+namespace VirtualElementPass {
+  export type ICallBack = (host: HTMLElement) => void;
+}
 
 /**
  * A type alias for a general virtual node.
  */
 export
-type VirtualNode = VirtualElement | VirtualText;
+type VirtualNode = VirtualElement | VirtualElementPass | VirtualText;
 
 
 /**
@@ -933,6 +954,9 @@ namespace h {
   export const wbr: IFactory = h.bind(undefined, 'wbr');
 }
 
+export function hpass(callback: (host: HTMLElement) => void): VirtualElementPass {
+  return new VirtualElementPass(callback);
+}
 
 /**
  * The namespace for the virtual DOM rendering functions.
@@ -1065,6 +1089,14 @@ namespace Private {
     let currElem = host.firstChild;
     let newCount = newContent.length;
     for (let i = 0; i < newCount; ++i) {
+      // Lookup the new virtual node.
+      let newVNode = newContent[i];
+
+      // If the new content is a pass thru, let it handle diffing
+      if (newVNode.type === 'passthru') {
+        newVNode.callback(host);
+        continue;
+      }
 
       // If the old content is exhausted, create a new node.
       if (i >= oldCopy.length) {
@@ -1072,9 +1104,8 @@ namespace Private {
         continue;
       }
 
-      // Lookup the old and new virtual nodes.
+      // Lookup the old virtual node.
       let oldVNode = oldCopy[i];
-      let newVNode = newContent[i];
 
       // If both elements are identical, there is nothing to do.
       if (oldVNode === newVNode) {

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -750,10 +750,7 @@ class VirtualElement {
 }
 
 export
-class VirtualElementPass {
-  readonly realize: VirtualElementPass.IRealize;
-
-  readonly render: VirtualElementPass.IRender;
+class VirtualElementPass{
 
   /**
    * The type of the node.
@@ -766,26 +763,13 @@ class VirtualElementPass {
   /**
    * Construct a new virtual element pass thru node.
    *
-   * @param realize - a function that takes no arguments and returns an HTMLElement
-   *
    * @param render - a function that takes a host HTMLElement and returns void
    */
-  constructor({realize, render}: VirtualElementPass.IProps) {
-    this.render = render;
-    this.realize = realize || (() => {const host = document.createElement('div'); this.render(host); return host});
-  }
+  constructor(readonly render: VirtualElementPass.IRender, readonly tag: string, readonly attrs: ElementAttrs) {}
 }
 
 export namespace VirtualElementPass {
-  export type IRealize = () => HTMLElement;
-
   export type IRender = (host: HTMLElement) => void;
-
-  export interface IProps {
-    realize?: IRealize;
-
-    render: IRender;
-  }
 }
 
 /**
@@ -975,8 +959,8 @@ namespace h {
   export const wbr: IFactory = h.bind(undefined, 'wbr');
 }
 
-export function hpass(props: VirtualElementPass.IProps): VirtualElementPass {
-  return new VirtualElementPass(props);
+export function hpass(render: VirtualElementPass.IRender, tag: string, attrs: ElementAttrs = {}): VirtualElementPass {
+  return new VirtualElementPass(render, tag, attrs);
 }
 
 /**
@@ -1072,32 +1056,28 @@ namespace Private {
     let host = arguments[1] || null;
     const before = arguments[2] || null;
 
-    if (node.type === 'passthru') {
-      if (host) {
-        // TODO: figure out how to do an "insert before" with a passthru node
-        node.render(host);
-      } else {
-        throw new Error("createDOMNode should not be called with only one argument on vdom nodes of type === 'passthru'");
-      }
+    if (host) {
+      host.insertBefore(createDOMNode(node), before);
     } else {
-      if (host) {
-        host.insertBefore(createDOMNode(node), before);
-      } else {
-        // Create a text node for a virtual text node.
-        if (node.type === 'text') {
-          return document.createTextNode(node.content);
-        }
+      // Create a text node for a virtual text node.
+      if (node.type === 'text') {
+        return document.createTextNode(node.content);
+      }
 
-        // Create the HTML element with the specified tag.
-        host = document.createElement(node.tag);
+      // Create the HTML element with the specified tag.
+      host = document.createElement(node.tag);
 
-        // Add the attributes for the new element.
-        addAttrs(host, node.attrs);
+      // Add the attributes for the new element.
+      addAttrs(host, node.attrs);
 
-        // Recursively populate the element with child content.
-        for (let i = 0, n = node.children.length; i < n; ++i) {
-          createDOMNode(node.children[i], host);
-        }
+      if (node.type === 'passthru') {
+        node.render(host);
+        return host;
+      }
+
+      // Recursively populate the element with child content.
+      for (let i = 0, n = node.children.length; i < n; ++i) {
+        createDOMNode(node.children[i], host);
       }
     }
 
@@ -1157,7 +1137,7 @@ namespace Private {
 
       // Handle the case of passthru update.
       if (oldVNode.type === 'passthru' && newVNode.type === 'passthru') {
-        newVNode.render(host);
+        newVNode.render(currElem as HTMLElement);
         currElem = currElem!.nextSibling;
         continue;
       }

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -1069,40 +1069,39 @@ namespace Private {
   function createDOMNode(node: VirtualNode, host: HTMLElement | null, before: Node | null): HTMLElement | Text;
   export
   function createDOMNode(node: VirtualNode): HTMLElement | Text {
-    const host = arguments[1] || null;
+    let host = arguments[1] || null;
     const before = arguments[2] || null;
 
-    if (host) {
-      if (node.type === 'passthru') {
+    if (node.type === 'passthru') {
+      if (host) {
         // TODO: figure out how to do an "insert before" with a passthru node
         node.render(host);
       } else {
-        host.insertBefore(createDOMNode(node), before);
-      }
-
-      return host;
-    } else {
-      // Create a text node for a virtual text node.
-      if (node.type === 'text') {
-        return document.createTextNode(node.content);
-      } else if (node.type === 'passthru') {
         throw new Error("createDOMNode should not be called with only one argument on vdom nodes of type === 'passthru'");
       }
+    } else {
+      if (host) {
+        host.insertBefore(createDOMNode(node), before);
+      } else {
+        // Create a text node for a virtual text node.
+        if (node.type === 'text') {
+          return document.createTextNode(node.content);
+        }
 
-      // Create the HTML element with the specified tag.
-      let element = document.createElement(node.tag);
+        // Create the HTML element with the specified tag.
+        host = document.createElement(node.tag);
 
-      // Add the attributes for the new element.
-      addAttrs(element, node.attrs);
+        // Add the attributes for the new element.
+        addAttrs(host, node.attrs);
 
-      // Recursively populate the element with child content.
-      for (let i = 0, n = node.children.length; i < n; ++i) {
-        createDOMNode(node.children[i], element);
+        // Recursively populate the element with child content.
+        for (let i = 0, n = node.children.length; i < n; ++i) {
+          createDOMNode(node.children[i], host);
+        }
       }
-
-      // Return the populated element.
-      return element;
     }
+
+    return host;
   }
 
   /**

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -981,8 +981,10 @@ namespace VirtualDOM {
    *
    * If virtual diffing is desired, use the `render` function instead.
    */
-  export
-  function realize(node: VirtualElement): HTMLElement {
+  export function realize(node: VirtualText): Text;
+  export function realize(node: VirtualElement): HTMLElement;
+  export function realize(node: VirtualElementPass): HTMLElement;
+  export function realize(node: VirtualNode): HTMLElement | Text {
     return Private.createDOMNode(node);
   }
 

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -751,6 +751,10 @@ class VirtualElement {
 
 export
 class VirtualElementPass {
+  readonly realize: VirtualElementPass.IRealize;
+
+  readonly render: VirtualElementPass.IRender;
+
   /**
    * The type of the node.
    *
@@ -762,13 +766,26 @@ class VirtualElementPass {
   /**
    * Construct a new virtual element pass thru node.
    *
-   * @param callback - a function that takes a host HTMLElement and returns void
+   * @param realize - a function that takes no arguments and returns an HTMLElement
+   *
+   * @param render - a function that takes a host HTMLElement and returns void
    */
-  constructor(readonly callback: VirtualElementPass.ICallBack) {}
+  constructor({realize, render}: VirtualElementPass.IProps) {
+    this.render = render;
+    this.realize = realize || (() => {const host = document.createElement('div'); this.render(host); return host});
+  }
 }
 
-namespace VirtualElementPass {
-  export type ICallBack = (host: HTMLElement) => void;
+export namespace VirtualElementPass {
+  export type IRealize = () => HTMLElement;
+
+  export type IRender = (host: HTMLElement) => void;
+
+  export interface IProps {
+    realize?: IRealize;
+
+    render: IRender;
+  }
 }
 
 /**
@@ -813,6 +830,8 @@ export function h(tag: string): VirtualElement {
       children.push(arg);
     } else if (arg instanceof VirtualElement) {
       children.push(arg);
+    } else if (arg instanceof VirtualElementPass) {
+      children.push(arg);
     } else if (arg instanceof Array) {
       extend(children, arg);
     } else if (i === 1 && arg && typeof arg === 'object') {
@@ -828,6 +847,8 @@ export function h(tag: string): VirtualElement {
       } else if (child instanceof VirtualText) {
         array.push(child);
       } else if (child instanceof VirtualElement) {
+        array.push(child);
+      } else if (child instanceof VirtualElementPass) {
         array.push(child);
       }
     }
@@ -954,8 +975,8 @@ namespace h {
   export const wbr: IFactory = h.bind(undefined, 'wbr');
 }
 
-export function hpass(callback: (host: HTMLElement) => void): VirtualElementPass {
-  return new VirtualElementPass(callback);
+export function hpass(props: VirtualElementPass.IProps): VirtualElementPass {
+  return new VirtualElementPass(props);
 }
 
 /**
@@ -1039,12 +1060,17 @@ namespace Private {
   export
   function createDOMNode(node: VirtualElement): HTMLElement;
   export
+  function createDOMNode(node: VirtualElementPass): HTMLElement;
+  export
   function createDOMNode(node: VirtualNode): HTMLElement | Text;
   export
   function createDOMNode(node: VirtualNode): HTMLElement | Text {
     // Create a text node for a virtual text node.
     if (node.type === 'text') {
       return document.createTextNode(node.content);
+    } else if (node.type === 'passthru') {
+      console.error("createDOMNode should not be called on vdom nodes of type === 'passthru'");
+      return node.realize();
     }
 
     // Create the HTML element with the specified tag.
@@ -1055,7 +1081,13 @@ namespace Private {
 
     // Recursively populate the element with child content.
     for (let i = 0, n = node.children.length; i < n; ++i) {
-      element.appendChild(createDOMNode(node.children[i]));
+      const child = node.children[i];
+
+      if (child.type === 'passthru') {
+        child.render(element);
+      } else {
+        element.appendChild(createDOMNode(child));
+      }
     }
 
     // Return the populated element.
@@ -1092,15 +1124,13 @@ namespace Private {
       // Lookup the new virtual node.
       let newVNode = newContent[i];
 
-      // If the new content is a pass thru, let it handle diffing
-      if (newVNode.type === 'passthru') {
-        newVNode.callback(host);
-        continue;
-      }
-
       // If the old content is exhausted, create a new node.
       if (i >= oldCopy.length) {
-        host.appendChild(createDOMNode(newContent[i]));
+        if (newVNode.type === 'passthru') {
+          newVNode.render(host);
+        } else {
+          host.appendChild(createDOMNode(newVNode));
+        }
         continue;
       }
 
@@ -1120,15 +1150,27 @@ namespace Private {
         continue;
       }
 
-      // If the old or new node is a text node, the other node is now
-      // known to be an element node, so create and insert a new node.
-      if (oldVNode.type === 'text' || newVNode.type === 'text') {
-        ArrayExt.insert(oldCopy, i, newVNode);
-        host.insertBefore(createDOMNode(newVNode), currElem);
+      // Handle the case of passthru update.
+      if (oldVNode.type === 'passthru' && newVNode.type === 'passthru') {
+        newVNode.render(host);
+        currElem = currElem!.nextSibling;
         continue;
       }
 
-      // At this point, both nodes are known to be element nodes.
+      // If the types of the old and new nodes differ,
+      // create and insert a new node.
+      if (oldVNode.type === 'text' || newVNode.type === 'text' ||
+        oldVNode.type === 'passthru' || newVNode.type === 'passthru') {
+        ArrayExt.insert(oldCopy, i, newVNode);
+        if (newVNode.type === 'passthru') {
+          newVNode.render(host);
+        } else {
+          host.insertBefore(createDOMNode(newVNode), currElem);
+        }
+        continue;
+      }
+
+      // At this point, both nodes are known to be of type element.
 
       // If the new elem is keyed, move an old keyed elem to the proper
       // location before proceeding with the diff. The search can start

--- a/packages/virtualdom/tests/src/index.spec.ts
+++ b/packages/virtualdom/tests/src/index.spec.ts
@@ -12,7 +12,7 @@ import {
 } from 'chai';
 
 import {
-  VirtualDOM, VirtualElement, VirtualText, h
+  VirtualDOM, VirtualElement, VirtualElementPass, VirtualText, h, hpass
 } from '@lumino/virtualdom';
 
 
@@ -94,6 +94,61 @@ describe('@lumino/virtualdom', () => {
         let children = [h.a(), h.img()];
         let vnode = new VirtualElement('div', {}, children);
         expect(vnode.children).to.equal(children);
+      });
+
+    });
+
+  });
+
+  describe('VirtualElementPass', () => {
+    let mockRenderer = {
+      render: (host: HTMLElement) => {},
+      unrender: (host: HTMLElement) =>{}
+    };
+
+    describe('#constructor()', () => {
+
+      it('should create a virtual element node', () => {
+        let vnode = new VirtualElementPass(mockRenderer, 'div', {});
+        expect(vnode).to.be.an.instanceof(VirtualElementPass);
+      });
+
+    });
+
+    describe('#type', () => {
+
+      it('should be `element`', () => {
+        let vnode = new VirtualElementPass(mockRenderer,'div', {});
+        expect(vnode.type).to.equal('passthru');
+      });
+
+    });
+
+    describe('#renderer', () => {
+
+      it('should be the element children renderer', () => {
+        let vnode = new VirtualElementPass(mockRenderer, 'div', {});
+        expect(vnode.renderer.render).to.equal(mockRenderer.render);
+        expect(vnode.renderer.unrender).to.equal(mockRenderer.unrender);
+      });
+
+    });
+
+    describe('#tag', () => {
+
+      it('should be the element tag name', () => {
+        let vnode = new VirtualElementPass(mockRenderer,'img', {});
+        expect(vnode.tag).to.equal('img');
+      });
+
+    });
+
+    describe('#attrs', () => {
+
+      it('should be the element attrs', () => {
+        let attrs = { className: 'baz' };
+        let vnode = new VirtualElementPass(mockRenderer,'img', attrs);
+        expect(vnode.attrs).to.deep.equal(attrs);
       });
 
     });
@@ -290,8 +345,22 @@ describe('@lumino/virtualdom', () => {
 
   });
 
-  describe('VirtualDOM', () => {
+  describe('hpass()', () => {
 
+    it('should create a new virtual element passthru node', () => {
+      let vnode = hpass(
+        {
+          render: (host: HTMLElement) => {},
+          unrender: (host: HTMLElement) =>{}
+        },
+        'div'
+      );
+      expect(vnode).to.be.an.instanceof(VirtualElementPass);
+    });
+
+  });
+
+  describe('VirtualDOM', () => {
     describe('realize()', () => {
 
       it('should create a real DOM node from a virtual DOM node', () => {
@@ -419,6 +488,48 @@ describe('@lumino/virtualdom', () => {
         expect(div.textContent).to.equal('bar');
       });
 
+    });
+
+  });
+
+  describe('VirtualDOM passthru', () => {
+    const rendererClosure = (record = {child: undefined, cleanedUp: false}) => {
+      return {
+        render: (host: HTMLElement) => {
+          const renderNode = document.createElement('div');
+          renderNode.className = 'p-render';
+          host.appendChild(renderNode);
+          (record.child as any) = renderNode;
+        },
+        unrender: (host: HTMLElement) => {
+          host.removeChild(host.lastChild as HTMLElement);
+          record.cleanedUp = true;
+        }
+      }
+    };
+
+    describe('render()', () => {
+      describe('should render child node', () => {
+        let host = document.createElement('div');
+        let record: any = {};
+        let children = [h.a(), h.span(), h.div(hpass(rendererClosure(record), 'span'))];
+        VirtualDOM.render(children, host);
+        expect(host.children[2].children[0]).to.equal(record.child);
+        expect(host.children[2].children[0].className).to.equal('p-render');
+      });
+
+      describe('should cleanup child node', () => {
+        let host = document.createElement('div');
+        let record: any = {};
+        let children = [h.a(), h.span(), h.div(hpass(rendererClosure(record), 'span'))];
+        // first pass, render the hpass children
+        VirtualDOM.render(children, host);
+
+        children[2] = h.label();
+        // second pass, explicitly unrender the hpass children
+        VirtualDOM.render(children, host);
+        expect(record.cleanedUp).to.equal(true);
+      });
     });
 
   });

--- a/packages/virtualdom/tests/src/index.spec.ts
+++ b/packages/virtualdom/tests/src/index.spec.ts
@@ -509,25 +509,26 @@ describe('@lumino/virtualdom', () => {
     };
 
     describe('render()', () => {
-      describe('should render child node', () => {
+      it('should render child node', () => {
         let host = document.createElement('div');
         let record: any = {};
-        let children = [h.a(), h.span(), h.div(hpass(rendererClosure(record), 'span'))];
+        let children = [h.a(), h.span(), h.div(h.div(), hpass(rendererClosure(record), 'span'), h.div())];
         VirtualDOM.render(children, host);
-        expect(host.children[2].children[0]).to.equal(record.child);
-        expect(host.children[2].children[0].className).to.equal('p-render');
+        expect(host.children[2].children[1].children[0]).to.equal(record.child);
+        expect(host.children[2].children[1].children[0].className).to.equal('p-render');
       });
 
-      describe('should cleanup child node', () => {
+      it('should cleanup child node', () => {
         let host = document.createElement('div');
         let record: any = {};
-        let children = [h.a(), h.span(), h.div(hpass(rendererClosure(record), 'span'))];
-        // first pass, render the hpass children
-        VirtualDOM.render(children, host);
 
-        children[2] = h.label();
+        // first pass, render the hpass children
+        let children0 = [h.a(), h.span(), h.div(h.div(), hpass(rendererClosure(record), 'span'), h.div())];
+        VirtualDOM.render(children0, host);
+
         // second pass, explicitly unrender the hpass children
-        VirtualDOM.render(children, host);
+        let children1 = [h.a(), h.span(), h.label()];
+        VirtualDOM.render(children1, host);
         expect(record.cleanedUp).to.equal(true);
       });
     });

--- a/packages/virtualdom/tests/src/index.spec.ts
+++ b/packages/virtualdom/tests/src/index.spec.ts
@@ -493,13 +493,13 @@ describe('@lumino/virtualdom', () => {
   });
 
   describe('VirtualDOM passthru', () => {
-    const rendererClosure = (record = {child: undefined, cleanedUp: false}) => {
+    const rendererClosure = (record: any = {}) => {
       return {
         render: (host: HTMLElement) => {
           const renderNode = document.createElement('div');
           renderNode.className = 'p-render';
           host.appendChild(renderNode);
-          (record.child as any) = renderNode;
+          record.child = renderNode;
         },
         unrender: (host: HTMLElement) => {
           host.removeChild(host.lastChild as HTMLElement);
@@ -508,10 +508,30 @@ describe('@lumino/virtualdom', () => {
       }
     };
 
+    describe('realize()', () => {
+      it('should realize successfully', () => {
+        let node = VirtualDOM.realize(hpass(rendererClosure(), 'span'));
+        expect(node.tagName.toLowerCase()).to.equal('span');
+        expect(node.children[0].tagName.toLowerCase()).to.equal('div');
+        expect(node.children[0].className).to.equal('p-render');
+      });
+
+    });
+
     describe('render()', () => {
+      it('should render successfully at top of tree', () => {
+        let host = document.createElement('div');
+
+        VirtualDOM.render(hpass(rendererClosure(), 'span'), host);
+        expect(host.children[0].tagName.toLowerCase()).to.equal('span');
+        expect(host.children[0].children[0].tagName.toLowerCase()).to.equal('div');
+        expect(host.children[0].children[0].className).to.equal('p-render');
+      });
+
       it('should render child node', () => {
         let host = document.createElement('div');
-        let record: any = {};
+        let record: any = {child: undefined, cleanedUp: false};
+
         let children = [h.a(), h.span(), h.div(h.div(), hpass(rendererClosure(record), 'span'), h.div())];
         VirtualDOM.render(children, host);
         expect(host.children[2].children[1].children[0]).to.equal(record.child);
@@ -520,7 +540,7 @@ describe('@lumino/virtualdom', () => {
 
       it('should cleanup child node', () => {
         let host = document.createElement('div');
-        let record: any = {};
+        let record: any = {child: undefined, cleanedUp: false};
 
         // first pass, render the hpass children
         let children0 = [h.a(), h.span(), h.div(h.div(), hpass(rendererClosure(record), 'span'), h.div())];

--- a/packages/virtualdom/tests/tsconfig.json
+++ b/packages/virtualdom/tests/tsconfig.json
@@ -9,6 +9,7 @@
     "moduleResolution": "node",
     "target": "ES5",
     "outDir": "build",
+    "sourceMap": true,
     "lib": [
       "ES5",
       "DOM"

--- a/packages/virtualdom/tests/webpack.config.js
+++ b/packages/virtualdom/tests/webpack.config.js
@@ -4,5 +4,6 @@ module.exports = {
   entry: './build/index.spec.js',
   output: {
     filename: './build/bundle.test.js'
-  }
+  },
+  devtool: 'inline-source-map'
 }

--- a/packages/virtualdom/tests/webpack.config.js
+++ b/packages/virtualdom/tests/webpack.config.js
@@ -6,4 +6,4 @@ module.exports = {
     filename: './build/bundle.test.js'
   },
   devtool: 'inline-source-map'
-}
+};

--- a/packages/virtualdom/tsconfig.json
+++ b/packages/virtualdom/tsconfig.json
@@ -15,6 +15,7 @@
       "ES2015.Collection",
       "DOM"
     ],
+    "sourceMap": true,
     "types": [],
     "rootDir": "src"
   },

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -37,8 +37,13 @@
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
     "test": "npm run test:firefox",
+    "test:debug": "npm run test:debug:firefox",
     "test:chrome": "cd tests && karma start --browsers=Chrome",
+    "test:chrome-headless": "cd tests && karma start --browsers=ChromeHeadless",
     "test:firefox": "cd tests && karma start --browsers=Firefox",
+    "test:debug:chrome": "cd tests && karma start --browsers=Chrome --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
+    "test:debug:chrome-headless": "cd tests && karma start  --browsers=ChromeHeadless --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
+    "test:debug:firefox": "cd tests && karma start --browsers=Firefox --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
     "test:ie": "cd tests && karma start --browsers=IE",
     "watch": "tsc --build --watch"
   },

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -32,7 +32,7 @@ import {
 } from '@lumino/signaling';
 
 import {
-  ElementDataset, ElementInlineStyle, VirtualDOM, VirtualElement, h
+  ElementDataset, ElementInlineStyle, VirtualDOM, VirtualElement, h, hpass, VirtualNode
 } from '@lumino/virtualdom';
 
 import {
@@ -1339,9 +1339,15 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab icon.
      */
-    renderIcon(data: IRenderData<any>): VirtualElement {
+    renderIcon(data: IRenderData<any>): VirtualNode {
+      const { title } = data;
       let className = this.createIconClass(data);
-      return h.div({ className }, data.title.iconLabel);
+
+      if (title.iconPass) {
+        return hpass(title.iconPass);
+      } else {
+        return h.div({className}, data.title.iconLabel);
+      }
     }
 
     /**

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1343,8 +1343,8 @@ namespace TabBar {
       const { title } = data;
       let className = this.createIconClass(data);
 
-      if (title.iconPass) {
-        return hpass(title.iconPass);
+      if (title.iconRender) {
+        return hpass(title.iconRender, 'div');
       } else {
         return h.div({className}, data.title.iconLabel);
       }

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1344,7 +1344,7 @@ namespace TabBar {
       let className = this.createIconClass(data);
 
       if (title.iconRenderer) {
-        return hpass(title.iconRenderer, 'div');
+        return hpass('div', title.iconRenderer);
       } else {
         return h.div({className}, data.title.iconLabel);
       }

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1343,8 +1343,8 @@ namespace TabBar {
       const { title } = data;
       let className = this.createIconClass(data);
 
-      if (title.iconRender) {
-        return hpass(title.iconRender, 'div');
+      if (title.iconRenderer) {
+        return hpass(title.iconRenderer, 'div');
       } else {
         return h.div({className}, data.title.iconLabel);
       }

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -32,7 +32,7 @@ import {
 } from '@lumino/signaling';
 
 import {
-  ElementDataset, ElementInlineStyle, VirtualDOM, VirtualElement, h, hpass, VirtualNode
+  ElementDataset, ElementInlineStyle, VirtualDOM, VirtualElement, VirtualElementPass, h, hpass
 } from '@lumino/virtualdom';
 
 import {
@@ -1339,7 +1339,7 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab icon.
      */
-    renderIcon(data: IRenderData<any>): VirtualNode {
+    renderIcon(data: IRenderData<any>): VirtualElement | VirtualElementPass {
       const { title } = data;
       let className = this.createIconClass(data);
 

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -11,7 +11,7 @@ import {
   ISignal, Signal
 } from '@lumino/signaling';
 
-import { VirtualElementPass } from "@phosphor/virtualdom";
+import { VirtualElementPass } from "@lumino/virtualdom";
 
 
 /**

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -11,6 +11,8 @@ import {
   ISignal, Signal
 } from '@lumino/signaling';
 
+import { VirtualElementPass } from "@phosphor/virtualdom";
+
 
 /**
  * An object which holds data related to an object's title.
@@ -43,6 +45,9 @@ class Title<T> {
     }
     if (options.iconLabel !== undefined) {
       this._iconLabel = options.iconLabel;
+    }
+    if (options.iconPass !== undefined) {
+      this._iconPass = options.iconPass;
     }
     if (options.caption !== undefined) {
       this._caption = options.caption;
@@ -172,6 +177,18 @@ class Title<T> {
     this._changed.emit(undefined);
   }
 
+  get iconPass(): VirtualElementPass.IProps {
+    return this._iconPass;
+  }
+
+  set iconPass(value: VirtualElementPass.IProps) {
+    if (this._iconPass === value) {
+      return;
+    }
+    this._iconPass = value;
+    this._changed.emit(undefined);
+  }
+
   /**
    * Get the caption for the title.
    *
@@ -270,6 +287,7 @@ class Title<T> {
   private _mnemonic = -1;
   private _iconClass = '';
   private _iconLabel = '';
+  private _iconPass: VirtualElementPass.IProps;
   private _className = '';
   private _closable = false;
   private _dataset: Title.Dataset;
@@ -322,6 +340,8 @@ namespace Title {
      * The icon label for the title.
      */
     iconLabel?: string;
+
+    iconPass?: VirtualElementPass.IProps;
 
     /**
      * The caption for the title.

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -177,10 +177,22 @@ class Title<T> {
     this._changed.emit(undefined);
   }
 
+  /**
+   * Get the icon renderer for the title.
+   *
+   * #### Notes
+   * The default value is undefined.
+   */
   get iconRenderer(): VirtualElementPass.IRenderer {
     return this._iconRenderer;
   }
 
+  /**
+   * Set the icon renderer for the title.
+   *
+   * #### Notes
+   * A renderer is an object that supplies a render and unrender function.
+   */
   set iconRenderer(value: VirtualElementPass.IRenderer) {
     if (this._iconRenderer === value) {
       return;
@@ -341,6 +353,10 @@ namespace Title {
      */
     iconLabel?: string;
 
+    /**
+     * An object that supplies render and unrender functions used
+     * to create and cleanup the icon of the title.
+     */
     iconRenderer?: VirtualElementPass.IRenderer;
 
     /**

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -46,8 +46,8 @@ class Title<T> {
     if (options.iconLabel !== undefined) {
       this._iconLabel = options.iconLabel;
     }
-    if (options.iconRender !== undefined) {
-      this._iconRender = options.iconRender;
+    if (options.iconRenderer !== undefined) {
+      this._iconRenderer = options.iconRenderer;
     }
     if (options.caption !== undefined) {
       this._caption = options.caption;
@@ -177,15 +177,15 @@ class Title<T> {
     this._changed.emit(undefined);
   }
 
-  get iconRender(): VirtualElementPass.IRender {
-    return this._iconRender;
+  get iconRenderer(): VirtualElementPass.IRenderer {
+    return this._iconRenderer;
   }
 
-  set iconRender(value: VirtualElementPass.IRender) {
-    if (this._iconRender === value) {
+  set iconRenderer(value: VirtualElementPass.IRenderer) {
+    if (this._iconRenderer === value) {
       return;
     }
-    this._iconRender = value;
+    this._iconRenderer = value;
     this._changed.emit(undefined);
   }
 
@@ -287,7 +287,7 @@ class Title<T> {
   private _mnemonic = -1;
   private _iconClass = '';
   private _iconLabel = '';
-  private _iconRender: VirtualElementPass.IRender;
+  private _iconRenderer: VirtualElementPass.IRenderer;
   private _className = '';
   private _closable = false;
   private _dataset: Title.Dataset;
@@ -341,7 +341,7 @@ namespace Title {
      */
     iconLabel?: string;
 
-    iconRender?: VirtualElementPass.IRender;
+    iconRenderer?: VirtualElementPass.IRenderer;
 
     /**
      * The caption for the title.

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -46,8 +46,8 @@ class Title<T> {
     if (options.iconLabel !== undefined) {
       this._iconLabel = options.iconLabel;
     }
-    if (options.iconPass !== undefined) {
-      this._iconPass = options.iconPass;
+    if (options.iconRender !== undefined) {
+      this._iconRender = options.iconRender;
     }
     if (options.caption !== undefined) {
       this._caption = options.caption;
@@ -177,15 +177,15 @@ class Title<T> {
     this._changed.emit(undefined);
   }
 
-  get iconPass(): VirtualElementPass.IProps {
-    return this._iconPass;
+  get iconRender(): VirtualElementPass.IRender {
+    return this._iconRender;
   }
 
-  set iconPass(value: VirtualElementPass.IProps) {
-    if (this._iconPass === value) {
+  set iconRender(value: VirtualElementPass.IRender) {
+    if (this._iconRender === value) {
       return;
     }
-    this._iconPass = value;
+    this._iconRender = value;
     this._changed.emit(undefined);
   }
 
@@ -287,7 +287,7 @@ class Title<T> {
   private _mnemonic = -1;
   private _iconClass = '';
   private _iconLabel = '';
-  private _iconPass: VirtualElementPass.IProps;
+  private _iconRender: VirtualElementPass.IRender;
   private _className = '';
   private _closable = false;
   private _dataset: Title.Dataset;
@@ -341,7 +341,7 @@ namespace Title {
      */
     iconLabel?: string;
 
-    iconPass?: VirtualElementPass.IProps;
+    iconRender?: VirtualElementPass.IRender;
 
     /**
      * The caption for the title.

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -32,7 +32,7 @@ import {
 } from '@lumino/messaging';
 
 import {
-  VirtualDOM
+  VirtualDOM, VirtualElement
 } from '@lumino/virtualdom';
 
 import {
@@ -873,7 +873,7 @@ describe('@lumino/widgets', () => {
           data.title.mnemonic = 1;
           let label = renderer.formatLabel(data);
           expect((label as any)[0]).to.equal('f');
-          let node = VirtualDOM.realize((label as any)[1]);
+          let node = VirtualDOM.realize(((label as any)[1]) as VirtualElement);
           expect(node.className).to.contain('p-MenuBar-itemMnemonic');
           expect(node.textContent).to.equal('o');
           expect((label as any)[2]).to.equal('o');

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -28,7 +28,7 @@ import {
 } from '@lumino/widgets';
 
 import {
-  VirtualDOM
+  VirtualDOM, VirtualElement
 } from '@lumino/virtualdom';
 
 
@@ -1310,7 +1310,7 @@ describe('@lumino/widgets', () => {
         it('should render the icon element for a tab', () => {
           let renderer = new TabBar.Renderer();
           let vNode = renderer.renderIcon({ title, current: true, zIndex: 1 });
-          let node = VirtualDOM.realize(vNode);
+          let node = VirtualDOM.realize(vNode as VirtualElement);
           expect(node.className).to.contain('p-TabBar-tabIcon');
           expect(node.classList.contains(title.icon)).to.equal(true);
         });


### PR DESCRIPTION
Fixes phosphorjs/phosphor#395, phosphorjs/phosphor#436, and probably a bunch of other issues.

This PR adds the hpass function and VirtualElementPass class described in phosphorjs/phosphor#436.

This PR was originally phosphorjs/phoshor#437. @blink1073 Since you reviewed the original PR, could you please take a look at this one too?