### PR TITLE
Modified function spliceArray in datastore/src/listfield.ts so that it behaves like Array.splice on large inputs.

### DIFF
--- a/packages/datastore/src/listfield.ts
+++ b/packages/datastore/src/listfield.ts
@@ -681,7 +681,7 @@ namespace Private {
     for (let i = 0; i < n; i++, idx += size) {
       arr.splice(start + idx, 0, ...items.slice(idx, idx + size));
     }
-    arr.splice(idx, 0, ...items.slice(idx));
+    arr.splice(start + idx, 0, ...items.slice(idx));
     return deleted;
   }
 }

--- a/packages/datastore/src/listfield.ts
+++ b/packages/datastore/src/listfield.ts
@@ -679,7 +679,7 @@ namespace Private {
     let n = Math.floor(items.length / size);
     let idx = 0;
     for (let i = 0; i < n; i++, idx += size) {
-      arr.splice(idx, 0, ...items.slice(idx, size));
+      arr.splice(start + idx, 0, ...items.slice(idx, idx + size));
     }
     arr.splice(idx, 0, ...items.slice(idx));
     return deleted;

--- a/packages/datastore/tests/src/listfield.spec.ts
+++ b/packages/datastore/tests/src/listfield.spec.ts
@@ -395,7 +395,7 @@ describe('@lumino/datastore', () => {
       it('should handle large patches', () => {
         let previous = field.createValue();
         let metadata = field.createMetadata();
-        let values = new Array(2**6).fill(0);
+        let values = new Array(2*10**5).fill(0);
         // Create a patch
         let { patch } = field.applyUpdate({
             previous,
@@ -412,7 +412,7 @@ describe('@lumino/datastore', () => {
             metadata,
             patch
         });
-        expect(patched.value).to.eql(values);
+        expect(patched.value.length).to.eql(values.length);
       })
 
     });

--- a/packages/datastore/tests/src/listfield.spec.ts
+++ b/packages/datastore/tests/src/listfield.spec.ts
@@ -392,6 +392,29 @@ describe('@lumino/datastore', () => {
         expect(patchC3.value).to.eql([4]);
       });
 
+      it('should handle large patches', () => {
+        let previous = field.createValue();
+        let metadata = field.createMetadata();
+        let values = new Array(10**6).fill(0);
+        // Create a patch
+        let { patch } = field.applyUpdate({
+            previous,
+            update: { index: 0, remove: 0, values },
+            metadata,
+            version: 1,
+            storeId: 1
+        });
+        // Reset the metadata
+        metadata = field.createMetadata();
+        // Apply the patch
+        let patched = field.applyPatch({
+            previous,
+            metadata,
+            patch
+        });
+        expect(patched).to.eql(values);
+      })
+
     });
 
     describe('unapplyPatch', () => {

--- a/packages/datastore/tests/src/listfield.spec.ts
+++ b/packages/datastore/tests/src/listfield.spec.ts
@@ -412,7 +412,7 @@ describe('@lumino/datastore', () => {
             metadata,
             patch
         });
-        expect(patched).to.eql(values);
+        expect(patched.value).to.eql(values);
       })
 
     });

--- a/packages/datastore/tests/src/listfield.spec.ts
+++ b/packages/datastore/tests/src/listfield.spec.ts
@@ -395,7 +395,7 @@ describe('@lumino/datastore', () => {
       it('should handle large patches', () => {
         let previous = field.createValue();
         let metadata = field.createMetadata();
-        let values = new Array(10**6).fill(0);
+        let values = new Array(2**6).fill(0);
         // Create a patch
         let { patch } = field.applyUpdate({
             previous,

--- a/packages/datastore/tests/src/listfield.spec.ts
+++ b/packages/datastore/tests/src/listfield.spec.ts
@@ -395,7 +395,7 @@ describe('@lumino/datastore', () => {
       it('should handle large patches', () => {
         let previous = field.createValue();
         let metadata = field.createMetadata();
-        let values = new Array(2*10**5).fill(0);
+        let values = new Array(250000).fill(0);
         // Create a patch
         let { patch } = field.applyUpdate({
             previous,


### PR DESCRIPTION
Hi, my name is Logan McNichols. I am an intern for Jupyter Cal Poly. I am working on a tabular data editor powered by the DataGrid along with @kgoo124 and @ryuntalan.

We are relying on the Datastore to store some data for us. In particular, we have two `ListField<number>` objects tracking the position of rows and columns respectively. I encountered some unexpected behavior when trying to work with a `ListField<number>` object who's length was greater than 100000.

I think I traced the problem to the function in `listfield.ts` called `spliceArray`. It was producing odd behavior when its argument `items` had length greater than 100000. With a slight modification to line 682, I think it is now having the intended mutation on `arr`.

Fixes #100 