### PR TITLE
Allow partial JSON for command callers but not receivers

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -619,7 +619,7 @@ namespace CommandRegistry {
    * A type alias for a user-defined command function.
    */
   export
-  type CommandFunc<T> = (args: ReadonlyJSONObject) => T;
+  type CommandFunc<T, U extends ReadonlyJSONObject = ReadonlyJSONObject> = (args: U) => T;
 
   /**
    * A type alias for a simple immutable string dataset.

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -173,7 +173,7 @@ class CommandRegistry {
    */
   label(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.label.call(undefined, JSONExt.deepCopy(args)) : '';
+    return cmd ? cmd.label.call(undefined, JSONExt.stripUndefined(args)) : '';
   }
 
   /**
@@ -191,7 +191,7 @@ class CommandRegistry {
    */
   mnemonic(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): number {
     let cmd = this._commands[id];
-    return cmd ? cmd.mnemonic.call(undefined, JSONExt.deepCopy(args)) : -1;
+    return cmd ? cmd.mnemonic.call(undefined, JSONExt.stripUndefined(args)) : -1;
   }
 
   /**
@@ -216,7 +216,7 @@ class CommandRegistry {
    */
   iconClass(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.iconClass.call(undefined, JSONExt.deepCopy(args)) : '';
+    return cmd ? cmd.iconClass.call(undefined, JSONExt.stripUndefined(args)) : '';
   }
 
   /**
@@ -234,7 +234,7 @@ class CommandRegistry {
    */
   iconLabel(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.iconLabel.call(undefined, JSONExt.deepCopy(args)) : '';
+    return cmd ? cmd.iconLabel.call(undefined, JSONExt.stripUndefined(args)) : '';
   }
 
   /**
@@ -252,7 +252,7 @@ class CommandRegistry {
    */
   caption(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.caption.call(undefined, JSONExt.deepCopy(args)) : '';
+    return cmd ? cmd.caption.call(undefined, JSONExt.stripUndefined(args)) : '';
   }
 
   /**
@@ -270,7 +270,7 @@ class CommandRegistry {
    */
   usage(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.usage.call(undefined, JSONExt.deepCopy(args)) : '';
+    return cmd ? cmd.usage.call(undefined, JSONExt.stripUndefined(args)) : '';
   }
 
   /**
@@ -288,7 +288,7 @@ class CommandRegistry {
    */
   className(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.className.call(undefined, JSONExt.deepCopy(args)) : '';
+    return cmd ? cmd.className.call(undefined, JSONExt.stripUndefined(args)) : '';
   }
 
   /**
@@ -306,7 +306,7 @@ class CommandRegistry {
    */
   dataset(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): CommandRegistry.Dataset {
     let cmd = this._commands[id];
-    return cmd ? cmd.dataset.call(undefined, JSONExt.deepCopy(args)) : {};
+    return cmd ? cmd.dataset.call(undefined, JSONExt.stripUndefined(args)) : {};
   }
 
   /**
@@ -324,7 +324,7 @@ class CommandRegistry {
    */
   isEnabled(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): boolean {
     let cmd = this._commands[id];
-    return cmd ? cmd.isEnabled.call(undefined, JSONExt.deepCopy(args)) : false;
+    return cmd ? cmd.isEnabled.call(undefined, JSONExt.stripUndefined(args)) : false;
   }
 
   /**
@@ -342,7 +342,7 @@ class CommandRegistry {
    */
   isToggled(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): boolean {
     let cmd = this._commands[id];
-    return cmd ? cmd.isToggled.call(undefined, JSONExt.deepCopy(args)) : false;
+    return cmd ? cmd.isToggled.call(undefined, JSONExt.stripUndefined(args)) : false;
   }
 
   /**
@@ -360,7 +360,7 @@ class CommandRegistry {
    */
   isVisible(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): boolean {
     let cmd = this._commands[id];
-    return cmd ? cmd.isVisible.call(undefined, JSONExt.deepCopy(args)) : false;
+    return cmd ? cmd.isVisible.call(undefined, JSONExt.stripUndefined(args)) : false;
   }
 
   /**
@@ -387,7 +387,7 @@ class CommandRegistry {
 
     // Execute the command and reject if an exception is thrown.
     let value: any;
-    const execArgs = JSONExt.deepCopy(args) as ReadonlyJSONObject;
+    const execArgs = JSONExt.stripUndefined(args) as ReadonlyJSONObject;
     try {
       value = cmd.execute.call(undefined, execArgs);
     } catch (err) {

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1207,7 +1207,7 @@ namespace Private {
       keys: CommandRegistry.normalizeKeys(options),
       selector: validateSelector(options),
       command: options.command,
-      args: options.args || JSONExt.emptyObject
+      args: (options.args as ReadonlyJSONObject) || JSONExt.emptyObject
     };
   }
 

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -12,7 +12,7 @@ import {
 } from '@lumino/algorithm';
 
 import {
-  JSONExt, ReadonlyPartialJSONObject
+  JSONExt, ReadonlyJSONObject, ReadonlyPartialJSONObject
 } from '@lumino/coreutils';
 
 import {
@@ -362,7 +362,8 @@ class CommandRegistry {
     let result = Promise.resolve(value);
 
     // Emit the command executed signal.
-    this._commandExecuted.emit({ id, args, result });
+    const execArgs = args as ReadonlyJSONObject;
+    this._commandExecuted.emit({ id, args: execArgs, result });
 
     // Return the result promise to the caller.
     return result;
@@ -583,7 +584,7 @@ namespace CommandRegistry {
    * A type alias for a user-defined command function.
    */
   export
-  type CommandFunc<T> = (args: ReadonlyPartialJSONObject) => T;
+  type CommandFunc<T> = (args: ReadonlyJSONObject) => T;
 
   /**
    * A type alias for a simple immutable string dataset.
@@ -808,7 +809,7 @@ namespace CommandRegistry {
     /**
      * The arguments object passed to the command.
      */
-    readonly args: ReadonlyPartialJSONObject;
+    readonly args: ReadonlyJSONObject;
 
     /**
      * The promise which resolves with the result of the command.
@@ -866,7 +867,7 @@ namespace CommandRegistry {
      *
      * The default value is an empty object.
      */
-    args?: ReadonlyPartialJSONObject;
+    args?: ReadonlyJSONObject;
 
     /**
      * The key sequence to use when running on Windows.
@@ -916,7 +917,7 @@ namespace CommandRegistry {
     /**
      * The arguments for the command.
      */
-    readonly args: ReadonlyPartialJSONObject;
+    readonly args: ReadonlyJSONObject;
   }
 
   /**

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -867,7 +867,7 @@ namespace CommandRegistry {
      *
      * The default value is an empty object.
      */
