### PR TITLE
Added type search to command pallet search input

### DIFF
--- a/packages/default-theme/style/commandpalette.css
+++ b/packages/default-theme/style/commandpalette.css
@@ -26,12 +26,13 @@
   padding: 4px 6px;
   background: white;
   border: 1px solid #E0E0E0;
+  position: relative;
 }
 
 
 /* <DEPRECATED> */ .p-CommandPalette-input, /* </DEPRECATED> */
 .lm-CommandPalette-input {
-  width: 100%;
+  width: 92%;
   border: none;
   outline: none;
   font-size: 16px;

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -1035,6 +1035,7 @@ namespace Private {
     content.classList.add('p-CommandPalette-content');
     /* </DEPRECATED> */
     input.spellcheck = false;
+    input.type = 'search';
     wrapper.appendChild(input);
     search.appendChild(wrapper);
     node.appendChild(search);

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -202,6 +202,14 @@ class CommandPalette extends Widget {
    */
   refresh(): void {
     this._results = null;
+    if(this.inputNode.value !== '') {
+      let clear = this.node.getElementsByClassName('lm-close-icon')[0] as HTMLInputElement;
+      clear.style.display = 'inherit'
+    }
+    else {
+      let clear = this.node.getElementsByClassName('lm-close-icon')[0] as HTMLInputElement;
+      clear.style.display = 'none'
+    }
     this.update();
   }
 
@@ -335,6 +343,13 @@ class CommandPalette extends Widget {
   private _evtClick(event: MouseEvent): void {
     // Bail if the click is not the left button.
     if (event.button !== 0) {
+      return;
+    }
+
+    // Clear input if the target is clear button
+    if((event.target as HTMLElement).classList.contains("lm-close-icon")) {
+      this.inputNode.value = '';
+      this.refresh();
       return;
     }
 
@@ -1024,9 +1039,12 @@ namespace Private {
     let wrapper = document.createElement('div');
     let input = document.createElement('input');
     let content = document.createElement('ul');
+    let clear = document.createElement('button');
     search.className = 'lm-CommandPalette-search';
     wrapper.className = 'lm-CommandPalette-wrapper';
     input.className = 'lm-CommandPalette-input';
+    clear.className = 'lm-close-icon';
+
     content.className = 'lm-CommandPalette-content';
     /* <DEPRECATED> */
     search.classList.add('p-CommandPalette-search');
@@ -1035,8 +1053,8 @@ namespace Private {
     content.classList.add('p-CommandPalette-content');
     /* </DEPRECATED> */
     input.spellcheck = false;
-    input.type = 'search';
     wrapper.appendChild(input);
+    wrapper.appendChild(clear);
     search.appendChild(wrapper);
     node.appendChild(search);
     node.appendChild(content);

--- a/packages/widgets/style/commandpalette.css
+++ b/packages/widgets/style/commandpalette.css
@@ -76,3 +76,30 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+
+.lm-close-icon {
+	border:1px solid transparent;
+  background-color: transparent;
+  position: absolute;
+	z-index:1;
+	right:3%;
+	top: 0;
+	bottom: 0;
+	margin: auto;
+	padding: 7px 0;
+	display: none;
+	vertical-align: middle;
+  outline: 0;
+  cursor: pointer;
+}
+.lm-close-icon:after {
+	content: "X";
+	display: block;
+	width: 15px;
+	height: 15px;
+	text-align: center;
+	color:#000;
+	font-weight: normal;
+	font-size: 12px;
+	cursor: pointer;
+}


### PR DESCRIPTION
Fixes - #56 
Jupyter Lab Issue - [6617](https://github.com/jupyterlab/jupyterlab/issues/6617)

Added type search to input to show clear search icon. It will solve usability issue by user should be able to use mouse click to clear search text.

<img width="218" alt="searchwithclear1" src="https://user-images.githubusercontent.com/4777119/75339031-bf4c6080-58b5-11ea-9bf7-1e38a128144c.PNG">
