### PR TITLE
Use the standby value generated instead of ignoring it.

### DIFF
--- a/packages/polling/src/poll.ts
+++ b/packages/polling/src/poll.ts
@@ -289,7 +289,7 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
         ? false
         : standby === 'when-hidden'
         ? !!(typeof document !== 'undefined' && document && document.hidden)
-        : true;
+        : standby;
 
     // If in standby mode schedule next tick without calling the factory.
     if (standby) {


### PR DESCRIPTION
The standby value generated in the line above is ignored in the current code if it is a boolean. This makes it actually be used where intended.