-    args?: ReadonlyJSONObject;
+    args?: ReadonlyPartialJSONObject;
 
     /**
      * The key sequence to use when running on Windows.

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -167,10 +167,13 @@ class CommandRegistry {
    *
    * @returns The display label for the command, or an empty string
    *   if the command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   label(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.label.call(undefined, args) : '';
+    return cmd ? cmd.label.call(undefined, JSONExt.deepCopy(args)) : '';
   }
 
   /**
@@ -182,10 +185,13 @@ class CommandRegistry {
    *
    * @returns The mnemonic index for the command, or `-1` if the
    *   command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   mnemonic(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): number {
     let cmd = this._commands[id];
-    return cmd ? cmd.mnemonic.call(undefined, args) : -1;
+    return cmd ? cmd.mnemonic.call(undefined, JSONExt.deepCopy(args)) : -1;
   }
 
   /**
@@ -204,10 +210,13 @@ class CommandRegistry {
    *
    * @returns The icon class for the command, or an empty string if
    *   the command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   iconClass(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.iconClass.call(undefined, args) : '';
+    return cmd ? cmd.iconClass.call(undefined, JSONExt.deepCopy(args)) : '';
   }
 
   /**
@@ -219,10 +228,13 @@ class CommandRegistry {
    *
    * @returns The icon label for the command, or an empty string if
    *   the command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   iconLabel(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.iconLabel.call(undefined, args) : '';
+    return cmd ? cmd.iconLabel.call(undefined, JSONExt.deepCopy(args)) : '';
   }
 
   /**
@@ -234,10 +246,13 @@ class CommandRegistry {
    *
    * @returns The caption for the command, or an empty string if the
    *   command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   caption(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.caption.call(undefined, args) : '';
+    return cmd ? cmd.caption.call(undefined, JSONExt.deepCopy(args)) : '';
   }
 
   /**
@@ -249,10 +264,13 @@ class CommandRegistry {
    *
    * @returns The usage text for the command, or an empty string if
    *   the command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   usage(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.usage.call(undefined, args) : '';
+    return cmd ? cmd.usage.call(undefined, JSONExt.deepCopy(args)) : '';
   }
 
   /**
@@ -264,10 +282,13 @@ class CommandRegistry {
    *
    * @returns The class name for the command, or an empty string if
    *   the command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   className(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
-    return cmd ? cmd.className.call(undefined, args) : '';
+    return cmd ? cmd.className.call(undefined, JSONExt.deepCopy(args)) : '';
   }
 
   /**
@@ -279,10 +300,13 @@ class CommandRegistry {
    *
    * @returns The dataset for the command, or an empty dataset if
    *   the command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   dataset(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): CommandRegistry.Dataset {
     let cmd = this._commands[id];
-    return cmd ? cmd.dataset.call(undefined, args) : {};
+    return cmd ? cmd.dataset.call(undefined, JSONExt.deepCopy(args)) : {};
   }
 
   /**
@@ -294,10 +318,13 @@ class CommandRegistry {
    *
    * @returns A boolean indicating whether the command is enabled,
    *   or `false` if the command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   isEnabled(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): boolean {
     let cmd = this._commands[id];
-    return cmd ? cmd.isEnabled.call(undefined, args) : false;
+    return cmd ? cmd.isEnabled.call(undefined, JSONExt.deepCopy(args)) : false;
   }
 
   /**
@@ -309,10 +336,13 @@ class CommandRegistry {
    *
    * @returns A boolean indicating whether the command is toggled,
    *   or `false` if the command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   isToggled(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): boolean {
     let cmd = this._commands[id];
-    return cmd ? cmd.isToggled.call(undefined, args) : false;
+    return cmd ? cmd.isToggled.call(undefined, JSONExt.deepCopy(args)) : false;
   }
 
   /**
@@ -324,10 +354,13 @@ class CommandRegistry {
    *
    * @returns A boolean indicating whether the command is visible,
    *   or `false` if the command is not registered.
+   *
+   * ### Notes
+   * Any `undefined` values in the args will be stripped.
    */
   isVisible(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): boolean {
     let cmd = this._commands[id];
-    return cmd ? cmd.isVisible.call(undefined, args) : false;
+    return cmd ? cmd.isVisible.call(undefined, JSONExt.deepCopy(args)) : false;
   }
 
   /**
@@ -342,6 +375,8 @@ class CommandRegistry {
    * #### Notes
    * The promise will reject if the command throws an exception,
    * or if the command is not registered.
+   *
+   * Any `undefined` values in the args will be stripped.
    */
   execute(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): Promise<any> {
     // Reject if the command is not registered.
@@ -352,8 +387,9 @@ class CommandRegistry {
 
     // Execute the command and reject if an exception is thrown.
     let value: any;
+    const execArgs = JSONExt.deepCopy(args) as ReadonlyJSONObject;
     try {
-      value = cmd.execute.call(undefined, args);
+      value = cmd.execute.call(undefined, execArgs);
     } catch (err) {
       value = Promise.reject(err);
     }
@@ -362,7 +398,6 @@ class CommandRegistry {
     let result = Promise.resolve(value);
 
     // Emit the command executed signal.
-    const execArgs = args as ReadonlyJSONObject;
     this._commandExecuted.emit({ id, args: execArgs, result });
 
     // Return the result promise to the caller.
@@ -866,6 +901,8 @@ namespace CommandRegistry {
      * The arguments for the command, if necessary.
      *
      * The default value is an empty object.
+     *
+     * Any `undefined` values in the args will be stripped.
      */
     args?: ReadonlyPartialJSONObject;
 

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -532,7 +532,7 @@ describe('@lumino/commands', () => {
           execute: (args: JSONObject) => { return args; },
         };
         registry.addCommand('test', cmd);
-        const result = registry.execute('test', { foo: 12, bar: undefined })
+        const result = await registry.execute('test', { foo: 12, bar: undefined })
         expect(result).to.deep.equal({ foo: 12 });
       });
 

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -527,6 +527,15 @@ describe('@lumino/commands', () => {
         expect(called).to.equal(true);
       });
 
+      it('should allow being called with a partial JSON value', async () => {
+        let cmd = {
+          execute: (args: JSONObject) => { return args; },
+        };
+        registry.addCommand('test', cmd);
+        const result = registry.execute('test', { foo: 12, bar: undefined })
+        expect(result).to.deep.equal({ foo: 12 });
+      });
+
     });
 
     let elemID = 0;

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '@lumino/commands';
 
 import {
-  JSONObject, ReadonlyPartialJSONObject
+  JSONObject, ReadonlyJSONObject
 } from '@lumino/coreutils';
 
 import {
@@ -505,20 +505,20 @@ describe('@lumino/commands', () => {
         });
       });
 
