### PR TITLE
Implement plus button on TabBar

### DIFF
--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -355,7 +355,24 @@ function main(): void {
   dock.addWidget(b2, { mode: 'split-right', ref: y1 });
   dock.id = 'dock';
 
+  dock.widgetAddRequested.connect((sender: DockPanel, args: DockPanel.IWidgetAddRequestedArgs<Widget>) => {
+    let w = new ContentWidget("Green");
+    sender.addWidget(w, { ref: args.tabBar.titles[0].owner });
+  });
+
   let savedLayouts: DockPanel.ILayoutConfig[] = [];
+
+  commands.addCommand('example:add-button', {
+    label: 'Toggle add button',
+    mnemonic: 0,
+    caption: 'Toggle add Button',
+    execute: () => {
+      dock.addButtonEnabled = !dock.addButtonEnabled;
+      console.log('Toggle add button');
+    }
+  });
+  contextMenu.addItem({ command: 'example:add-button', selector: '.content' });
+
 
   commands.addCommand('save-dock-layout', {
     label: 'Save Layout',

--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -356,7 +356,7 @@ function main(): void {
   dock.id = 'dock';
 
   dock.addRequested.connect((sender: DockPanel, arg: TabBar<Widget>) => {
-    let w = new ContentWidget("Green");
+    let w = new ContentWidget('Green');
     sender.addWidget(w, { ref: arg.titles[0].owner });
   });
 

--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -18,7 +18,7 @@ import {
 } from '@lumino/messaging';
 
 import {
-  BoxPanel, CommandPalette, ContextMenu, DockPanel, Menu, MenuBar, Widget
+  BoxPanel, CommandPalette, ContextMenu, DockPanel, Menu, MenuBar, Widget, TabBar
 } from '@lumino/widgets';
 
 import '../style/index.css';
@@ -355,9 +355,9 @@ function main(): void {
   dock.addWidget(b2, { mode: 'split-right', ref: y1 });
   dock.id = 'dock';
 
-  dock.widgetAddRequested.connect((sender: DockPanel, args: DockPanel.IWidgetAddRequestedArgs<Widget>) => {
+  dock.addRequested.connect((sender: DockPanel, arg: TabBar<Widget>) => {
     let w = new ContentWidget("Green");
-    sender.addWidget(w, { ref: args.tabBar.titles[0].owner });
+    sender.addWidget(w, { ref: arg.titles[0].owner });
   });
 
   let savedLayouts: DockPanel.ILayoutConfig[] = [];

--- a/packages/default-theme/style/tabbar.css
+++ b/packages/default-theme/style/tabbar.css
@@ -93,11 +93,22 @@
 }
 
 
+.lm-TabBar .lm-TabBar-addButton {
+  padding: 0px 6px;
+  border-bottom: 1px solid #C0C0C0;
+}
+
+
 /* <DEPRECATED> */
 .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:before,
 /* </DEPRECATED> */
 .lm-TabBar-tab.lm-mod-closable > .lm-TabBar-tabCloseIcon:before {
   content: '\f00d';
+  font-family: FontAwesome;
+}
+
+.lm-TabBar .lm-TabBar-addButton:before {
+  content: '\f067';
   font-family: FontAwesome;
 }
 

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -928,7 +928,7 @@ class DockPanel extends Widget {
     tabBar.tabCloseRequested.connect(this._onTabCloseRequested, this);
     tabBar.tabDetachRequested.connect(this._onTabDetachRequested, this);
     tabBar.tabActivateRequested.connect(this._onTabActivateRequested, this);
-    tabBar.tabAddRequested.connect(this._onTabAddRequested, this);
+    tabBar.addRequested.connect(this._onTabAddRequested, this);
 
     // Return the initialized tab bar.
     return tabBar;
@@ -977,7 +977,7 @@ class DockPanel extends Widget {
   /**
    * Handle the `tabAddRequested` signal from the tab bar.
    */
-  private _onTabAddRequested(sender: TabBar<Widget>, args: TabBar.ITabAddRequestedArgs): void {
+  private _onTabAddRequested(sender: TabBar<Widget>, args: void): void {
     this._widgetAddRequested.emit({
       tabBar: sender
     });

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -136,8 +136,8 @@ class DockPanel extends Widget {
    * A signal emitted when the add button on a tab bar is clicked.
    *
    */
-  get widgetAddRequested(): ISignal<this, DockPanel.IWidgetAddRequestedArgs<Widget>> {
-    return this._widgetAddRequested;
+  get addRequested(): ISignal<this, TabBar<Widget>> {
+    return this._addRequested;
   }
 
   /**
@@ -978,9 +978,7 @@ class DockPanel extends Widget {
    * Handle the `tabAddRequested` signal from the tab bar.
    */
   private _onTabAddRequested(sender: TabBar<Widget>, args: void): void {
-    this._widgetAddRequested.emit({
-      tabBar: sender
-    });
+    this._addRequested.emit(sender);
   }
 
   /**
@@ -1057,7 +1055,7 @@ class DockPanel extends Widget {
   private _pressData: Private.IPressData | null = null;
   private _layoutModified = new Signal<this, void>(this);
 
-  private _widgetAddRequested = new Signal<this, DockPanel.IWidgetAddRequestedArgs<Widget>>(this);
+  private _addRequested = new Signal<this, TabBar<Widget>>(this);
 
 }
 
@@ -1402,18 +1400,6 @@ namespace DockPanel {
    */
   export
   const defaultRenderer = new Renderer();
-
-
-  /**
-   * The arguments object for the `addRequested` signal.
-   */
-  export
-  interface IWidgetAddRequestedArgs<T> {
-    /**
-     * The tabbar.
-     */
-    tabBar: TabBar<T>;
-  }
 }
 
 

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -218,7 +218,7 @@ class DockPanel extends Widget {
   get tabsMovable(): boolean {
     return this._tabsMovable;
   }
-  
+
 
   /**
    * Enable / Disable draggable / movable tabs.
@@ -243,18 +243,18 @@ class DockPanel extends Widget {
   }
 
   /**
-   * Whether the add buttons for each tab bar are enableds.
+   * Whether the add buttons for each tab bar are enabled.
    */
   get addButtonEnabled(): boolean {
     return this._addButtonEnabled;
   }
 
   /**
-   * Enable / Disable add button.
+   * Set whether the add buttons for each tab bar are enabled.
    */
   set addButtonEnabled(value: boolean) {
     this._addButtonEnabled = value;
-    each(this.tabBars(), (tabbar) => { tabbar.addButtonEnabled = value });
+    each(this.tabBars(), tabbar => { tabbar.addButtonEnabled = value; });
   }
 
   /**
@@ -975,9 +975,9 @@ class DockPanel extends Widget {
   }
 
   /**
-   * Handle the `tabAddRequested` signal from the tab bar.
+   * Handle the `addRequested` signal from a tab bar.
    */
-  private _onTabAddRequested(sender: TabBar<Widget>, args: void): void {
+  private _onTabAddRequested(sender: TabBar<Widget>): void {
     this._addRequested.emit(sender);
   }
 
@@ -1113,13 +1113,13 @@ namespace DockPanel {
 
     /**
      * Constrain tabs to this dock panel
-     * 
+     *
      * The default is `'false'`.
      */
     tabsConstrained?: boolean;
 
     /**
-     * Show add buttons to each tab bar.
+     * Enable add buttons in each of the dock panel's tab bars.
      *
      * The default is `'false'`.
      */

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -129,8 +129,7 @@ class TabBar<T> extends Widget {
   }
 
   /**
-   * A signal emitted when the tabbar add button is clicked.
-   *
+   * A signal emitted when the tab bar add button is clicked.
    */
   get addRequested(): ISignal<this, void> {
     return this._addRequested;
@@ -329,16 +328,14 @@ class TabBar<T> extends Widget {
   }
 
   /**
-   * Get the currently selected title.
-   *
+   * Whether the add button is enabled.
    */
   get addButtonEnabled(): boolean {
     return this._addButtonEnabled;
   }
 
   /**
-   * Set the currently selected title.
-   *
+   * Set whether the add button is enabled.
    */
   set addButtonEnabled(value: boolean) {
     // Do nothing if the value does not change.
@@ -375,7 +372,7 @@ class TabBar<T> extends Widget {
 
 
   /**
-   * The tab bar add node.
+   * The tab bar add button node.
    *
    * #### Notes
    * This is the node which holds the add button.
@@ -733,11 +730,9 @@ class TabBar<T> extends Widget {
       return;
     }
 
-    // Handle clicking on the add button
-    let addButtonClicked = false;
-    if (this.addButtonEnabled && this.addButtonNode.contains(event.target as HTMLElement)) {
-      addButtonClicked = true;
-    }
+    // Check if the add button was clicked.
+    let addButtonClicked = this.addButtonEnabled &&
+      this.addButtonNode.contains(event.target as HTMLElement);
 
     // Lookup the tab nodes.
     let tabs = this.contentNode.children;
@@ -747,7 +742,7 @@ class TabBar<T> extends Widget {
       return ElementExt.hitTest(tab, event.clientX, event.clientY);
     });
 
-    // Do nothing if the press is not on a tab.
+    // Do nothing if the press is not on a tab or the add button.
     if (index === -1 && !addButtonClicked) {
       return;
     }
@@ -777,8 +772,7 @@ class TabBar<T> extends Widget {
     // Add the document mouse up listener.
     document.addEventListener('mouseup', this, true);
 
-    // Do nothing else if the middle button is clicked
-    // or tabbar add button is clicked
+    // Do nothing else if the middle button or add button is clicked.
     if (event.button === 1 || addButtonClicked) {
       return;
     }
@@ -920,8 +914,10 @@ class TabBar<T> extends Widget {
       // Clear the drag data.
       this._dragData = null;
 
-      // Handle clicking on the add button
-      if (this.addButtonEnabled && this.addButtonNode.contains(event.target as HTMLElement)) {
+      // Handle clicking the add button.
+      let addButtonClicked = this.addButtonEnabled &&
+        this.addButtonNode.contains(event.target as HTMLElement);
+      if (addButtonClicked) {
         this._addRequested.emit(undefined);
         return;
       }
@@ -1712,7 +1708,7 @@ namespace TabBar {
   const defaultRenderer = new Renderer();
 
   /**
-   * A selector which matches the close icon node in a tab.
+   * A selector which matches the add button node in the tab bar.
    */
   export
   const addButtonSelector = '.lm-TabBar-addButton';

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -132,8 +132,8 @@ class TabBar<T> extends Widget {
    * A signal emitted when the tabbar add button is clicked.
    *
    */
-  get tabAddRequested(): ISignal<this, TabBar.ITabAddRequestedArgs> {
-    return this._tabAddRequested;
+  get addRequested(): ISignal<this, void> {
+    return this._addRequested;
   }
 
   /**
@@ -922,7 +922,7 @@ class TabBar<T> extends Widget {
 
       // Handle clicking on the add button
       if (this.addButtonEnabled && this.addButtonNode.contains(event.target as HTMLElement)) {
-        this._tabAddRequested.emit({});
+        this._addRequested.emit(undefined);
         return;
       }
 
@@ -1207,8 +1207,8 @@ class TabBar<T> extends Widget {
   private _addButtonEnabled: boolean = false;
   private _tabMoved = new Signal<this, TabBar.ITabMovedArgs<T>>(this);
   private _currentChanged = new Signal<this, TabBar.ICurrentChangedArgs<T>>(this);
+  private _addRequested = new Signal<this, void>(this);
   private _tabCloseRequested = new Signal<this, TabBar.ITabCloseRequestedArgs<T>>(this);
-  private _tabAddRequested = new Signal<this, TabBar.ITabAddRequestedArgs>(this);
   private _tabDetachRequested = new Signal<this, TabBar.ITabDetachRequestedArgs<T>>(this);
   private _tabActivateRequested = new Signal<this, TabBar.ITabActivateRequestedArgs<T>>(this);
 }
@@ -1432,13 +1432,6 @@ namespace TabBar {
      * The title for the tab.
      */
     readonly title: Title<T>;
-  }
-
-  /**
-   * The arguments object for the `tabAddRequested` signal.
-   */
-  export
-  interface ITabAddRequestedArgs {
   }
 
   /**

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -70,6 +70,7 @@ class TabBar<T> extends Widget {
     this.tabsMovable = options.tabsMovable || false;
     this.titlesEditable = options.titlesEditable || false;
     this.allowDeselect = options.allowDeselect || false;
+    this.addButtonEnabled = options.addButtonEnabled || false;
     this.insertBehavior = options.insertBehavior || 'select-tab-if-needed';
     this.name = options.name || '';
     this.orientation = options.orientation || 'horizontal';
@@ -125,6 +126,14 @@ class TabBar<T> extends Widget {
    */
   get tabActivateRequested(): ISignal<this, TabBar.ITabActivateRequestedArgs<T>> {
     return this._tabActivateRequested;
+  }
+
+  /**
+   * A signal emitted when the tabbar add button is clicked.
+   *
+   */
+  get tabAddRequested(): ISignal<this, TabBar.ITabAddRequestedArgs> {
+    return this._tabAddRequested;
   }
 
   /**
@@ -320,6 +329,32 @@ class TabBar<T> extends Widget {
   }
 
   /**
+   * Get the currently selected title.
+   *
+   */
+  get addButtonEnabled(): boolean {
+    return this._addButtonEnabled;
+  }
+
+  /**
+   * Set the currently selected title.
+   *
+   */
+  set addButtonEnabled(value: boolean) {
+    // Do nothing if the value does not change.
+    if (this._addButtonEnabled === value) {
+      return;
+    }
+
+    this._addButtonEnabled = value;
+    if (value) {
+      this.addButtonNode.classList.remove('lm-mod-hidden');
+    } else {
+      this.addButtonNode.classList.add('lm-mod-hidden');
+    }
+  }
+
+  /**
    * A read-only array of the titles in the tab bar.
    */
   get titles(): ReadonlyArray<Title<T>> {
@@ -336,6 +371,19 @@ class TabBar<T> extends Widget {
    */
   get contentNode(): HTMLUListElement {
     return this.node.getElementsByClassName('lm-TabBar-content')[0] as HTMLUListElement;
+  }
+
+
+  /**
+   * The tab bar add node.
+   *
+   * #### Notes
+   * This is the node which holds the add button.
+   *
+   * Modifying this node directly can lead to undefined behavior.
+   */
+  get addButtonNode(): HTMLDivElement {
+    return this.node.getElementsByClassName('lm-TabBar-addButton')[0] as HTMLDivElement;
   }
 
   /**
@@ -685,6 +733,12 @@ class TabBar<T> extends Widget {
       return;
     }
 
+    // Handle clicking on the add button
+    let addButtonClicked = false;
+    if (this.addButtonNode.contains(event.target as HTMLElement)) {
+      addButtonClicked = true;
+    }
+
     // Lookup the tab nodes.
     let tabs = this.contentNode.children;
 
@@ -694,7 +748,7 @@ class TabBar<T> extends Widget {
     });
 
     // Do nothing if the press is not on a tab.
-    if (index === -1) {
+    if (index === -1 && !addButtonClicked) {
       return;
     }
 
@@ -723,8 +777,9 @@ class TabBar<T> extends Widget {
     // Add the document mouse up listener.
     document.addEventListener('mouseup', this, true);
 
-    // Do nothing else if the middle button is clicked.
-    if (event.button === 1) {
+    // Do nothing else if the middle button is clicked
+    // or tabbar add button is clicked
+    if (event.button === 1 || addButtonClicked) {
       return;
     }
 
@@ -864,6 +919,12 @@ class TabBar<T> extends Widget {
     if (!data.dragActive) {
       // Clear the drag data.
       this._dragData = null;
+
+      // Handle clicking on the add button
+      if (this.addButtonNode.contains(event.target as HTMLElement)) {
+        this._tabAddRequested.emit({});
+        return;
+      }
 
       // Lookup the tab nodes.
       let tabs = this.contentNode.children;
@@ -1143,9 +1204,11 @@ class TabBar<T> extends Widget {
   private _titlesEditable: boolean = false;
   private _previousTitle: Title<T> | null = null;
   private _dragData: Private.IDragData | null = null;
+  private _addButtonEnabled: boolean = false;
   private _tabMoved = new Signal<this, TabBar.ITabMovedArgs<T>>(this);
   private _currentChanged = new Signal<this, TabBar.ICurrentChangedArgs<T>>(this);
   private _tabCloseRequested = new Signal<this, TabBar.ITabCloseRequestedArgs<T>>(this);
+  private _tabAddRequested = new Signal<this, TabBar.ITabAddRequestedArgs>(this);
   private _tabDetachRequested = new Signal<this, TabBar.ITabDetachRequestedArgs<T>>(this);
   private _tabActivateRequested = new Signal<this, TabBar.ITabActivateRequestedArgs<T>>(this);
 }
@@ -1264,6 +1327,13 @@ namespace TabBar {
     titlesEditable?: boolean;
 
     /**
+     * Whether the add button is enabled.
+     *
+     * The default is `false`.
+     */
+    addButtonEnabled?: boolean;
+
+    /**
      * The selection behavior when inserting a tab.
      *
      * The default is `'select-tab-if-needed'`.
@@ -1362,6 +1432,13 @@ namespace TabBar {
      * The title for the tab.
      */
     readonly title: Title<T>;
+  }
+
+  /**
+   * The arguments object for the `tabAddRequested` signal.
+   */
+  export
+  interface ITabAddRequestedArgs {
   }
 
   /**
@@ -1640,6 +1717,13 @@ namespace TabBar {
    */
   export
   const defaultRenderer = new Renderer();
+
+  /**
+   * A selector which matches the close icon node in a tab.
+   */
+  export
+  const addButtonSelector = '.lm-TabBar-addButton';
+
 }
 
 
@@ -1783,6 +1867,10 @@ namespace Private {
     content.classList.add('p-TabBar-content');
     /* </DEPRECATED> */
     node.appendChild(content);
+
+    let add = document.createElement('div');
+    add.className = 'lm-TabBar-addButton lm-mod-hidden';
+    node.appendChild(add);
     return node;
   }
 

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -735,7 +735,7 @@ class TabBar<T> extends Widget {
 
     // Handle clicking on the add button
     let addButtonClicked = false;
-    if (this.addButtonNode.contains(event.target as HTMLElement)) {
+    if (this.addButtonEnabled && this.addButtonNode.contains(event.target as HTMLElement)) {
       addButtonClicked = true;
     }
 
@@ -921,7 +921,7 @@ class TabBar<T> extends Widget {
       this._dragData = null;
 
       // Handle clicking on the add button
-      if (this.addButtonNode.contains(event.target as HTMLElement)) {
+      if (this.addButtonEnabled && this.addButtonNode.contains(event.target as HTMLElement)) {
         this._tabAddRequested.emit({});
         return;
       }

--- a/packages/widgets/src/tabpanel.ts
+++ b/packages/widgets/src/tabpanel.ts
@@ -238,8 +238,8 @@ class TabPanel extends Widget {
    * A signal emitted when the add button on a tab bar is clicked.
    *
    */
-  get widgetAddRequested(): ISignal<this, TabPanel.IWidgetAddRequestedArgs<Widget>> {
-    return this._widgetAddRequested;
+  get addRequested(): ISignal<this, TabBar<Widget>> {
+    return this._addRequested;
   }
 
   /**
@@ -343,9 +343,7 @@ class TabPanel extends Widget {
    * Handle the `tabAddRequested` signal from the tab bar.
    */
   private _onTabAddRequested(sender: TabBar<Widget>, args: void): void {
-    this._widgetAddRequested.emit({
-      tabBar: sender
-    });
+    this._addRequested.emit(sender);
   }
 
   /**
@@ -381,7 +379,7 @@ class TabPanel extends Widget {
   private _tabPlacement: TabPanel.TabPlacement;
   private _currentChanged = new Signal<this, TabPanel.ICurrentChangedArgs>(this);
 
-  private _widgetAddRequested = new Signal<this, TabPanel.IWidgetAddRequestedArgs<Widget>>(this);
+  private _addRequested = new Signal<this, TabBar<Widget>>(this);
 
 }
 
@@ -475,17 +473,6 @@ namespace TabPanel {
      * The currently selected widget.
      */
     currentWidget: Widget | null;
-  }
-
-  /**
-   * The arguments object for the `addRequested` signal.
-   */
-  export
-  interface IWidgetAddRequestedArgs<T> {
-    /**
-     * The tabbar.
-     */
-    tabBar: TabBar<T>;
   }
 }
 

--- a/packages/widgets/src/tabpanel.ts
+++ b/packages/widgets/src/tabpanel.ts
@@ -76,6 +76,8 @@ class TabPanel extends Widget {
     this.tabBar.currentChanged.connect(this._onCurrentChanged, this);
     this.tabBar.tabCloseRequested.connect(this._onTabCloseRequested, this);
     this.tabBar.tabActivateRequested.connect(this._onTabActivateRequested, this);
+    this.tabBar.tabAddRequested.connect(this._onTabAddRequested, this);
+    this.tabBar.tabAddRequested.connect(this._onTabAddRequested, this);
 
     // Connect the stacked panel signal handlers.
     this.stackedPanel.widgetRemoved.connect(this._onWidgetRemoved, this);
@@ -181,6 +183,22 @@ class TabPanel extends Widget {
   }
 
   /**
+   * Get the whether the add button is enabled.
+   *
+   */
+  get addButtonEnabled(): boolean {
+    return this.tabBar.addButtonEnabled;
+  }
+
+  /**
+   * Set the whether the add button is enabled.
+   *
+   */
+  set addButtonEnabled(value: boolean) {
+    this.tabBar.addButtonEnabled = value;
+  }
+
+  /**
    * Get the tab placement for the tab panel.
    *
    * #### Notes
@@ -215,6 +233,14 @@ class TabPanel extends Widget {
 
     // Update the layout direction.
     (this.layout as BoxLayout).direction = direction;
+  }
+
+  /**
+   * A signal emitted when the add button on a tab bar is clicked.
+   *
+   */
+  get widgetAddRequested(): ISignal<this, TabPanel.IWidgetAddRequestedArgs<Widget>> {
+    return this._widgetAddRequested;
   }
 
   /**
@@ -315,6 +341,15 @@ class TabPanel extends Widget {
   }
 
   /**
+   * Handle the `tabAddRequested` signal from the tab bar.
+   */
+  private _onTabAddRequested(sender: TabBar<Widget>, args: TabBar.ITabAddRequestedArgs): void {
+    this._widgetAddRequested.emit({
+      tabBar: sender
+    });
+  }
+
+  /**
    * Handle the `tabActivateRequested` signal from the tab bar.
    */
   private _onTabActivateRequested(sender: TabBar<Widget>, args: TabBar.ITabActivateRequestedArgs<Widget>): void {
@@ -346,6 +381,9 @@ class TabPanel extends Widget {
 
   private _tabPlacement: TabPanel.TabPlacement;
   private _currentChanged = new Signal<this, TabPanel.ICurrentChangedArgs>(this);
+
+  private _widgetAddRequested = new Signal<this, TabPanel.IWidgetAddRequestedArgs<Widget>>(this);
+
 }
 
 
@@ -393,6 +431,13 @@ namespace TabPanel {
     tabsMovable?: boolean;
 
     /**
+     * Whether the button to add new tabs is enabled.
+     *
+     * The default is `false`.
+     */
+    addButtonEnabled?: boolean;
+
+    /**
      * The placement of the tab bar relative to the content.
      *
      * The default is `'top'`.
@@ -431,6 +476,17 @@ namespace TabPanel {
      * The currently selected widget.
      */
     currentWidget: Widget | null;
+  }
+
+  /**
+   * The arguments object for the `addRequested` signal.
+   */
+  export
+  interface IWidgetAddRequestedArgs<T> {
+    /**
+     * The tabbar.
+     */
+    tabBar: TabBar<T>;
   }
 }
 

--- a/packages/widgets/src/tabpanel.ts
+++ b/packages/widgets/src/tabpanel.ts
@@ -76,8 +76,7 @@ class TabPanel extends Widget {
     this.tabBar.currentChanged.connect(this._onCurrentChanged, this);
     this.tabBar.tabCloseRequested.connect(this._onTabCloseRequested, this);
     this.tabBar.tabActivateRequested.connect(this._onTabActivateRequested, this);
-    this.tabBar.tabAddRequested.connect(this._onTabAddRequested, this);
-    this.tabBar.tabAddRequested.connect(this._onTabAddRequested, this);
+    this.tabBar.addRequested.connect(this._onTabAddRequested, this);
 
     // Connect the stacked panel signal handlers.
     this.stackedPanel.widgetRemoved.connect(this._onWidgetRemoved, this);
@@ -343,7 +342,7 @@ class TabPanel extends Widget {
   /**
    * Handle the `tabAddRequested` signal from the tab bar.
    */
-  private _onTabAddRequested(sender: TabBar<Widget>, args: TabBar.ITabAddRequestedArgs): void {
+  private _onTabAddRequested(sender: TabBar<Widget>, args: void): void {
     this._widgetAddRequested.emit({
       tabBar: sender
     });

--- a/packages/widgets/style/tabbar.css
+++ b/packages/widgets/style/tabbar.css
@@ -21,12 +21,14 @@
 /* <DEPRECATED> */ .p-TabBar[data-orientation='horizontal'], /* </DEPRECATED> */
 .lm-TabBar[data-orientation='horizontal'] {
   flex-direction: row;
+  align-items: flex-end;
 }
 
 
 /* <DEPRECATED> */ .p-TabBar[data-orientation='vertical'], /* </DEPRECATED> */
 .lm-TabBar[data-orientation='vertical'] {
   flex-direction: column;
+  align-items: flex-end;
 }
 
 
@@ -96,6 +98,11 @@
 }
 
 
+.lm-TabBar-addButton.lm-mod-hidden {
+  display: none !important;
+}
+
+
 /* <DEPRECATED> */ .p-TabBar.p-mod-dragging .p-TabBar-tab, /* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging .lm-TabBar-tab {
   position: relative;
@@ -125,4 +132,11 @@
 /* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging .lm-TabBar-tab.lm-mod-dragging {
   transition: none;
+}
+
+.lm-TabBar-tabLabel .lm-TabBar-tabInput {
+  user-select: all;
+  width: 100%;
+  box-sizing : border-box;
+  background: inherit;
 }

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -374,7 +374,7 @@ describe('@lumino/widgets', () => {
     });
 
 
-    describe('#tabAddRequested', () => {
+    describe('#addRequested', () => {
 
       let addButton: Element;
 
@@ -388,7 +388,7 @@ describe('@lumino/widgets', () => {
         bar.addButtonEnabled = true;
         let called = false;
         let rect = addButton.getBoundingClientRect();
-        bar.tabAddRequested.connect((sender, args) => {
+        bar.addRequested.connect((sender, args) => {
           expect(sender).to.equal(bar);
           expect(args).to.eql({});
           called = true;
@@ -402,7 +402,7 @@ describe('@lumino/widgets', () => {
         bar.addButtonEnabled = false;
         let called = false;
         let rect = addButton.getBoundingClientRect();
-        bar.tabAddRequested.connect((sender, args) => {
+        bar.addRequested.connect((sender, args) => {
           expect(sender).to.equal(bar);
           expect(args).to.eql({});
           called = true;

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -390,7 +390,7 @@ describe('@lumino/widgets', () => {
         let rect = addButton.getBoundingClientRect();
         bar.tabAddRequested.connect((sender, args) => {
           expect(sender).to.equal(bar);
-          expect(args).to.equal({});
+          expect(args).to.eql({});
           called = true;
         });
         simulate(addButton, 'mousedown', { clientX: rect.left, clientY: rect.top, button: 0 });
@@ -404,7 +404,7 @@ describe('@lumino/widgets', () => {
         let rect = addButton.getBoundingClientRect();
         bar.tabAddRequested.connect((sender, args) => {
           expect(sender).to.equal(bar);
-          expect(args).to.equal({});
+          expect(args).to.eql({});
           called = true;
         });
         simulate(addButton, 'mousedown', { clientX: rect.left, clientY: rect.top, button: 0 });
@@ -516,6 +516,30 @@ describe('@lumino/widgets', () => {
         let titles = bar.titles.slice();
         bar.insertTab(2, titles[0]);
         expect(bar.titles[2]).to.equal(titles[0]);
+      });
+
+    });
+
+    describe('#addButtonEnabled', () => {
+
+      it('should get whether the add button is enabled', () => {
+        let bar = new TabBar<Widget>();
+        expect(bar.addButtonEnabled).to.equal(false);
+      });
+
+      it('should set whether the add button is enabled', () => {
+        let bar = new TabBar<Widget>();
+        bar.addButtonEnabled = true;
+        expect(bar.addButtonEnabled).to.equal(true);
+      });
+
+      it('should not show the add button if not set', () => {
+        populateBar(bar);
+        expect(bar.addButtonNode.classList.contains('lm-mod-hidden')).to.equal(true);
+
+        bar.addButtonEnabled = true;
+        expect(bar.addButtonNode.classList.contains('lm-mod-hidden')).to.equal(false);
+
       });
 
     });

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -147,6 +147,7 @@ describe('@lumino/widgets', () => {
           orientation: 'horizontal',
           tabsMovable: true,
           allowDeselect: true,
+          addButtonEnabled: true,
           insertBehavior: 'select-tab',
           removeBehavior: 'select-previous-tab',
           renderer
@@ -154,6 +155,7 @@ describe('@lumino/widgets', () => {
         expect(newBar).to.be.an.instanceof(TabBar);
         expect(newBar.tabsMovable).to.equal(true);
         expect(newBar.renderer).to.equal(renderer);
+        expect(newBar.addButtonEnabled).to.equal(true);
       });
 
       it('should add the `lm-TabBar` class', () => {
@@ -366,6 +368,47 @@ describe('@lumino/widgets', () => {
         simulate(closeIcon, 'mouseup', { clientX: rect1.left, clientY: rect1.top, button: 0 });
         simulate(tab, 'mousedown', { clientX: rect2.left, clientY: rect2.top, button: 1 });
         simulate(tab, 'mouseup', { clientX: rect2.left, clientY: rect2.top, button: 1 });
+        expect(called).to.equal(false);
+      });
+
+    });
+
+
+    describe('#tabAddRequested', () => {
+
+      let addButton: Element;
+
+      beforeEach(() => {
+        populateBar(bar);
+        bar.currentIndex = 0;
+        addButton = bar.addButtonNode;
+      });
+
+      it('should be emitted when the add button is clicked', () => {
+        bar.addButtonEnabled = true;
+        let called = false;
+        let rect = addButton.getBoundingClientRect();
+        bar.tabAddRequested.connect((sender, args) => {
+          expect(sender).to.equal(bar);
+          expect(args).to.equal({});
+          called = true;
+        });
+        simulate(addButton, 'mousedown', { clientX: rect.left, clientY: rect.top, button: 0 });
+        simulate(addButton, 'mouseup', { clientX: rect.left, clientY: rect.top, button: 0 });
+        expect(called).to.equal(true);
+      });
+
+      it('should not be emitted if addButtonEnabled is `false`', () => {
+        bar.addButtonEnabled = false;
+        let called = false;
+        let rect = addButton.getBoundingClientRect();
+        bar.tabAddRequested.connect((sender, args) => {
+          expect(sender).to.equal(bar);
+          expect(args).to.equal({});
+          called = true;
+        });
+        simulate(addButton, 'mousedown', { clientX: rect.left, clientY: rect.top, button: 0 });
+        simulate(addButton, 'mouseup', { clientX: rect.left, clientY: rect.top, button: 0 });
         expect(called).to.equal(false);
       });
 

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -390,7 +390,7 @@ describe('@lumino/widgets', () => {
         let rect = addButton.getBoundingClientRect();
         bar.addRequested.connect((sender, args) => {
           expect(sender).to.equal(bar);
-          expect(args).to.eql({});
+          expect(args).to.equal(undefined);
           called = true;
         });
         simulate(addButton, 'mousedown', { clientX: rect.left, clientY: rect.top, button: 0 });
@@ -404,7 +404,7 @@ describe('@lumino/widgets', () => {
         let rect = addButton.getBoundingClientRect();
         bar.addRequested.connect((sender, args) => {
           expect(sender).to.equal(bar);
-          expect(args).to.eql({});
+          expect(args).to.equal(undefined);
           called = true;
         });
         simulate(addButton, 'mousedown', { clientX: rect.left, clientY: rect.top, button: 0 });


### PR DESCRIPTION
This PR implements a plus button on the TabBar (similar to google chrome) that will trigger an event when clicked. I've wired up this event for the TabPanel to emit a AddWidgetRequested event, which can be handled by the end user to create the appropriate widget and add it to the panel. A similar approach can also be implemented for the DockPanel if desired.

The CSS is a bit tricky - currently the plus button floats to the end of the TabBar instead of following the tabs.