### PR TITLE
Text eliding with ellipsis on datagrid text renderer

### DIFF
--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -436,6 +436,10 @@ function main(): void {
     horizontalAlignment: 'right'
   });
 
+  let elideFloatRenderer = new TextRenderer({
+    elideDirection: ({ column }) => (column % 2 === 0) ? 'right' : 'left',
+  });
+
   let grid1 = new DataGrid({ style: blueStripeStyle });
   grid1.dataModel = model1;
   grid1.keyHandler = new BasicKeyHandler();
@@ -443,6 +447,7 @@ function main(): void {
   grid1.selectionModel = new BasicSelectionModel({ dataModel: model1 });
 
   let grid2 = new DataGrid({ style: brownStripeStyle });
+  grid2.cellRenderers.update({ 'body': elideFloatRenderer });
   grid2.dataModel = model2;
   grid2.keyHandler = new BasicKeyHandler();
   grid2.mouseHandler = new BasicMouseHandler();

--- a/packages/datagrid/src/textrenderer.ts
+++ b/packages/datagrid/src/textrenderer.ts
@@ -150,6 +150,7 @@ class TextRenderer extends CellRenderer {
     // Set up the text position variables.
     let textX: number;
     let textY: number;
+    let boxWidth: number;
 
     // Compute the Y position for the text.
     switch (vAlign) {
@@ -170,12 +171,15 @@ class TextRenderer extends CellRenderer {
     switch (hAlign) {
     case 'left':
       textX = config.x + 2;
+      boxWidth = config.width - 4;
       break;
     case 'center':
       textX = config.x + config.width / 2;
+      boxWidth = config.width;
       break;
     case 'right':
       textX = config.x + config.width - 3;
+      boxWidth = config.width - 6;
       break;
     default:
       throw 'unreachable';
@@ -193,6 +197,22 @@ class TextRenderer extends CellRenderer {
     gc.fillStyle = color;
     gc.textAlign = hAlign;
     gc.textBaseline = 'bottom';
+
+    // Elide text that is too long
+    let elide = '\u2026';
+    let textWidth = gc.measureText(text).width;
+
+    // Compute elided text
+    while ((textWidth > boxWidth) && (text.length > 1)) {
+      if (text.length > 4 && textWidth >= 2 * boxWidth) {
+        // If text width is substantially bigger, take half the string
+        text = text.substring(0, (text.length / 2) + 1) + elide;
+      } else {
+        // Otherwise incrementally remove the last character
+        text = text.substring(0, text.length - 2) + elide;
+      }
+      textWidth = gc.measureText(text).width;
+    }
 
     // Draw the text for the cell.
     gc.fillText(text, textX, textY);

--- a/packages/datagrid/src/textrenderer.ts
+++ b/packages/datagrid/src/textrenderer.ts
@@ -170,16 +170,16 @@ class TextRenderer extends CellRenderer {
     // Compute the X position for the text.
     switch (hAlign) {
     case 'left':
-      textX = config.x + 2;
-      boxWidth = config.width - 4;
+      textX = config.x + 8;
+      boxWidth = config.width - 14;
       break;
     case 'center':
       textX = config.x + config.width / 2;
       boxWidth = config.width;
       break;
     case 'right':
-      textX = config.x + config.width - 3;
-      boxWidth = config.width - 6;
+      textX = config.x + config.width - 8;
+      boxWidth = config.width - 14;
       break;
     default:
       throw 'unreachable';


### PR DESCRIPTION
This PR (https://github.com/phosphorjs/phosphor/pull/341) was sitting latent on the phosphor repo - I ported it over to lumino. I removed the optionality of eliding text - I feel like in almost all cases it looks better visually, although if you feel otherwise i can add the option back. I also improved the margins around the text a bit for easier readability.