### PR TITLE
Fix `output.path` for webpack 4

### DIFF
--- a/packages/algorithm/tests/webpack.config.js
+++ b/packages/algorithm/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/application/tests/webpack.config.js
+++ b/packages/application/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/collections/tests/webpack.config.js
+++ b/packages/collections/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/commands/tests/webpack.config.js
+++ b/packages/commands/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/coreutils/tests/webpack.config.js
+++ b/packages/coreutils/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/datastore/tests/webpack.config.js
+++ b/packages/datastore/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/disposable/tests/webpack.config.js
+++ b/packages/disposable/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/domutils/tests/webpack.config.js
+++ b/packages/domutils/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/dragdrop/tests/webpack.config.js
+++ b/packages/dragdrop/tests/webpack.config.js
@@ -4,7 +4,8 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   },
   module: {
     rules: [

--- a/packages/keyboard/tests/webpack.config.js
+++ b/packages/keyboard/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/messaging/tests/webpack.config.js
+++ b/packages/messaging/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/polling/tests/webpack.config.js
+++ b/packages/polling/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/properties/tests/webpack.config.js
+++ b/packages/properties/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/signaling/tests/webpack.config.js
+++ b/packages/signaling/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/virtualdom/tests/webpack.config.js
+++ b/packages/virtualdom/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/widgets/tests/webpack.config.js
+++ b/packages/widgets/tests/webpack.config.js
@@ -4,7 +4,8 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   },
   module: {
     rules: [


### PR DESCRIPTION
Ref: https://github.com/jupyterlab/lumino/issues/21#issuecomment-567859371

Recently in #31, we upgraded the Webpack used to build the tests in all of the `@lumnio` packages from `v2` => `v4`.  

Webpack `v4` [adds a default value to `output.path`](https://webpack.js.org/configuration/output/#outputpath): `path.join(process.cwd(), 'dist')`. So currently, while our tests sucessfully build, they end up in the `tests/dist/build` dir, and Karma can't find them. This makes all of our test cases empty but successful. This PR fixes that