### PR TITLE
API report checks - OPTIONS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+api-extractor.json  linguist-language=JSON-with-Comments
+api-extractor-base.json  linguist-language=JSON-with-Comments

--- a/.github/workflows/api-extractor.yml
+++ b/.github/workflows/api-extractor.yml
@@ -1,0 +1,126 @@
+name: API Reports
+
+on: [pull_request]
+
+jobs:
+  base_report:
+    name: Base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn
+        uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: |
+          yarn
+
+      - name: Build packages
+        run: |
+          yarn build:src
+
+      - name: Generate report
+        continue-on-error: true   # Allows to match against old jobs
+        run: |
+          yarn api
+
+      - name: Fallback
+        if: ${{ failure() }}
+        # We still fail if canary report is missing:
+        run: |
+          test -f review/api/algorithm.api.md && echo "::warning ::Failed to generate fresh report"
+
+      - name: Upload API report
+        uses: actions/upload-artifact@v2
+        with:
+          name: base-api-report
+          path: review/api/*.api.md
+
+
+  head_report:
+    name: Head
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn
+        uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: |
+          yarn
+
+      - name: Build packages
+        run: |
+          yarn build:src
+
+      - name: Generate report
+        run: |
+          yarn api
+
+      - name: Upload API report
+        uses: actions/upload-artifact@v2
+        with:
+          name: head-api-report
+          path: review/api/*.api.md
+
+
+  compare:
+    name: Compare
+    needs: [base_report, head_report]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download base report
+        uses: actions/download-artifact@v2
+        continue-on-error: true   # Allows to match against old jobs
+        with:
+          name: base-api-report
+          path: review/api/
+
+      - name: Fallback
+        if: ${{ failure() }}
+        uses: actions/checkout@v2
+
+      - name: Download head report
+        uses: actions/download-artifact@v2
+        with:
+          name: head-api-report
+          path: review-head/api/
+
+      - name: Compare Reports
+        run: |
+          export DIFF_OUTPUT=$(diff -rub review/api/ review-head/api/)
+          [ -n "$DIFF_OUTPUT" ] && echo "::warning file=package.json,line=1 ::API reports differ" && echo "${DIFF_OUTPUT}"

--- a/.github/workflows/api-report-check.yml
+++ b/.github/workflows/api-report-check.yml
@@ -1,0 +1,40 @@
+name: Ensure API Reports Valid
+
+on: [pull_request]
+
+jobs:
+  triage:
+    name: Validate API reports
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn
+        uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: |
+          yarn
+
+      - name: Build packages
+        run: |
+          yarn build:src
+
+      - name: Check that report is up to date
+        run: |
+          yarn api:check

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ script:
     yarn build:test;
     yarn test;
     yarn docs;
+    yarn api:check

--- a/api-extractor-base.json
+++ b/api-extractor-base.json
@@ -45,7 +45,7 @@
    *
    * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
    */
