### PR TITLE
Minimal alternative to #84 => reverts changes to JSONObject from 36debf6 while keeping typescript 3.9.2

### DIFF
--- a/packages/coreutils/src/json.ts
+++ b/packages/coreutils/src/json.ts
@@ -27,7 +27,7 @@ type JSONValue = JSONPrimitive | JSONObject | JSONArray;
  * A type definition for a JSON object.
  */
 export
-interface JSONObject { [key: string]: JSONValue | ReadonlyJSONValue; }
+interface JSONObject { [key: string]: JSONValue; }
 
 
 /**


### PR DESCRIPTION
fixes: #83

An attempt to fix #83 while keeping the bump to typescript 3.9.2