### PR TITLE
Fix broken links in polling package and signaling tests.

### DIFF
--- a/packages/polling/package.json
+++ b/packages/polling/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/luminojs/lumino.git"
+    "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
   "author": "A. T. Darian <git@darian.af>",

--- a/packages/signaling/tests/src/index.spec.ts
+++ b/packages/signaling/tests/src/index.spec.ts
@@ -122,6 +122,17 @@ describe('@lumino/signaling', () => {
         expect(handler.twoValue).to.equal(42);
       });
 
+      it('should handle connect after disconnect and emit', () => {
+        let obj = new TestObject();
+        let handler = new TestHandler();
+        let c1 = obj.one.connect(handler.onOne, handler);
+        expect(c1).to.equal(true);
+        obj.one.disconnect(handler.onOne, handler);
+        obj.one.emit(undefined);
+        let c2 = obj.one.connect(handler.onOne, handler);
+        expect(c2).to.equal(true);
+      });
+
     });
 
     describe('#disconnect()', () => {
@@ -173,6 +184,26 @@ describe('@lumino/signaling', () => {
         expect(handler1.oneCount).to.equal(0);
         expect(handler2.oneCount).to.equal(1);
         expect(handler3.oneCount).to.equal(2);
+      });
+
+      it('should handle disconnecting sender after receiver', () => {
+        let obj = new TestObject();
+        let handler = new TestHandler();
+        obj.one.connect(handler.onOne, handler);
+        Signal.disconnectReceiver(handler);
+        Signal.disconnectSender(obj);
+        obj.one.emit(undefined);
+        expect(handler.oneCount).to.equal(0);
+      });
+
+      it('should handle disconnecting receiver after sender', () => {
+        let obj = new TestObject();
+        let handler = new TestHandler();
+        obj.one.connect(handler.onOne, handler);
+        Signal.disconnectSender(obj);
+        Signal.disconnectReceiver(handler);
+        obj.one.emit(undefined);
+        expect(handler.oneCount).to.equal(0);
       });
 
     });
@@ -457,45 +488,6 @@ describe('@lumino/signaling', () => {
         expect(called).to.equal(true);
       });
 
-    });
-
-  });
-
-  context('https://github.com/luminojs/lumino-signaling/issues/5', () => {
-
-    it('should handle connect after disconnect and emit', () => {
-      let obj = new TestObject();
-      let handler = new TestHandler();
-      let c1 = obj.one.connect(handler.onOne, handler);
-      expect(c1).to.equal(true);
-      obj.one.disconnect(handler.onOne, handler);
-      obj.one.emit(undefined);
-      let c2 = obj.one.connect(handler.onOne, handler);
-      expect(c2).to.equal(true);
-    });
-
-  });
-
-  context('https://github.com/luminojs/lumino-signaling/issues/8', () => {
-
-    it('should handle disconnecting sender after receiver', () => {
-      let obj = new TestObject();
-      let handler = new TestHandler();
-      obj.one.connect(handler.onOne, handler);
-      Signal.disconnectReceiver(handler);
-      Signal.disconnectSender(obj);
-      obj.one.emit(undefined);
-      expect(handler.oneCount).to.equal(0);
-    });
-
-    it('should handle disconnecting receiver after sender', () => {
-      let obj = new TestObject();
-      let handler = new TestHandler();
-      obj.one.connect(handler.onOne, handler);
-      Signal.disconnectSender(obj);
-      Signal.disconnectReceiver(handler);
-      obj.one.emit(undefined);
-      expect(handler.oneCount).to.equal(0);
     });
 
   });


### PR DESCRIPTION
This PR removes references to broken links. The original signaling issues are lost and the polling URL was incorrect.