-  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/types/index.d.ts",
 
   /**
    * A list of NPM package names whose exports should be treated as part of this package.
@@ -357,16 +357,23 @@
      */
     "tsdocMessageReporting": {
       "default": {
+        // Should be a low threshold to setting this to "none":
         "logLevel": "warning",
         // "addToApiReportFile": false
+      },
+
+      "tsdoc-undefined-tag": {
+        "logLevel": "none"
+      },
+
+      "tsdoc-unsupported-tag": {
+        "logLevel": "none"
+      },
+
+      "tsdoc-param-tag-with-invalid-name": {
+        "logLevel": "none"
       }
 
-      // "tsdoc-link-tag-unescaped-text": {
-      //   "logLevel": "warning",
-      //   "addToApiReportFile": true
-      // },
-      //
-      // . . .
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "tests/*"
   ],
   "scripts": {
-    "api": "lerna run api",
+    "api": "lerna run api --parallel --no-sort --no-bail",
+    "api:check": "lerna run api:check --parallel --no-sort",
     "minimize": "lerna run minimize",
     "build": "lerna run build",
     "build:examples": "lerna run build --scope \"@lumino/example-*\"",

--- a/packages/algorithm/package.json
+++ b/packages/algorithm/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -31,7 +31,8 @@
   },
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/coreutils/src/random.ts
+++ b/packages/coreutils/src/random.ts
@@ -32,8 +32,8 @@ namespace Random {
    * The following RNGs are supported, listed in order of precedence:
    *   - `window.crypto.getRandomValues`
    *   - `window.msCrypto.getRandomValues`
-   *   - `require('crypto').randomFillSync
-   *   - `require('crypto').randomBytes
+   *   - `require('crypto').randomFillSync`
+   *   - `require('crypto').randomBytes`
    *   - `Math.random`
    */
   export

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -27,7 +27,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",
     "docs": "typedoc --options tdoptions.json src",

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -29,7 +29,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/datastore/src/datastore.ts
+++ b/packages/datastore/src/datastore.ts
@@ -704,9 +704,9 @@ namespace Datastore {
    * A helper function to wrap an update to the datastore in calls to
    * `beginTransaction` and `endTransaction`.
    *
-   * @param datastore: the datastore to which to apply the update.
+   * @param datastore - the datastore to which to apply the update.
    *
-   * @param update: A function that performs the update on the datastore.
+   * @param update - A function that performs the update on the datastore.
    *   The function is called with a transaction id string, in case the
    *   user wishes to store the transaction ID for later use.
    *
@@ -788,9 +788,9 @@ namespace Datastore {
   /**
    * Get a given table by its location.
    *
-   * @param datastore: the datastore in which the table resides.
+   * @param datastore - the datastore in which the table resides.
    *
-   * @param loc: The table location.
+   * @param loc - The table location.
    *
    * @returns the table.
    */
@@ -804,9 +804,9 @@ namespace Datastore {
   /**
    * Get a given record by its location.
    *
-   * @param datastore: the datastore in which the record resides.
+   * @param datastore - the datastore in which the record resides.
    *
-   * @param loc: The record location.
+   * @param loc - The record location.
    *
    * @returns the record, or undefined if it does not exist.
    */
@@ -820,9 +820,9 @@ namespace Datastore {
   /**
    * Get a given field by its location.
    *
-   * @param datastore: the datastore in which the field resides.
+   * @param datastore - the datastore in which the field resides.
    *
-   * @param loc: the field location.
+   * @param loc - the field location.
    *
    * @returns the field in question.
    *
@@ -843,11 +843,11 @@ namespace Datastore {
   /**
    * Update a table.
    *
-   * @param datastore: the datastore in which the table resides.
+   * @param datastore - the datastore in which the table resides.
    *
-   * @param loc: the table location.
+   * @param loc - the table location.
    *
-   * @param update: the update to the table.
+   * @param update - the update to the table.
    *
    * #### Notes
    * This does not begin a transaction, so usage of this function should be
@@ -865,11 +865,11 @@ namespace Datastore {
   /**
    * Update a record in a table.
    *
-   * @param datastore: the datastore in which the record resides.
+   * @param datastore - the datastore in which the record resides.
    *
-   * @param loc: the record location.
+   * @param loc - the record location.
    *
-   * @param update: the update to the record.
+   * @param update - the update to the record.
    *
    * #### Notes
    * This does not begin a transaction, so usage of this function should be
@@ -889,11 +889,11 @@ namespace Datastore {
   /**
    * Update a field in a table.
    *
-   * @param datastore: the datastore in which the field resides.
+   * @param datastore - the datastore in which the field resides.
    *
-   * @param loc: the field location.
+   * @param loc - the field location.
    *
-   * @param update: the update to the field.
+   * @param update - the update to the field.
    *
    * #### Notes
    * This does not begin a transaction, so usage of this function should be
@@ -917,11 +917,11 @@ namespace Datastore {
   /**
    * Listen to changes in a table. Changes to other tables are ignored.
    *
-   * @param datastore: the datastore in which the table resides.
+   * @param datastore - the datastore in which the table resides.
    *
-   * @param loc: the table location.
+   * @param loc - the table location.
    *
-   * @param slot: a callback function to invoke when the table changes.
+   * @param slot - a callback function to invoke when the table changes.
    *
    * @returns an `IDisposable` that can be disposed to remove the listener.
    */
@@ -951,11 +951,11 @@ namespace Datastore {
    * Listen to changes in a record in a table. Changes to other tables and
    * other records in the same table are ignored.
    *
-   * @param datastore: the datastore in which the record resides.
+   * @param datastore - the datastore in which the record resides.
    *
-   * @param loc: the record location.
+   * @param loc - the record location.
    *
-   * @param slot: a callback function to invoke when the record changes.
+   * @param slot - a callback function to invoke when the record changes.
    *
    * @returns an `IDisposable` that can be disposed to remove the listener.
    */
@@ -988,11 +988,11 @@ namespace Datastore {
    * Listen to changes in a fields in a table. Changes to other tables, other
    * records in the same table, and other fields in the same record are ignored.
    *
-   * @param datastore: the datastore in which the field resides.
+   * @param datastore - the datastore in which the field resides.
    *
-   * @param loc: the field location.
+   * @param loc - the field location.
    *
-   * @param slot: a callback function to invoke when the field changes.
+   * @param slot - a callback function to invoke when the field changes.
    *
    * @returns an `IDisposable` that can be disposed to remove the listener.
    */

--- a/packages/datastore/src/serveradapter.ts
+++ b/packages/datastore/src/serveradapter.ts
@@ -40,14 +40,14 @@ interface IServerAdapter extends IDisposable {
    * but the undo is not actually done until the datastore recieves the
    * corresponding transaction and applies it.
    *
-   * @param id: the transaction to undo.
+   * @param id - the transaction to undo.
    */
   undo(id: string): Promise<void>;
 
   /**
    * Redo a transaction by id.
    *
-   * @param id: the transaction to redo.
+   * @param id - the transaction to redo.
    */
   redo(id: string): Promise<void>;
 

--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/domutils/package.json
+++ b/packages/domutils/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -30,7 +30,8 @@
   "types": "types/index.d.ts",
   "style": "style/index.css",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/keyboard/src/index.ts
+++ b/packages/keyboard/src/index.ts
@@ -70,7 +70,7 @@ function getKeyboardLayout(): IKeyboardLayout {
 /**
  * Set the global application keyboard layout instance.
  *
- * @param - The keyboard layout for use by the application.
+ * @param layout - The keyboard layout for use by the application.
  *
  * #### Notes
  * The keyboard layout should typically be set on application startup

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/polling/package.json
+++ b/packages/polling/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/polling/src/index.ts
+++ b/packages/polling/src/index.ts
@@ -73,7 +73,7 @@ export namespace IPoll {
    * Essentially, if consecutive retries are needed, we choose an integer:
    * `sleep = min(max, rand(interval, backoff * sleep))`
    * This ensures that the poll is never less than `interval`, and nicely
-   * spreads out retries for consecutive tries. Over time, if (interval < max),
+   * spreads out retries for consecutive tries. Over time, if (interval \< max),
    * the random number will be above `max` about (1 - 1/backoff) of the time
    * (sleeping the `max`), and the rest of the time the sleep will be a random
    * number below `max`, decorrelating our trigger time from other pollers.
@@ -81,7 +81,7 @@ export namespace IPoll {
   export type Frequency = {
     /**
      * Whether poll frequency backs off (boolean) or the backoff growth rate
-     * (float > 1).
+     * (float \> 1).
      *
      * #### Notes
      * If `true`, the default backoff growth rate is `3`.

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/signaling/package.json
+++ b/packages/signaling/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -28,7 +28,8 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -30,7 +30,8 @@
   "types": "types/index.d.ts",
   "style": "style/index.css",
   "scripts": {
-    "api": "api-extractor run --local --verbose",
+    "api": "api-extractor run --local",
+    "api:check": "api-extractor run --verbose",
     "build": "tsc --build && rollup -c",
     "build:test": "tsc --build tests && cd tests && webpack",
     "clean": "rimraf ./lib && rimraf *.tsbuildinfo && rimraf ./types && rimraf ./dist",

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -1172,7 +1172,7 @@ namespace DockPanel {
      * Hide the overlay node.
      *
      * @param delay - The delay (in ms) before hiding the overlay.
-     *   A delay value <= 0 should hide the overlay immediately.
+     *   A delay value \<= 0 should hide the overlay immediately.
      *
      * #### Notes
      * This is called whenever the overlay node should been hidden.
@@ -1242,7 +1242,7 @@ namespace DockPanel {
      * Hide the overlay node.
      *
      * @param delay - The delay (in ms) before hiding the overlay.
-     *   A delay value <= 0 will hide the overlay immediately.
+     *   A delay value \<= 0 will hide the overlay immediately.
      */
     hide(delay: number): void {
       // Do nothing if the overlay is already hidden.


### PR DESCRIPTION
This PR outlines a few options for how to start enforcing / using the API extractor reports:
1. Add a check to the Travis build to see if the files are up to date. If not, fail and ask the user to run the "yarn api" command and commit the results.
2. Add a similar check to 1., but using a GH action. Mostly there for completeness.
3. Run the comparison, but don't fail the check if there are differences. Instead report the differences as a warning. The warning mechanism is incomplete at the moment, but alternatives include:
   1. Use a bot to post the diff as a comment (that ideally gets updated).
   2. For each change, figure out the file (and ideally line) of that change. Use Github warnings to highlight those on the diff (see next point). This would depend on https://github.com/microsoft/rushstack/issues/895 .
   3. Use a github warning on some more central file. The current code puts it on the root package.json, and doesn't currently include the diff. Not the cleanest, but it is still better than nothing.