### PR TITLE
Fix `disconnectAll` implementation.

### DIFF
--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -522,19 +522,10 @@ namespace Private {
    */
   export
   function disconnectAll(object: any): void {
-    // Clear and cleanup any receiver connections.
-    let receivers = receiversForSender.get(object);
-    if (receivers && receivers.length > 0) {
-      each(receivers, connection => { connection.signal = null; });
-      scheduleCleanup(receivers);
-    }
-
-    // Clear and cleanup any sender connections.
-    let senders = sendersForReceiver.get(object);
-    if (senders && senders.length > 0) {
-      each(senders, connection => { connection.signal = null; });
-      scheduleCleanup(senders);
-    }
+    // Remove all connections where the given object is the sender.
+    disconnectSender(object);
+    // Remove all connections where the given object is the receiver.
+    disconnectReceiver(object);
   }
 
   /**


### PR DESCRIPTION
Let `A` be an object which sends and receives signals, `B` an object which sends a signal received by `A`.

References to the object `A` are present as:

1. `signal.sender` property of the connections associated to `A` in the `receiversForSender` `WeakMap`.

1. `thisArg` property of the connections associated to `A` in the `sendersForReceiver` `WeakMap`.

1. `thisArg` property of a connection associated to `B` in the `receiversForSender` `WeakMap`.

Calling `Signal.ClearAll` on `A`, when `A` is disposed, removes the references mentioned in the points 1 and 2, but does'not remove the reference mentioned in 3. This leads to memory leaks ([see here][1]).

This PR should fix this issue.

Regards

[1]: https://github.com/jupyterlab/jupyterlab/issues/8371