### PR TITLE
Remove 'sourceMap' from tsconfig in `@lumino/virtualdom`

### DIFF
--- a/packages/virtualdom/tests/tsconfig.json
+++ b/packages/virtualdom/tests/tsconfig.json
@@ -9,7 +9,6 @@
     "moduleResolution": "node",
     "target": "ES5",
     "outDir": "build",
-    "sourceMap": true,
     "lib": [
       "ES5",
       "DOM"

--- a/packages/virtualdom/tsconfig.json
+++ b/packages/virtualdom/tsconfig.json
@@ -15,7 +15,6 @@
       "ES2015.Collection",
       "DOM"
     ],
-    "sourceMap": true,
     "types": [],
     "rootDir": "src"
   },


### PR DESCRIPTION
@lumino/virtualdom@1.4.0 triggers a warning on webpack because it references a source map that's not disted.

This PR stops tsc from generating sourcemaps in @lumino/virtualdom, so it's consistent with the other packages