### PR TITLE
IRenderer cleanup; normalize icon fields across all interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,12 @@ build
 review/api/temp
 *.tsbuildinfo
 
-# jetbrains IDE stuff
+# jetbrains ide stuff
 *.iml
 .idea/
 
-# ms IDE stuff
+# ms ide stuff
+*.code-workspace
+.history
 .vscode
 

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -34,10 +34,20 @@
     "clean": "rimraf lib && rimraf *.tsbuildinfo",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
+
     "test": "npm run test:firefox",
-    "test:chrome": "cd tests && karma start --browsers=Chrome",
-    "test:firefox": "cd tests && karma start --browsers=Firefox",
-    "test:ie": "cd tests && karma start --browsers=IE",
+    "test:chrome": "npm run test:nobrowser -- --browsers=Chrome",
+    "test:chrome-headless": "npm run test:nobrowser -- --browsers=ChromeHeadless",
+    "test:ie": "npm run test:nobrowser -- --browsers=IE",
+    "test:firefox": "npm run test:nobrowser -- --browsers=Firefox",
+    "test:nobrowser": "cd tests && karma start",
+
+    "test:debug": "npm run test:debug:firefox",
+    "test:debug:chrome-headless": "npm run test:debug:nobrowser -- --browsers=ChromeHeadless",
+    "test:debug:chrome": "npm run test:debug:nobrowser -- --browsers=Chrome",
+    "test:debug:firefox": "npm run test:debug:nobrowser -- --browsers=Firefox",
+    "test:debug:nobrowser": "cd tests && karma start --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
+
     "watch": "tsc --build --watch"
   },
   "dependencies": {

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -46,7 +46,8 @@
     "@lumino/disposable": "^1.3.4",
     "@lumino/domutils": "^1.1.7",
     "@lumino/keyboard": "^1.1.6",
-    "@lumino/signaling": "^1.3.4"
+    "@lumino/signaling": "^1.3.4",
+    "@lumino/virtualdom": "^1.5.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.6.0",

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -31,6 +31,9 @@ import {
   ISignal, Signal
 } from '@lumino/signaling';
 
+import {
+  VirtualElement
+} from '@lumino/virtualdom';
 
 /**
  * An object which manages a collection of commands.
@@ -223,6 +226,21 @@ class CommandRegistry {
   iconLabel(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): string {
     let cmd = this._commands[id];
     return cmd ? cmd.iconLabel.call(undefined, args) : '';
+  }
+
+  /**
+   * Get the icon renderer for a specific command.
+   *
+   * @param id - The id of the command of interest.
+   *
+   * @param args - The arguments for the command.
+   *
+   * @returns The icon renderer for the command, or undefined if
+   *   the command is not registered.
+   */
+  iconRenderer(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): VirtualElement.IRenderer {
+    let cmd = this._commands[id];
+    return cmd ? cmd.iconRenderer.call(undefined, args) : undefined;
   }
 
   /**
@@ -680,6 +698,17 @@ namespace CommandRegistry {
      * The default value is an empty string.
      */
     iconLabel?: string | CommandFunc<string>;
+
+    /**
+     * The icon renderer for the command.
+     *
+     * #### Notes
+     * This can be an IRenderer object, or a function which returns the
+     * renderer based on the provided command arguments.
+     *
+     * The default value is undefined.
+     */
+    iconRenderer?: VirtualElement.IRenderer | CommandFunc<VirtualElement.IRenderer>;
 
     /**
      * The caption for the command.
@@ -1167,6 +1196,7 @@ namespace Private {
     readonly mnemonic: CommandFunc<number>;
     readonly iconClass: CommandFunc<string>;
     readonly iconLabel: CommandFunc<string>;
+    readonly iconRenderer: CommandFunc<VirtualElement.IRenderer | undefined>;
     readonly caption: CommandFunc<string>;
     readonly usage: CommandFunc<string>;
     readonly className: CommandFunc<string>;
@@ -1187,6 +1217,7 @@ namespace Private {
       mnemonic: asFunc(options.mnemonic, negativeOneFunc),
       iconClass: asFunc(options.iconClass || options.icon, emptyStringFunc),
       iconLabel: asFunc(options.iconLabel, emptyStringFunc),
+      iconRenderer: asFunc(options.iconRenderer, undefinedFunc),
       caption: asFunc(options.caption, emptyStringFunc),
       usage: asFunc(options.usage, emptyStringFunc),
       className: asFunc(options.className, emptyStringFunc),
@@ -1324,6 +1355,11 @@ namespace Private {
    * A singleton empty dataset function.
    */
   const emptyDatasetFunc = () => ({});
+
+  /**
+   * A singleton undefined function
+   */
+  const undefinedFunc = () => undefined;
 
   /**
    * Cast a value or command func to a command func.

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -674,10 +674,10 @@ namespace CommandRegistry {
      * DEPRECATED: if set to a string value, the .icon field will function as
      * an alias for the .iconClass field, for backwards compatibility
      */
-    icon?: VirtualElement.IRenderer
+    icon?: VirtualElement.IRenderer | undefined
     /* <DEPRECATED> */ | string /* </DEPRECATED> */
     | CommandFunc<
-      VirtualElement.IRenderer
+      VirtualElement.IRenderer | undefined
       /* <DEPRECATED> */ | string /* </DEPRECATED> */
     >;
     
@@ -1197,8 +1197,7 @@ namespace Private {
     readonly mnemonic: CommandFunc<number>;
     
     readonly icon: CommandFunc<
-      VirtualElement.IRenderer
-      | undefined
+      VirtualElement.IRenderer | undefined
       /* <DEPRECATED> */ | string /* </DEPRECATED> */
     >;
     

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -194,21 +194,23 @@ class CommandRegistry {
   /**
    * Get the icon renderer for a specific command.
    *
+   * DEPRECATED: if set to a string value, the .icon field will
+   * function as an alias for the .iconClass field, for backwards
+   * compatibility. In the future when this is removed, the default
+   * return type will become undefined.
+   *
    * @param id - The id of the command of interest.
    *
    * @param args - The arguments for the command.
    *
-   * @returns The icon renderer for the command, or undefined if
-   *   the command is not registered.
-   *   
-   *   DEPRECATED: if set to a string value, the .icon field will function as
-   *   an alias for the .iconClass field, for backwards compatibility
+   * @returns The icon renderer for the command, or
+   *   an empty string if the command is not registered.
    */
   icon(id: string, args: ReadonlyPartialJSONObject = JSONExt.emptyObject): VirtualElement.IRenderer | undefined
   /* <DEPRECATED> */ | string /* </DEPRECATED> */
   {
     let cmd = this._commands[id];
-    return cmd ? cmd.icon.call(undefined, args) : undefined;
+    return cmd ? cmd.icon.call(undefined, args) : /* <DEPRECATED> */ '' /* </DEPRECATED> */ /* <FUTURE> undefined </FUTURE> */;
   }
 
   /**
@@ -1221,7 +1223,7 @@ namespace Private {
     let iconClass;
     
     /* <DEPRECATED> */
-    if (typeof options.icon === 'string') {
+    if (!(options.icon) || typeof options.icon === 'string') {
       // alias icon to iconClass
       iconClass = asFunc(options.iconClass || options.icon, emptyStringFunc);
       icon = iconClass;

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -275,13 +275,21 @@ describe('@lumino/commands', () => {
 
     describe('#icon()', () => {
 
+      const iconRenderer = {
+        render: (host: HTMLElement, options?: any) => {
+          const renderNode = document.createElement('div');
+          renderNode.className = 'p-render';
+          host.appendChild(renderNode);
+        }
+      };
+
       it('should get the icon for a specific command', () => {
         let cmd = {
           execute: (args: JSONObject) => { return args; },
-          icon: 'foo'
+          icon: iconRenderer
         };
         registry.addCommand('test', cmd);
-        expect(registry.icon('test')).to.equal('foo');
+        expect(registry.icon('test')).to.equal(iconRenderer);
       });
 
       it('should give the appropriate icon given arguments', () => {
@@ -302,6 +310,25 @@ describe('@lumino/commands', () => {
         expect(registry.icon('test')).to.equal('');
       });
 
+      /* <DEPRECATED> */
+      it('should be able to return a string value', () => {
+        let cmd = {
+          execute: (args: JSONObject) => { return args; },
+          icon: 'foo'
+        };
+        registry.addCommand('test', cmd);
+        expect(registry.icon('test')).to.equal('foo');
+      });
+
+      it('should alias .iconClass() if cmd.icon is unset', () => {
+        let cmd = {
+          execute: (args: JSONObject) => { return args; },
+          iconClass: 'foo'
+        };
+        registry.addCommand('test', cmd);
+        expect(registry.icon('test')).to.equal('foo');
+      });
+      /* </DEPRECATED> */
     });
 
     describe('#caption()', () => {

--- a/packages/commands/tsconfig.json
+++ b/packages/commands/tsconfig.json
@@ -40,6 +40,9 @@
     },
     {
       "path": "../signaling"
+    },
+    {
+      "path": "../virtualdom"
     }
   ]
 }

--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -34,13 +34,20 @@
     "clean": "rimraf lib && rimraf *.tsbuildinfo",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
+
     "test": "npm run test:firefox",
-    "test:chrome": "cd tests && karma start --browsers=Chrome",
-    "test:chrome-headless": "cd tests && karma start --browsers=ChromeHeadless",
-    "test:debug": "cd tests && karma start --browsers=Chrome --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
-    "test:debug:chrome-headless": "cd tests && karma start  --browsers=ChromeHeadless --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
-    "test:firefox": "cd tests && karma start --browsers=Firefox",
-    "test:ie": "cd tests && karma start --browsers=IE",
+    "test:chrome": "npm run test:nobrowser -- --browsers=Chrome",
+    "test:chrome-headless": "npm run test:nobrowser -- --browsers=ChromeHeadless",
+    "test:ie": "npm run test:nobrowser -- --browsers=IE",
+    "test:firefox": "npm run test:nobrowser -- --browsers=Firefox",
+    "test:nobrowser": "cd tests && karma start",
+
+    "test:debug": "npm run test:debug:firefox",
+    "test:debug:chrome-headless": "npm run test:debug:nobrowser -- --browsers=ChromeHeadless",
+    "test:debug:chrome": "npm run test:debug:nobrowser -- --browsers=Chrome",
+    "test:debug:firefox": "npm run test:debug:nobrowser -- --browsers=Firefox",
+    "test:debug:nobrowser": "cd tests && karma start --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
+
     "watch": "tsc --build --watch"
   },
   "dependencies": {

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -805,8 +805,11 @@ namespace VirtualElement {
      * a memory leak.
      *
      * @param host - the DOM element to be removed.
+     *
+     * @param options - Will be populated with the .attrs and .children fields
+     * set on the VirtualElement being unrendered.
      */
-    unrender?: (host: HTMLElement) => void;
+    unrender?: (host: HTMLElement, options?: {attrs?: ElementAttrs, children?: ReadonlyArray<VirtualNode>}) => void;
   };
 }
 
@@ -1313,7 +1316,7 @@ namespace Private {
 
       // Update the element content.
       if (newVNode.renderer) {
-        newVNode.renderer.render(currElem as HTMLElement);
+        newVNode.renderer.render(currElem as HTMLElement, {attrs: newVNode.attrs, children: newVNode.children});
       } else {
         updateContent(currElem as HTMLElement, oldVNode.children, newVNode.children);
       }
@@ -1342,7 +1345,7 @@ namespace Private {
 
       // recursively clean up host children
       if (oldNode.type === 'text') {} else if (oldNode.renderer && oldNode.renderer.unrender) {
-        oldNode.renderer.unrender(child!);
+        oldNode.renderer.unrender(child!, {attrs: oldNode.attrs, children: oldNode.children});
       } else {
         removeContent(child!, oldNode.children, 0, false);
       }

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -801,7 +801,8 @@ namespace VirtualElement {
      *
      * For example, if render calls `ReactDOM.render(..., host)`, then
      * there has to also be a corresponding implementation of unrender that
-     * calls `ReactDOM.unmountComponentAtNode(host)`.
+     * calls `ReactDOM.unmountComponentAtNode(host)` in order to prevent
+     * a memory leak.
      *
      * @param host - the DOM element to be removed.
      */

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -41,7 +41,7 @@
     "test:chrome-headless": "cd tests && karma start --browsers=ChromeHeadless",
     "test:debug": "npm run test:debug:firefox",
     "test:debug:chrome": "cd tests && karma start --browsers=Chrome --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
-    "test:debug:chrome-headless": "cd tests && karma start  --browsers=ChromeHeadless --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
+    "test:debug:chrome-headless": "cd tests && karma start --browsers=ChromeHeadless --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
     "test:debug:firefox": "cd tests && karma start --browsers=Firefox --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
     "test:firefox": "cd tests && karma start --browsers=Firefox",
     "test:ie": "cd tests && karma start --browsers=IE",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -36,15 +36,20 @@
     "clean": "rimraf lib && rimraf *.tsbuildinfo",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
+
     "test": "npm run test:firefox",
-    "test:chrome": "cd tests && karma start --browsers=Chrome",
-    "test:chrome-headless": "cd tests && karma start --browsers=ChromeHeadless",
+    "test:chrome": "npm run test:nobrowser -- --browsers=Chrome",
+    "test:chrome-headless": "npm run test:nobrowser -- --browsers=ChromeHeadless",
+    "test:ie": "npm run test:nobrowser -- --browsers=IE",
+    "test:firefox": "npm run test:nobrowser -- --browsers=Firefox",
+    "test:nobrowser": "cd tests && karma start",
+
     "test:debug": "npm run test:debug:firefox",
-    "test:debug:chrome": "cd tests && karma start --browsers=Chrome --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
-    "test:debug:chrome-headless": "cd tests && karma start --browsers=ChromeHeadless --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
-    "test:debug:firefox": "cd tests && karma start --browsers=Firefox --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
-    "test:firefox": "cd tests && karma start --browsers=Firefox",
-    "test:ie": "cd tests && karma start --browsers=IE",
+    "test:debug:chrome-headless": "npm run test:debug:nobrowser -- --browsers=ChromeHeadless",
+    "test:debug:chrome": "npm run test:debug:nobrowser -- --browsers=Chrome",
+    "test:debug:firefox": "npm run test:debug:nobrowser -- --browsers=Firefox",
+    "test:debug:nobrowser": "cd tests && karma start --singleRun=false --debug=true --browserNoActivityTimeout=10000000 --browserDisconnectTimeout=10000000",
+
     "watch": "tsc --build --watch"
   },
   "dependencies": {

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -588,6 +588,12 @@ namespace CommandPalette {
     readonly caption: string;
 
     /**
+     * The icon renderer for the command item.
+     */
+    readonly icon: VirtualElement.IRenderer | undefined
+    /* <DEPRECATED> */ | string /* </DEPRECATED> */;
+
+    /**
      * The icon class for the command item.
      */
     readonly iconClass: string;
@@ -779,7 +785,15 @@ namespace CommandPalette {
      */
     renderItemIcon(data: IItemRenderData): VirtualElement {
       let className = this.createIconClass(data);
-      return h.div({ className }, data.item.iconLabel);
+
+      /* <DEPRECATED> */
+      if (typeof data.item.icon === 'string') {
+        return h.div({className}, data.item.iconLabel);
+      }
+      /* </DEPRECATED> */
+
+      // if data.item.icon is undefined, it will be ignored
+      return h.div({className}, data.item.icon!, data.item.iconLabel);
     }
 
     /**
@@ -1444,6 +1458,15 @@ namespace Private {
      */
     get label(): string {
       return this._commands.label(this.command, this.args);
+    }
+
+    /**
+     * The icon renderer for the command item.
+     */
+    get icon(): VirtualElement.IRenderer | undefined
+    /* <DEPRECATED> */ | string /* </DEPRECATED> */
+    {
+      return this._commands.icon(this.command, this.args);
     }
 
     /**

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1765,7 +1765,15 @@ namespace Private {
       if (this.type === 'submenu' && this.submenu) {
         return this.submenu.title.icon;
       }
-      return undefined!;
+
+      /* <DEPRECATED> */
+      // alias to icon class if not otherwise defined
+      return this.iconClass;
+      /* </DEPRECATED> */
+
+      /* <FUTURE>
+      return undefined;
+      </FUTURE> */
     }
 
     /**

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1054,6 +1054,11 @@ namespace Menu {
     readonly iconLabel: string;
 
     /**
+     * The icon renderer for the menu item.
+     */
+    readonly iconRenderer?: VirtualElement.IRenderer;
+
+    /**
      * The display caption for the menu item.
      */
     readonly caption: string;
@@ -1167,7 +1172,8 @@ namespace Menu {
      */
     renderIcon(data: IRenderData): VirtualElement {
       let className = this.createIconClass(data);
-      return h.div({ className }, data.item.iconLabel);
+      // if iconRenderer is undefined, it will just be ignored
+      return h.div({ className }, data.item.iconRenderer!, data.item.iconLabel);
     }
 
     /**
@@ -1775,6 +1781,19 @@ namespace Private {
         return this.submenu.title.iconLabel;
       }
       return '';
+    }
+
+    /**
+     * The icon renderer for the menu item.
+     */
+    get iconRenderer(): VirtualElement.IRenderer {
+      if (this.type === 'command') {
+        return this._commands.iconRenderer(this.command, this.args);
+      }
+      if (this.type === 'submenu' && this.submenu) {
+        return this.submenu.title.iconRenderer;
+      }
+      return undefined!;
     }
 
     /**

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1039,9 +1039,10 @@ namespace Menu {
     readonly mnemonic: number;
 
     /**
-     * @deprecated Use `iconClass` instead.
+     * The icon renderer for the menu item.
      */
-    readonly icon: string;
+    readonly icon: VirtualElement.IRenderer | undefined
+    /* <DEPRECATED> */ | string /* </DEPRECATED> */;
 
     /**
      * The icon class for the menu item.
@@ -1052,11 +1053,6 @@ namespace Menu {
      * The icon label for the menu item.
      */
     readonly iconLabel: string;
-
-    /**
-     * The icon renderer for the menu item.
-     */
-    readonly iconRenderer?: VirtualElement.IRenderer;
 
     /**
      * The display caption for the menu item.
@@ -1172,8 +1168,15 @@ namespace Menu {
      */
     renderIcon(data: IRenderData): VirtualElement {
       let className = this.createIconClass(data);
-      // if iconRenderer is undefined, it will just be ignored
-      return h.div({ className }, data.item.iconRenderer!, data.item.iconLabel);
+
+      /* <DEPRECATED> */
+      if (typeof data.item.icon === 'string') {
+        return h.div({className}, data.item.iconLabel);
+      }
+      /* </DEPRECATED> */
+
+      // if data.item.icon is undefined, it will be ignored
+      return h.div({className}, data.item.icon!, data.item.iconLabel);
     }
 
     /**
@@ -1751,10 +1754,18 @@ namespace Private {
     }
 
     /**
-     * @deprecated Use `iconClass` instead.
+     * The icon renderer for the menu item.
      */
-    get icon(): string {
-      return this.iconClass;
+    get icon(): VirtualElement.IRenderer | undefined 
+    /* <DEPRECATED> */ | string /* </DEPRECATED> */
+    {
+      if (this.type === 'command') {
+        return this._commands.icon(this.command, this.args);
+      }
+      if (this.type === 'submenu' && this.submenu) {
+        return this.submenu.title.icon;
+      }
+      return undefined!;
     }
 
     /**
@@ -1783,18 +1794,6 @@ namespace Private {
       return '';
     }
 
-    /**
-     * The icon renderer for the menu item.
-     */
-    get iconRenderer(): VirtualElement.IRenderer {
-      if (this.type === 'command') {
-        return this._commands.iconRenderer(this.command, this.args);
-      }
-      if (this.type === 'submenu' && this.submenu) {
-        return this.submenu.title.iconRenderer;
-      }
-      return undefined!;
-    }
 
     /**
      * The display caption for the menu item.

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1756,7 +1756,7 @@ namespace Private {
     /**
      * The icon renderer for the menu item.
      */
-    get icon(): VirtualElement.IRenderer | undefined 
+    get icon(): VirtualElement.IRenderer | undefined
     /* <DEPRECATED> */ | string /* </DEPRECATED> */
     {
       if (this.type === 'command') {

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -787,7 +787,15 @@ namespace MenuBar {
      */
     renderIcon(data: IRenderData): VirtualElement {
       let className = this.createIconClass(data);
-      return h.div({ className }, data.title.iconLabel);
+
+      /* <DEPRECATED> */
+      if (typeof data.title.icon === 'string') {
+        return h.div({className}, data.title.iconLabel);
+      }
+      /* </DEPRECATED> */
+
+      // if data.title.icon is undefined, it will be ignored
+      return h.div({className}, data.title.icon!, data.title.iconLabel);
     }
 
     /**

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1360,7 +1360,14 @@ namespace TabBar {
       const { title } = data;
       let className = this.createIconClass(data);
 
-      return h.div({className}, title.iconRenderer, title.iconLabel);
+      /* <DEPRECATED> */
+      if (typeof title.icon === 'string') {
+        return h.div({className}, title.iconLabel);
+      }
+      /* </DEPRECATED> */
+
+      // if title.icon is undefined, it will be ignored
+      return h.div({className}, title.icon!, title.iconLabel);
     }
 
     /**

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -38,7 +38,7 @@ class Title<T> {
       this._mnemonic = options.mnemonic;
     }
     if (options.icon !== undefined) {
-      this._iconClass = options.icon;
+      this.icon = options.icon;
     }
     if (options.iconClass !== undefined) {
       this._iconClass = options.iconClass;
@@ -47,7 +47,7 @@ class Title<T> {
       this._iconLabel = options.iconLabel;
     }
     if (options.iconRenderer !== undefined) {
-      this._iconRenderer = options.iconRenderer;
+      this._icon = options.iconRenderer;
     }
     if (options.caption !== undefined) {
       this._caption = options.caption;
@@ -116,17 +116,52 @@ class Title<T> {
   }
 
   /**
-   * @deprecated Use `iconClass` instead.
+   * Get the icon renderer for the title.
+   *
+   * #### Notes
+   * The default value is undefined.
+   *
+   * DEPRECATED: if set to a string value, the .icon field will function as
+   * an alias for the .iconClass field, for backwards compatibility
    */
-  get icon(): string {
-    return this.iconClass;
+  get icon(): VirtualElement.IRenderer | string | undefined {
+    /* <DEPRECATED> */
+    if (this._icon === null) {
+      // only alias .iconClass if ._icon has been explicitly nulled
+      return this.iconClass
+    }
+    /* </DEPRECATED> */
+
+    return this._icon;
   }
 
   /**
-   * @deprecated Use `iconClass` instead.
+   * Set the icon renderer for the title.
+   *
+   * #### Notes
+   * A renderer is an object that supplies a render and unrender function.
+   *
+   * DEPRECATED: if set to a string value, the .icon field will function as
+   * an alias for the .iconClass field, for backwards compatibility
    */
-  set icon(value: string) {
-    this.iconClass = value;
+  set icon(value: VirtualElement.IRenderer | string | undefined ) {
+    /* <DEPRECATED> */
+    if (typeof value === "string") {
+      // when ._icon is null, the .icon getter will alias .iconClass
+      this._icon = null;
+      this.iconClass = value;
+    } else {
+    /* </DEPRECATED> */
+
+      if (this._icon === value) {
+        return;
+      }
+      this._icon = value;
+      this._changed.emit(undefined);
+
+    /* <DEPRECATED> */
+    }
+    /* </DEPRECATED> */
   }
 
   /**
@@ -178,27 +213,17 @@ class Title<T> {
   }
 
   /**
-   * Get the icon renderer for the title.
-   *
-   * #### Notes
-   * The default value is undefined.
+   * @deprecated Use `icon` instead.
    */
-  get iconRenderer(): VirtualElement.IRenderer {
-    return this._iconRenderer;
+  get iconRenderer(): VirtualElement.IRenderer | undefined {
+    return this._icon || undefined;
   }
 
   /**
-   * Set the icon renderer for the title.
-   *
-   * #### Notes
-   * A renderer is an object that supplies a render and unrender function.
+   * @deprecated Use `icon` instead.
    */
-  set iconRenderer(value: VirtualElement.IRenderer) {
-    if (this._iconRenderer === value) {
-      return;
-    }
-    this._iconRenderer = value;
-    this._changed.emit(undefined);
+  set iconRenderer(value: VirtualElement.IRenderer | undefined) {
+    this.icon = value;
   }
 
   /**
@@ -297,9 +322,9 @@ class Title<T> {
   private _label = '';
   private _caption = '';
   private _mnemonic = -1;
+  private _icon: VirtualElement.IRenderer | null | undefined;
   private _iconClass = '';
   private _iconLabel = '';
-  private _iconRenderer: VirtualElement.IRenderer;
   private _className = '';
   private _closable = false;
   private _dataset: Title.Dataset;
@@ -339,9 +364,12 @@ namespace Title {
     mnemonic?: number;
 
     /**
-     * @deprecated Use `iconClass` instead.
+     * The icon renderer for the title.
+     *
+     * DEPRECATED: if set to a string value, the .icon field will function as
+     * an alias for the .iconClass field, for backwards compatibility
      */
-    icon?: string;
+    icon?: VirtualElement.IRenderer | string;
 
     /**
      * The icon class name for the title.
@@ -354,8 +382,7 @@ namespace Title {
     iconLabel?: string;
 
     /**
-     * An object that supplies render and unrender functions used
-     * to create and cleanup the icon of the title.
+     * @deprecated Use `icon` instead.
      */
     iconRenderer?: VirtualElement.IRenderer;
 

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -52,6 +52,14 @@ class Title<T> {
       }
       /* </DEPRECATED> */
     }
+
+    /* <DEPRECATED> */
+    else {
+      // if unset, default to aliasing .iconClass
+      this._icon = null;
+    }
+    /* </DEPRECATED> */
+
     if (options.iconClass !== undefined) {
       this._iconClass = options.iconClass;
     }

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -124,7 +124,9 @@ class Title<T> {
    * DEPRECATED: if set to a string value, the .icon field will function as
    * an alias for the .iconClass field, for backwards compatibility
    */
-  get icon(): VirtualElement.IRenderer | string | undefined {
+  get icon(): VirtualElement.IRenderer| undefined
+  /* <DEPRECATED> */ | string /* </DEPRECATED> */
+  {
     /* <DEPRECATED> */
     if (this._icon === null) {
       // only alias .iconClass if ._icon has been explicitly nulled
@@ -144,7 +146,9 @@ class Title<T> {
    * DEPRECATED: if set to a string value, the .icon field will function as
    * an alias for the .iconClass field, for backwards compatibility
    */
-  set icon(value: VirtualElement.IRenderer | string | undefined ) {
+  set icon(value: VirtualElement.IRenderer | undefined
+  /* <DEPRECATED> */ | string /* </DEPRECATED> */
+  ) {
     /* <DEPRECATED> */
     if (typeof value === "string") {
       // when ._icon is null, the .icon getter will alias .iconClass
@@ -153,11 +157,11 @@ class Title<T> {
     } else {
     /* </DEPRECATED> */
 
-      if (this._icon === value) {
-        return;
-      }
-      this._icon = value;
-      this._changed.emit(undefined);
+    if (this._icon === value) {
+      return;
+    }
+    this._icon = value;
+    this._changed.emit(undefined);
 
     /* <DEPRECATED> */
     }

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -38,7 +38,19 @@ class Title<T> {
       this._mnemonic = options.mnemonic;
     }
     if (options.icon !== undefined) {
-      this.icon = options.icon;
+      /* <DEPRECATED> */
+      if (typeof options.icon === "string") {
+        // when ._icon is null, the .icon getter will alias .iconClass
+        this._icon = null;
+        this._iconClass = options.icon;
+      } else {
+      /* </DEPRECATED> */
+
+      this._icon = options.icon;
+
+      /* <DEPRECATED> */
+      }
+      /* </DEPRECATED> */
     }
     if (options.iconClass !== undefined) {
       this._iconClass = options.iconClass;

--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -338,7 +338,10 @@ class Title<T> {
   private _label = '';
   private _caption = '';
   private _mnemonic = -1;
-  private _icon: VirtualElement.IRenderer | null | undefined;
+
+  private _icon: VirtualElement.IRenderer | undefined
+  /* <DEPRECATED> */ | null /* </DEPRECATED> */;
+
   private _iconClass = '';
   private _iconLabel = '';
   private _className = '';

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1297,10 +1297,17 @@ describe('@lumino/widgets', () => {
           expect(node.classList.contains('lm-mod-closable')).to.equal(true);
           expect(node.title).to.equal(title.caption);
 
-          let icon = node.getElementsByClassName('lm-TabBar-tabIcon')[0] as HTMLElement;
           let label = node.getElementsByClassName('lm-TabBar-tabLabel')[0] as HTMLElement;
-          expect(icon.classList.contains(title.icon)).to.equal(true);
           expect(label.textContent).to.equal(title.label);
+
+          let icon = node.getElementsByClassName('lm-TabBar-tabIcon')[0] as HTMLElement;
+          expect(icon.classList.contains(title.iconClass)).to.equal(true);
+
+          /* <DEPRECATED> */
+          // since a string was assigned to .icon, it should alias .iconClass
+          expect(icon.classList.contains(title.icon as string)).to.equal(true);
+          expect(title.icon).to.equal(title.iconClass);
+          /* </DEPRECATED> */
         });
 
       });
@@ -1312,7 +1319,13 @@ describe('@lumino/widgets', () => {
           let vNode = renderer.renderIcon({ title, current: true, zIndex: 1 });
           let node = VirtualDOM.realize(vNode as VirtualElement);
           expect(node.className).to.contain('lm-TabBar-tabIcon');
-          expect(node.classList.contains(title.icon)).to.equal(true);
+          expect(node.classList.contains(title.iconClass)).to.equal(true);
+
+          /* <DEPRECATED> */
+          // make sure that icon and iconClass match
+          expect(node.classList.contains(title.icon as string)).to.equal(true);
+          expect(title.icon).to.equal(title.iconClass);
+          /* </DEPRECATED> */
         });
 
       });
@@ -1383,7 +1396,13 @@ describe('@lumino/widgets', () => {
             title, current: true, zIndex: 1
           });
           expect(className).to.contain('lm-TabBar-tabIcon');
-          expect(className).to.contain(title.icon);
+          expect(className).to.contain(title.iconClass);
+
+          /* <DEPRECATED> */
+          // make sure that icon and iconClass match
+          expect(className).to.contain(title.icon as string);
+          expect(title.icon).to.equal(title.iconClass);
+          /* </DEPRECATED> */
         });
 
       });

--- a/packages/widgets/tests/src/title.spec.ts
+++ b/packages/widgets/tests/src/title.spec.ts
@@ -210,6 +210,11 @@ describe('@lumino/widgets', () => {
         // when switched to string, should alias .iconClass
         expect(title.icon).to.equal(title.iconClass);
       });
+
+      it('should alias .iconClass if unset', () => {
+        let title = new Title({ owner, iconClass: 'foo' });
+        expect(title.icon).to.equal('foo');
+      });
       /* </DEPRECATED> */
 
     });

--- a/packages/widgets/tests/src/title.spec.ts
+++ b/packages/widgets/tests/src/title.spec.ts
@@ -143,6 +143,14 @@ describe('@lumino/widgets', () => {
 
     describe('#icon', () => {
 
+      const iconRenderer = {
+        render: (host: HTMLElement, options?: any) => {
+          const renderNode = document.createElement('div');
+          renderNode.className = 'p-render';
+          host.appendChild(renderNode);
+        }
+      };
+
       it('should default to an empty string', () => {
         let title = new Title({ owner });
         expect(title.icon).to.equal('');
@@ -180,6 +188,29 @@ describe('@lumino/widgets', () => {
         title.icon = 'foo';
         expect(called).to.equal(false);
       });
+
+      /* <DEPRECATED> */
+      it('should be able to switch string => renderer', () => {
+        let title = new Title({ owner, icon: 'foo' });
+        expect(title.icon).to.equal('foo');
+
+        // when initialized with string, should alias .iconClass
+        expect(title.icon).to.equal(title.iconClass);
+
+        title.icon = iconRenderer;
+        expect(title.icon).to.equal(iconRenderer);
+      });
+
+      it('should be able to switch renderer => string', () => {
+        let title = new Title({ owner, icon: iconRenderer });
+        expect(title.icon).to.equal(iconRenderer);
+        title.icon = 'foo';
+        expect(title.icon).to.equal('foo');
+
+        // when switched to string, should alias .iconClass
+        expect(title.icon).to.equal(title.iconClass);
+      });
+      /* </DEPRECATED> */
 
     });
 


### PR DESCRIPTION
needed for jupyterlab/jupyterlab#7864

This PR has two goals:

- I recently got this bit of feedback from one of the `LabIcon` early adopters (@vidartf [via gitter](https://gitter.im/jupyterlab/jupyterlab?at=5e3d3ec7433e1d40399f5d07)):

    > by inspecting the lab source, I figured `iconRenderer` was the attribute to set

    He was talking about figuring out that `Title.iconRenderer` was the field you're supposed to pass a `LabIcon` object into. Which, fair point, it's pretty confusing that `LabIcon` gets passed into the `Foo.icon` field for all interfaces except those defined in Lumino. On top of that, `iconRenderer` as a name is kind of clunky and maybe a bit conceptually confusing. Given all that, I want to experiment with reclaiming the deprecated `Title.icon` field, and see if I can do so in a backwards compatible way

- Given that it's possible to reclaim `Title.icon`, I want to normalize the behavior of the `.icon` field in all of the relevant interfaces across Lumino, so that all icons in Lumino are able to use custom renderers. Once that's done, I'll be able to finally migrate the last few holdout icons in Jupyterlab to `LabIcon` and resolve the remaining issues with that (see jupyterlab/jupyterlab#7864)

There's also a minor fix to the custom renderer implementation in `virtualdom` that needs getting in (the `attrs` and `children` args currently aren't getting passed in to a custom renderer in a consistent fashion)