### PR TITLE
Constrain tabs to their source DockPanel

### DIFF
--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -516,7 +516,7 @@ class DockPanel extends Widget {
 
     // Show the drop indicator overlay and update the drop
     // action based on the drop target zone under the mouse.
-    if (this._showOverlay(event.clientX, event.clientY) === 'invalid') {
+    if (event.source !== this || this._showOverlay(event.clientX, event.clientY) === 'invalid') {
       event.dropAction = 'none';
     } else {
       event.dropAction = event.proposedAction;
@@ -970,6 +970,7 @@ class DockPanel extends Widget {
       mimeData, dragImage,
       proposedAction: 'move',
       supportedActions: 'move',
+      source: this
     });
 
     // Hide the tab node in the original tab.


### PR DESCRIPTION
Fixes #43.

This change constrains tabs in a DockPanel to their source DockPanel. It means that tabs cannot be dragged from one DockPanel and dropped in another one.

This allows using a DockPanel inside another DockPanel, but also two DockPanel side by side like this this example:

![dock-source](https://user-images.githubusercontent.com/591645/74608102-93272780-50de-11ea-99dd-3c04ceb99431.gif)

It is true that creating two (or more) DockPanel can lead to a convoluted UX in some cases, especially when they have the same importance, the same size, or are positioned side by side like in the example above.

However we can imagine having a much "smaller" DockPanel inside a larger web application, for example something similar to this gallery: https://raw.githack.com/hpcc-systems/Visualization/master/demos/gallery/gallery.html?./samples/layout

In that case a user would expect each DockPanel to be self-contained, and it should not be possible to drag a tab from one panel and drop it in another one.

This change adds this constraint by default, since it doesn't alter the case when only one DockPanel is used. But we can also consider making this an opt-in by adding a configurable option that would allow such behavior.