### PR TITLE
Improve handling of attributes for hpass virtualdom elements

### DIFF
--- a/packages/algorithm/tests/webpack.config.js
+++ b/packages/algorithm/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/application/tests/webpack.config.js
+++ b/packages/application/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/collections/tests/webpack.config.js
+++ b/packages/collections/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/commands/tests/webpack.config.js
+++ b/packages/commands/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/coreutils/tests/webpack.config.js
+++ b/packages/coreutils/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/datastore/tests/webpack.config.js
+++ b/packages/datastore/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/disposable/tests/webpack.config.js
+++ b/packages/disposable/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/domutils/tests/webpack.config.js
+++ b/packages/domutils/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/dragdrop/tests/webpack.config.js
+++ b/packages/dragdrop/tests/webpack.config.js
@@ -4,7 +4,8 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   },
   module: {
     rules: [

--- a/packages/keyboard/tests/webpack.config.js
+++ b/packages/keyboard/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/messaging/tests/webpack.config.js
+++ b/packages/messaging/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/polling/tests/webpack.config.js
+++ b/packages/polling/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/properties/tests/webpack.config.js
+++ b/packages/properties/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/signaling/tests/webpack.config.js
+++ b/packages/signaling/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/virtualdom/tests/webpack.config.js
+++ b/packages/virtualdom/tests/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   }
 }

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1344,9 +1344,9 @@ namespace TabBar {
       let className = this.createIconClass(data);
 
       if (title.iconRenderer) {
-        return hpass('div', title.iconRenderer);
+        return hpass('div', {className, title: title.iconLabel}, title.iconRenderer);
       } else {
-        return h.div({className}, data.title.iconLabel);
+        return h.div({className}, title.iconLabel);
       }
     }
 

--- a/packages/widgets/tests/webpack.config.js
+++ b/packages/widgets/tests/webpack.config.js
@@ -4,7 +4,8 @@ module.exports = {
   entry: './build/index.spec.js',
   mode: 'development',
   output: {
-    filename: './build/bundle.test.js'
+    filename: './build/bundle.test.js',
+    path: path.resolve(__dirname)
   },
   module: {
     rules: [


### PR DESCRIPTION
cf #29, https://github.com/jupyterlab/lumino/pull/29#discussion_r359318649

This improves the handling of the set of attributes of an hpass virtualdom element. With this PR, the handling of attrs for h and hpass elements now use mostly the same code path.

This is branched off of #35, so that PR should go in before this one