### PR TITLE
Add an external examples section, with the vue example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ Lumino is Jupyter project and follows the Jupyter
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) to know how to contribute and set up
 a development environment.
+
+## External Examples
+
+- [Using Lumino in a Vue.js application](https://github.com/kinow/vue-lumino)


### PR DESCRIPTION
Hi,

Adding an external examples section to readme, with the link to an example with Lumino + Vue.js.

Ref: https://github.com/jupyterlab/lumino/issues/3#issuecomment-596542091

Cheers
Bruno