### PR TITLE
Change the Drag class's private method _moveDragImage to a public method moveDragImage.

### DIFF
--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -286,7 +286,7 @@ class Drag implements IDisposable {
    *
    * This is a no-op if there is no drag image element.
    */
-  moveDragImage(clientX: number, clientY: number): void {
+  protected moveDragImage(clientX: number, clientY: number): void {
     if (!this.dragImage) {
       return;
     }

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -282,6 +282,20 @@ class Drag implements IDisposable {
   }
 
   /**
+   * Move the drag image element to the specified location.
+   *
+   * This is a no-op if there is no drag image element.
+   */
+  moveDragImage(clientX: number, clientY: number): void {
+    if (!this.dragImage) {
+      return;
+    }
+    let style = this.dragImage.style;
+    style.top = `${clientY}px`;
+    style.left = `${clientX}px`;
+  }
+
+  /**
    * Handle the `'mousemove'` event for the drag object.
    */
   private _evtMouseMove(event: MouseEvent): void {
@@ -297,7 +311,7 @@ class Drag implements IDisposable {
 
     // Move the drag image to the specified client position. This is
     // performed *after* dispatching to prevent unnecessary reflows.
-    this._moveDragImage(event.clientX, event.clientY);
+    this.moveDragImage(event.clientX, event.clientY);
   }
 
   /**
@@ -467,20 +481,6 @@ class Drag implements IDisposable {
     style.top = `${clientY}px`;
     style.left = `${clientX}px`;
     document.body.appendChild(this.dragImage);
-  }
-
-  /**
-   * Move the drag image element to the specified location.
-   *
-   * This is a no-op if there is no drag image element.
-   */
-  private _moveDragImage(clientX: number, clientY: number): void {
-    if (!this.dragImage) {
-      return;
-    }
-    let style = this.dragImage.style;
-    style.top = `${clientY}px`;
-    style.left = `${clientX}px`;
   }
 
   /**


### PR DESCRIPTION
Hi, my name is Logan McNichols. I am an intern for Jupyter Cal Poly. I am working on a tabular data editor powered by the datagrid along with @kgoo124 and @ryuntalan.

We would like to use lumino's `Drag` class to create a column/row shadow which appears on a mouse click of a column/row header and is drag-able. The movement of this shadow can't just follow the cursor wherever it goes, but must be constrained to the bounds of the `DataGrid`. This PR would allow us to do this, by letting us extend `Drag` and make modifications to `moveDragImage`.

This PR would rename `_moveDragImage` to `moveDragImage` and update it's implementations to reflect this change. It would remove the **private** access modifier and relocate `moveDragImage` to the area where the other public methods are.

fixes #95

