### PR TITLE
Have the DataGrid syncViewport when receiving a DataModel.ChangedArgs signal of type "rows-moved" or "columns-moved"

### DIFF
--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -2682,8 +2682,8 @@ class DataGrid extends Widget {
       this._repaintRegion('corner-header', r1, 0, r2, Infinity);
     }
 
-    // Schedule a repaint of the overlay.
-    this._repaintOverlay();
+    // Sync the viewport.
+    this._syncViewport();
   }
 
   /**
@@ -2740,8 +2740,8 @@ class DataGrid extends Widget {
       this._repaintRegion('corner-header', 0, c1, Infinity, c2);
     }
 
-    // Schedule a repaint of the overlay.
-    this._repaintOverlay();
+    // Sync the viewport.
+    this._syncViewport();
   }
 
   /**


### PR DESCRIPTION
Hi, my name is Logan McNichols. I am an intern for Jupyter Cal Poly, working with @kgoo124 and @ryuntalan to develop a tabular data editor powered by the DataGrid.

We noticed that submitting a `'rows-moved'` or `'columns-moved'` signal to the `DataGrid` does not seem to update it visually. I believe this is because, unlike the methods which handle adding or removing rows or columns, the methods `_onRowsMoved` and `_onColumnsMoved` do not call `_syncViewport() `.

This pull request would replace `_onRowsMoved` and `_onColumnsMoved` call to `_repaintOverlay` with a call to `_syncViewport`. It would also update the comments above these lines of code to reflect the change.

Fixes #93 