-      it('should handle partial objects', () => {
-        interface ITestPartial extends ReadonlyPartialJSONObject {
+      it('should handle specific objects', () => {
+        interface ITestSpecific extends ReadonlyJSONObject {
           foo: string;
-          bar?: string;
+          bar: string;
         }
-        const a: ITestPartial = {
+        const a: ITestSpecific = {
           foo: 'hi',
-          bar: undefined
+          bar: 'ho'
         };
         let called = false;
         let cmd = {
-          execute: (args: ITestPartial) => {
+          execute: (args: ITestSpecific) => {
             expect(args.foo).to.equal('hi');
-            expect(Object.keys(args).indexOf('bar')).to.equal(-1);
+            expect(args.bar).to.equal('ho');
             called = true;
           },
         };

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '@lumino/commands';
 
 import {
-  JSONObject
+  JSONObject, ReadonlyPartialJSONObject
 } from '@lumino/coreutils';
 
 import {
@@ -503,6 +503,28 @@ describe('@lumino/commands', () => {
         registry.execute('foo').catch(() => {
           done();
         });
+      });
+
+      it('should handle partial objects', () => {
+        interface ITestPartial extends ReadonlyPartialJSONObject {
+          foo: string;
+          bar?: string;
+        }
+        const a: ITestPartial = {
+          foo: 'hi',
+          bar: undefined
+        };
+        let called = false;
+        let cmd = {
+          execute: (args: ITestPartial) => {
+            expect(args.foo).to.equal('hi');
+            expect(Object.keys(args).indexOf('bar')).to.equal(-1);
+            called = true;
+          },
+        };
+        registry.addCommand('test', cmd);
+        registry.execute('test', a);
+        expect(called).to.equal(true);
       });
 
     });

--- a/packages/coreutils/src/json.ts
+++ b/packages/coreutils/src/json.ts
@@ -64,7 +64,7 @@ type ReadonlyJSONValue = JSONPrimitive | ReadonlyJSONObject | ReadonlyJSONArray;
  * Note: Partial here means that JSON object attributes can be `undefined`.
  */
 export
-type PartialJSONValue = JSONPrimitive | PartialJSONObject | PartialJSONArray;
+type PartialJSONValue = ReadonlyJSONValue | PartialJSONObject | PartialJSONArray;
 
 
 /**

--- a/packages/coreutils/src/json.ts
+++ b/packages/coreutils/src/json.ts
@@ -249,6 +249,56 @@ namespace JSONExt {
   }
 
   /**
+   * Strip out any `undefined` values from a JSON object.
+   *
+   * @param value - The JSON value to copy.
+   *
+   * @returns The given JSON value with `undefined` values stripped, recursively.
+   */
+  export
+  function stripUndefined(value: ReadonlyPartialJSONObject): ReadonlyJSONObject {
+    for (let key in value) {
+      // Remove undefined values.
+      let subvalue = value[key];
+      if (subvalue === undefined) {
+        delete (value as any)[key];
+        continue;
+      }
+
+      // Do nothing for primitive values.
+      if (isPrimitive(subvalue)) {
+        continue;
+      }
+
+      // Strip an array.
+      if (isArray(subvalue)) {
+        stripUndefinedArray(subvalue);
+        continue;
+      }
+
+      // Strip an object.
+      stripUndefined(subvalue);
+    }
+    return value as ReadonlyJSONObject;
+  }
+
+
+  /**
+   * Strip a ReadonlyPartialArray of any underlying `undefined` keys.
+   */
+  function stripUndefinedArray(value: ReadonlyPartialJSONArray) {
+    for (let i = 0, n = value.length; i < n; ++i) {
+      const subValue = value[i];
+      if (isPrimitive(subValue)) {
+      } else if (isArray(subValue)) {
+        stripUndefinedArray(subValue);
+      } else {
+        stripUndefined(subValue);
+      }
+    }
+  }
+
+  /**
    * Compare two JSON arrays for deep equality.
    */
   function deepArrayEqual(first: ReadonlyPartialJSONArray, second: ReadonlyPartialJSONArray): boolean {

--- a/packages/coreutils/src/json.ts
+++ b/packages/coreutils/src/json.ts
@@ -64,7 +64,7 @@ type ReadonlyJSONValue = JSONPrimitive | ReadonlyJSONObject | ReadonlyJSONArray;
  * Note: Partial here means that JSON object attributes can be `undefined`.
  */
 export
-type PartialJSONValue = ReadonlyJSONValue | PartialJSONObject | PartialJSONArray;
+type PartialJSONValue = JSONPrimitive | PartialJSONObject | PartialJSONArray;
 
 
 /**

--- a/packages/coreutils/tests/src/json.spec.ts
+++ b/packages/coreutils/tests/src/json.spec.ts
@@ -13,7 +13,7 @@ import {
 
 import {
   JSONArray, JSONExt, JSONObject, JSONPrimitive,
-  PartialJSONObject
+  PartialJSONObject, ReadonlyJSONObject, ReadonlyJSONArray
 } from '@lumino/coreutils';
 
 
@@ -149,6 +149,23 @@ describe('@lumino/coreutils', () => {
       });
 
     });
+
+    describe('stripUndefined()', () => {
+
+      it('should remove undefined values', () => {
+        let v1 = { a: false, b: { bar: undefined } };
+        let r1 = JSONExt.stripUndefined(v1);
+        expect(r1.a).to.equal(false);
+        expect(Object.keys((r1.b as ReadonlyJSONObject)).length).to.equal(0);
+
+        let v2 = { a: [1, { foo: 'a', bar: undefined } ] };
+        let r2 = JSONExt.stripUndefined(v2);
+        let a = r2.a as ReadonlyJSONArray;
+        expect(Object.keys(a[1] as ReadonlyJSONObject).length).to.equal(1);
+        expect((a[1] as ReadonlyJSONObject)['foo']).to.equal('a');
+      });
+
+    })
 
   });
 

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -1360,7 +1360,7 @@ namespace Private {
       this._commands = commands;
       this.category = normalizeCategory(options.category);
       this.command = options.command;
-      this.args = JSONExt.deepCopy(options.args || JSONExt.emptyObject) as ReadonlyJSONObject;
+      this.args = JSONExt.stripUndefined(options.args || JSONExt.emptyObject);
       this.rank = options.rank !== undefined ? options.rank : Infinity;
     }
 

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -1358,7 +1358,7 @@ namespace Private {
       this._commands = commands;
       this.category = normalizeCategory(options.category);
       this.command = options.command;
-      this.args = options.args || JSONExt.emptyObject;
+      this.args = (options.args as ReadonlyJSONObject) || JSONExt.emptyObject;
       this.rank = options.rank !== undefined ? options.rank : Infinity;
     }
 

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -12,7 +12,7 @@ import {
 } from '@lumino/algorithm';
 
 import {
-  JSONExt, ReadonlyJSONObject
+  JSONExt, ReadonlyJSONObject, ReadonlyPartialJSONObject
 } from '@lumino/coreutils';
 
 import {
@@ -526,7 +526,7 @@ namespace CommandPalette {
      *
      * The default value is an empty object.
      */
-    args?: ReadonlyJSONObject;
+    args?: ReadonlyPartialJSONObject;
 
     /**
      * The rank for the command item.

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -525,6 +525,8 @@ namespace CommandPalette {
      * The arguments for the command.
      *
      * The default value is an empty object.
+     *
+     * Any `undefined` values in the args will be stripped.
      */
     args?: ReadonlyPartialJSONObject;
 
@@ -1358,7 +1360,7 @@ namespace Private {
       this._commands = commands;
       this.category = normalizeCategory(options.category);
       this.command = options.command;
-      this.args = (options.args as ReadonlyJSONObject) || JSONExt.emptyObject;
+      this.args = JSONExt.deepCopy(options.args || JSONExt.emptyObject) as ReadonlyJSONObject;
       this.rank = options.rank !== undefined ? options.rank : Infinity;
     }
 

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -986,6 +986,8 @@ namespace Menu {
      * The arguments for the command.
      *
      * The default value is an empty object.
+     *
+     * Any `undefined` values in the args will be stripped.
      */
     args?: ReadonlyPartialJSONObject;
 
@@ -1647,7 +1649,7 @@ namespace Private {
       this._commands = commands;
       this.type = options.type || 'command';
       this.command = options.command || '';
-      this.args = (options.args as ReadonlyJSONObject) || JSONExt.emptyObject;
+      this.args = JSONExt.deepCopy(options.args || JSONExt.emptyObject) as ReadonlyJSONObject;
       this.submenu = options.submenu || null;
     }
 

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -16,7 +16,7 @@ import {
 } from '@lumino/commands';
 
 import {
-  JSONExt, ReadonlyJSONObject
+  JSONExt, ReadonlyJSONObject, ReadonlyPartialJSONObject
 } from '@lumino/coreutils';
 
 import {
@@ -987,7 +987,7 @@ namespace Menu {
      *
      * The default value is an empty object.
      */
-    args?: ReadonlyJSONObject;
+    args?: ReadonlyPartialJSONObject;
 
     /**
      * The submenu for a `'submenu'` type item.

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1649,7 +1649,7 @@ namespace Private {
       this._commands = commands;
       this.type = options.type || 'command';
       this.command = options.command || '';
-      this.args = JSONExt.deepCopy(options.args || JSONExt.emptyObject) as ReadonlyJSONObject;
+      this.args = JSONExt.stripUndefined(options.args || JSONExt.emptyObject);
       this.submenu = options.submenu || null;
     }
 

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1647,7 +1647,7 @@ namespace Private {
       this._commands = commands;
       this.type = options.type || 'command';
       this.command = options.command || '';
-      this.args = options.args || JSONExt.emptyObject;
+      this.args = (options.args as ReadonlyJSONObject) || JSONExt.emptyObject;
       this.submenu = options.submenu || null;
     }
 


### PR DESCRIPTION
Alternative to #33, addresses https://github.com/jupyterlab/lumino/pull/32#issuecomment-568076133.

Allows invokers of commands to pass in `PartialReadonlyJSONObject` values, but ensures that the command consumers receive `ReadonlyJSONObject` values (through API and by stripping `undefined` values).