### PR TITLE
Revert "chore(build): Bump Typescript to 3.9.2"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 dist
 lib
 types
-types-3.4
 node_modules
 build
 review/api/temp

--- a/examples/example-datagrid/package.json
+++ b/examples/example-datagrid/package.json
@@ -18,7 +18,7 @@
     "file-loader": "^5.0.2",
     "rimraf": "^2.5.2",
     "style-loader": "^1.0.2",
-    "typescript": "~3.9.2",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   }

--- a/examples/example-datastore/package.json
+++ b/examples/example-datastore/package.json
@@ -27,7 +27,7 @@
     "file-loader": "^5.0.2",
     "rimraf": "^2.5.2",
     "style-loader": "^1.0.2",
-    "typescript": "~3.9.2",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3"
   }
 }

--- a/examples/example-datastore/src/messages.ts
+++ b/examples/example-datastore/src/messages.ts
@@ -38,7 +38,7 @@ namespace WSAdapterMessages {
    * A base message for the patch server.
    */
   export
-  interface IBaseMessage extends Partial<JSONObject> {
+  type IBaseMessage = JSONObject & {
     msgId: string;
     msgType: (
       'storeid-request' | 'storeid-reply'|
@@ -48,13 +48,13 @@ namespace WSAdapterMessages {
       'history-request' | 'history-reply' |
       'fetch-transaction-request' | 'fetch-transaction-reply'
     );
-    parentId?: string;
+    parentId: undefined;
 
     readonly content: ReadonlyJSONObject;
   }
 
   export
-  interface IBaseReplyMessage extends IBaseMessage {
+  type IBaseReplyMessage = IBaseMessage & {
     parentId: string;
   }
 
@@ -71,7 +71,7 @@ namespace WSAdapterMessages {
    * A reply from the server containing a unique store ID.
    */
   export
-  interface IStoreIdMessageReply extends IBaseReplyMessage {
+  type IStoreIdMessageReply = IBaseReplyMessage & {
     msgType: 'storeid-reply';
     content: {
       readonly storeId: number

--- a/examples/example-datastore/src/wsbase.ts
+++ b/examples/example-datastore/src/wsbase.ts
@@ -21,7 +21,7 @@ import {
  * Abstract base for a class that sends/receives messages over websocket.
  */
 export
-abstract class WSConnection<T extends Partial<JSONValue>, U extends Partial<JSONValue>> implements IDisposable {
+abstract class WSConnection<T extends JSONValue, U extends JSONValue> implements IDisposable {
   /**
    * Create a new websocket based connection.
    */

--- a/examples/example-dockpanel/package.json
+++ b/examples/example-dockpanel/package.json
@@ -20,7 +20,7 @@
     "rimraf": "^2.5.2",
     "source-map-loader": "0.2.4",
     "style-loader": "^1.0.2",
-    "typescript": "~3.9.2",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   }

--- a/packages/algorithm/package.json
+++ b/packages/algorithm/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -55,7 +46,6 @@
     "@microsoft/api-extractor": "^7.6.0",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -70,8 +60,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/algorithm/tdoptions.json
+++ b/packages/algorithm/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/algorithm",
   "baseUrl": ".",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -61,7 +52,6 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -76,8 +66,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/application/tdoptions.json
+++ b/packages/application/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/application",
   "baseUrl": ".",

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -59,7 +50,6 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -74,8 +64,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/collections/tdoptions.json
+++ b/packages/collections/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "out": "../../docs/api/collections",
   "baseUrl": ".",
   "paths": {

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -72,7 +63,6 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "es6-promise": "^4.0.5",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
@@ -89,8 +79,8 @@
     "simulate-event": "^1.4.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/commands/tdoptions.json
+++ b/packages/commands/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/commands",
   "baseUrl": ".",

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -59,7 +50,6 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "es6-promise": "^4.0.5",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
@@ -75,8 +65,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/coreutils/src/json.ts
+++ b/packages/coreutils/src/json.ts
@@ -27,7 +27,7 @@ type JSONValue = JSONPrimitive | JSONObject | JSONArray;
  * A type definition for a JSON object.
  */
 export
-interface JSONObject { [key: string]: JSONValue | ReadonlyJSONValue; }
+interface JSONObject { [key: string]: JSONValue; }
 
 
 /**

--- a/packages/coreutils/tdoptions.json
+++ b/packages/coreutils/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/coreutils",
   "baseUrl": ".",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -16,21 +16,13 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jupyterlab/lumino.git"
@@ -38,8 +30,7 @@
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
+    "build": "tsc --build && rollup -c",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "docs": "typedoc --options tdoptions.json src",
     "watch": "tsc --build --watch"
@@ -56,7 +47,6 @@
     "@lumino/widgets": "^1.13.1"
   },
   "devDependencies": {
-    "downlevel-dts": "^0.4.0",
     "rimraf": "^2.5.2",
     "rollup": "^1.29.0",
     "rollup-plugin-node-resolve": "^5.2.0",
@@ -64,8 +54,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2"
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/datagrid/tdoptions.json
+++ b/packages/datagrid/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/datagrid",
   "baseUrl": ".",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -18,21 +18,13 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jupyterlab/lumino.git"
@@ -40,8 +32,7 @@
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
+    "build": "tsc --build && rollup -c",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "docs": "typedoc --options tdoptions.json src",
     "test": "npm run test:firefox",
@@ -60,7 +51,6 @@
     "@lumino/signaling": "^1.4.1"
   },
   "devDependencies": {
-    "downlevel-dts": "^0.4.0",
     "rimraf": "^2.5.2",
     "rollup": "^1.29.0",
     "rollup-plugin-node-resolve": "^5.2.0",
@@ -68,8 +58,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack-cli": "^3.3.10"
   },
   "publishConfig": {

--- a/packages/datastore/tdoptions.json
+++ b/packages/datastore/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/datastore",
   "baseUrl": ".",

--- a/packages/datastore/tests/package.json
+++ b/packages/datastore/tests/package.json
@@ -22,7 +22,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.2",
     "rimraf": "^2.5.2",
-    "typescript": "~3.9.2",
+    "typescript": "~3.6.4",
     "webpack": "^2.2.1"
   },
   "scripts": {

--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -60,7 +51,6 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -75,8 +65,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/disposable/tdoptions.json
+++ b/packages/disposable/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/disposable",
   "baseUrl": ".",

--- a/packages/domutils/package.json
+++ b/packages/domutils/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -56,7 +47,6 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -71,8 +61,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/domutils/tdoptions.json
+++ b/packages/domutils/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/domutils",
   "baseUrl": ".",

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -22,7 +22,6 @@
     "dist/*",
     "src/*",
     "types/*",
-    "types-3.4/*",
     "style/*.css"
   ],
   "main": "dist/index.js",
@@ -30,20 +29,12 @@
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "style": "style/index.css",
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -81,8 +72,8 @@
     "style-loader": "^1.0.2",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/dragdrop/tdoptions.json
+++ b/packages/dragdrop/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/dragdrop",
   "baseUrl": ".",

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -56,7 +47,6 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -72,8 +62,8 @@
     "simulate-event": "^1.4.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/keyboard/tdoptions.json
+++ b/packages/keyboard/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/keyboard",
   "baseUrl": ".",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -61,7 +52,6 @@
     "@types/mocha": "^2.2.39",
     "@types/node": "^12.12.17",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -76,8 +66,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/messaging/tdoptions.json
+++ b/packages/messaging/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/messaging",
   "baseUrl": ".",

--- a/packages/polling/package.json
+++ b/packages/polling/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -62,7 +53,6 @@
     "@types/mocha": "^2.2.39",
     "@types/node": "^12.12.17",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -77,8 +67,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.12.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/polling/tdoptions.json
+++ b/packages/polling/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/disposable",
   "baseUrl": ".",

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -56,7 +47,6 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -71,8 +61,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/properties/tdoptions.json
+++ b/packages/properties/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/properties",
   "baseUrl": ".",

--- a/packages/signaling/package.json
+++ b/packages/signaling/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -59,7 +50,6 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -74,8 +64,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/signaling/tdoptions.json
+++ b/packages/signaling/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/signaling",
   "baseUrl": ".",

--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -21,27 +21,18 @@
   "files": [
     "dist/*",
     "src/*",
-    "types/*",
-    "types-3.4/*"
+    "types/*"
   ],
   "main": "dist/index.js",
   "module": "dist/index.es6",
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -66,7 +57,6 @@
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
     "chai": "^3.5.0",
-    "downlevel-dts": "^0.4.0",
     "karma": "^4.4.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^1.0.0",
@@ -81,8 +71,8 @@
     "rollup-plugin-sourcemaps": "^0.5.0",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -1509,7 +1509,7 @@ namespace Private {
     let elemStyle = element.style;
     let name: keyof ElementInlineStyle;
     for (name in style) {
-      (elemStyle as any)[name] = style[name];
+      elemStyle[name] = style[name];
     }
   }
 
@@ -1521,12 +1521,12 @@ namespace Private {
     let name: keyof ElementInlineStyle;
     for (name in oldStyle) {
       if (!(name in newStyle)) {
-        (elemStyle as any)[name] = '';
+        elemStyle[name] = '';
       }
     }
     for (name in newStyle) {
       if (oldStyle[name] !== newStyle[name]) {
-        (elemStyle as any)[name] = newStyle[name];
+        elemStyle[name] = newStyle[name];
       }
     }
   }

--- a/packages/virtualdom/tdoptions.json
+++ b/packages/virtualdom/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/virtualdom",
   "baseUrl": ".",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -22,7 +22,6 @@
     "dist/*",
     "src/*",
     "types/*",
-    "types-3.4/*",
     "style/*.css"
   ],
   "main": "dist/index.js",
@@ -30,20 +29,12 @@
   "unpkg": "dist/index.min.js",
   "jsdelivr": "dist/index.min.js",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "<3.8": {
-      "*": [
-        "types-3.4/index.d.ts"
-      ]
-    }
-  },
   "style": "style/index.css",
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "minimize": "terser dist/index.js -c -m --source-map \"content='dist/index.js.map',url='index.min.js.map'\" -o dist/index.min.js",
-    "build": "tsc --build && npm run gen-legacy-types && rollup -c",
+    "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
-    "gen-legacy-types": "downlevel-dts ./types ./types-3.4",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "clean:test": "rimraf tests/build",
     "docs": "typedoc --options tdoptions.json src",
@@ -97,8 +88,8 @@
     "style-loader": "^1.0.2",
     "terser": "^4.6.2",
     "tslib": "1.10.0",
-    "typedoc": "~0.17.7",
-    "typescript": "~3.9.2",
+    "typedoc": "~0.15.0",
+    "typescript": "~3.6.4",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/widgets/tdoptions.json
+++ b/packages/widgets/tdoptions.json
@@ -2,7 +2,7 @@
   "excludeNotExported": true,
   "mode": "file",
   "target": "es5",
-  "module": "es6",
+  "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
   "out": "../../docs/api/widgets",
   "baseUrl": ".",

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,7 +940,14 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/glob@^7.1.1":
+"@types/fs-extra@^5.0.3":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.1.0.tgz#2a325ef97901504a3828718c390d34b8426a10a1"
+  integrity sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -949,12 +956,34 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/handlebars@^4.0.38":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.1.0.tgz#3fcce9bf88f85fe73dc932240ab3fb682c624850"
+  integrity sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==
+  dependencies:
+    handlebars "*"
+
+"@types/highlight.js@^9.12.3":
+  version "9.12.3"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
+  integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
+
+"@types/lodash@^4.14.110":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
+"@types/marked@^0.4.0":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.4.2.tgz#64a89e53ea37f61cc0f3ee1732c555c2dbf6452f"
+  integrity sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==
+
 "@types/mime-types@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
   integrity sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=
 
-"@types/minimatch@*":
+"@types/minimatch@*", "@types/minimatch@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -989,6 +1018,14 @@
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
+    "@types/node" "*"
+
+"@types/shelljs@^0.8.0":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.6.tgz#45193a51df99e0f00513c39a2152832399783221"
+  integrity sha512-svx2eQS268awlppL/P8wgDLBrsDXdKznABHJcuqXyWpSKJgE1s2clXlBvAwbO/lehTmG06NtEWJRkAk4tAgenA==
+  dependencies:
+    "@types/glob" "*"
     "@types/node" "*"
 
 "@types/tern@*":
@@ -1488,6 +1525,13 @@ aws4@^1.8.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.0.tgz#24390e6ad61386b0a747265754d2a17219de862c"
   integrity sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==
+
+backbone@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
+  integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
+  dependencies:
+    underscore ">=1.8.3"
 
 backo2@1.0.2:
   version "1.0.2"
@@ -2914,14 +2958,6 @@ dot-prop@^4.1.1, dot-prop@^4.2.0:
   dependencies:
     is-obj "^1.0.0"
 
-downlevel-dts@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.4.0.tgz#43f9f649c8b137373d76b4ee396d5a0227c10ddb"
-  integrity sha512-nh5vM3n2pRhPwZqh0iWo5gpItPAYEGEWw9yd0YpI+lO60B7A3A6iJlxDbt7kKVNbqBXKsptL+jwE/Yg5Go66WQ==
-  dependencies:
-    shelljs "^0.8.3"
-    typescript "^3.8.0-dev.20200111"
-
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -3522,7 +3558,7 @@ fs-access@^1.0.0:
   dependencies:
     null-check "^1.0.0"
 
-fs-extra@^7.0.1, fs-extra@~7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1, fs-extra@~7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -3828,7 +3864,7 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-handlebars@^4.4.0:
+handlebars@*, handlebars@^4.0.6, handlebars@^4.4.0, handlebars@^4.5.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
   integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
@@ -3836,18 +3872,6 @@ handlebars@^4.4.0:
     neo-async "^2.6.0"
     optimist "^0.6.1"
     source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
-handlebars@^4.7.6:
-  version "4.7.6"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
-  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
-  dependencies:
-    minimist "^1.2.5"
-    neo-async "^2.6.0"
-    source-map "^0.6.1"
-    wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -3967,10 +3991,12 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@^10.0.0:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.0.3.tgz#5effcc58420f113f279a0badb8ac50c4be06e63b"
-  integrity sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ==
+highlight.js@^9.0.0, highlight.js@^9.17.1:
+  version "9.17.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.17.1.tgz#14a4eded23fd314b05886758bb906e39dd627f9a"
+  integrity sha512-TA2/doAur5Ol8+iM3Ov7qy3jYcr/QiJ2eDTdRF4dfbjG7AaaB99J5G+zSl11ljbl6cIcahgPY6SKb3sC3EJ0fw==
+  dependencies:
+    handlebars "^4.5.3"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -4596,6 +4622,11 @@ jju@~1.4.0:
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha1-o6vicYryQaKykE+EpiWXDzia4yo=
 
+jquery@^3.4.1:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
+  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+
 js-yaml@3.13.1, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
@@ -4926,7 +4957,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.2.1, lodash@^4.6.1, lodash@~4.17.15:
+lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.2.1, lodash@^4.6.1, lodash@~4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -5058,10 +5089,15 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.0.0.tgz#d35784245a04871e5988a491e28867362e941693"
-  integrity sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==
+marked@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
+  integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
+
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -5273,11 +5309,6 @@ minimist@1.2.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minimist@~0.0.1:
   version "0.0.10"
@@ -6582,7 +6613,7 @@ process@^0.11.1, process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.1, progress@^2.0.3:
+progress@^2.0.0, progress@^2.0.1, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -7356,19 +7387,10 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shelljs@^0.8.3:
+shelljs@^0.8.2, shelljs@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
   integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-shelljs@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
-  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -8192,43 +8214,80 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.10.1.tgz#eb27b7d689457c7ec843e47ec0d3e500581296a7"
-  integrity sha512-SuqAQI0CkwhqSJ2kaVTgl37cWs733uy9UGUqwtcds8pkFK8oRF4rZmCq+FXTGIb9hIUOu40rf5Kojg0Ha6akeg==
-  dependencies:
-    lunr "^2.3.8"
+typedoc-default-themes@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
+  integrity sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=
 
-typedoc@~0.17.7:
-  version "0.17.7"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.17.7.tgz#70797401140403a5f91589ed3f4f24c03841bf7a"
-  integrity sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==
+typedoc-default-themes@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.6.2.tgz#b36d8910987a40e5a80353b88e178c6ffa78f24b"
+  integrity sha512-+O+1aHjVIpDLsbkIDkZSNu+kutqmg7WdzahT+4KwBC/95mUgAb0xkbwdPpEJEpRX0ov1UJoCmvEPb1/VHxnTuw==
   dependencies:
-    fs-extra "^8.1.0"
-    handlebars "^4.7.6"
-    highlight.js "^10.0.0"
-    lodash "^4.17.15"
+    backbone "^1.4.0"
+    jquery "^3.4.1"
     lunr "^2.3.8"
-    marked "1.0.0"
+    underscore "^1.9.1"
+
+typedoc@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.12.0.tgz#c5d606f52af29d841658e18d9faa1a72acf0e270"
+  integrity sha512-dsdlaYZ7Je8JC+jQ3j2Iroe4uyD0GhqzADNUVyBRgLuytQDP/g0dPkAw5PdM/4drnmmJjRzSWW97FkKo+ITqQg==
+  dependencies:
+    "@types/fs-extra" "^5.0.3"
+    "@types/handlebars" "^4.0.38"
+    "@types/highlight.js" "^9.12.3"
+    "@types/lodash" "^4.14.110"
+    "@types/marked" "^0.4.0"
+    "@types/minimatch" "3.0.3"
+    "@types/shelljs" "^0.8.0"
+    fs-extra "^7.0.0"
+    handlebars "^4.0.6"
+    highlight.js "^9.0.0"
+    lodash "^4.17.10"
+    marked "^0.4.0"
+    minimatch "^3.0.0"
+    progress "^2.0.0"
+    shelljs "^0.8.2"
+    typedoc-default-themes "^0.5.0"
+    typescript "3.0.x"
+
+typedoc@~0.15.0:
+  version "0.15.5"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.15.5.tgz#1dd2a15ed0caf284c2be674794a2a8b74e0f2383"
+  integrity sha512-AKXLtOUCLRlSTyfXQHYp3LFPy6RiFLnxnKS5z1jwQsYXmCPbHWuhmfgS264Es2hPMZjzvHqk/ZQDzCBpb49u6w==
+  dependencies:
+    "@types/minimatch" "3.0.3"
+    fs-extra "^8.1.0"
+    handlebars "^4.5.3"
+    highlight.js "^9.17.1"
+    lodash "^4.17.15"
+    marked "^0.7.0"
     minimatch "^3.0.0"
     progress "^2.0.3"
-    shelljs "^0.8.4"
-    typedoc-default-themes "^0.10.1"
+    shelljs "^0.8.3"
+    typedoc-default-themes "^0.6.2"
+    typescript "3.7.x"
 
-typescript@^3.8.0-dev.20200111, typescript@~3.9.2:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
-  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
+typescript@3.0.x:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
+  integrity sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==
+
+typescript@3.7.x, typescript@~3.7.2:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@~3.5.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@~3.7.2:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@~3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
+  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
 uglify-js@^3.1.4:
   version "3.7.2"
@@ -8252,6 +8311,11 @@ umask@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
   integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
+
+underscore@>=1.8.3, underscore@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -8582,11 +8646,6 @@ windows-release@^3.1.0:
   integrity sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==
   dependencies:
     execa "^1.0.0"
-
-wordwrap@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
- fixes #83

This reverts commit 36debf6f5e367dea8f4019e988b2d411f65bbf57.