### PR TITLE
Tell bundlers to not package a crypto module for the browser.

### DIFF
--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -61,5 +61,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "browser": {
+    "crypto": false
   }
 }


### PR DESCRIPTION
In Webpack 5, builtin nodejs modules are no longer automatically polyfilled. This means that any project packaging lumino coreutils with webpack 5 will need to include either a polyfill or tell webpack to not package the module.

Looking at the current state of polyfills, the webpack-recommended package, crypto-browserify, does not implement the needed randomBytes (https://github.com/crypto-browserify/crypto-browserify/blob/460a13b5bf1e4ea60dc995906ba0543f7933a32b/example/bundle.js#L408). Additionally, “modern” browsers (FF 34, Chrome 37, Safari 6.1, IE 11) will use their own native crypto functions, so we do not need a module. Also, in a browser, polyfills for the crypto modules should implement the window.crypto interface rather than providing a module replacing the npm module.

In short, for a browser, Lumino should be using the browser api, and not trying to package a replacement for the nodejs module ‘crypto’.

See https://github.com/defunctzombie/package-browser-field-spec for the spec for this package.json field.