### PR TITLE
Give extending classes access to some of the data grid's paint utilities.

### DIFF
--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3772,7 +3772,7 @@ class DataGrid extends Widget {
     }
 
     // Create the paint region object.
-    let rgn: Private.PaintRegion = {
+    let rgn: DataGrid.PaintRegion = {
       region: 'body',
       xMin: x1, yMin: y1,
       xMax: x2, yMax: y2,
@@ -3900,7 +3900,7 @@ class DataGrid extends Widget {
     }
 
     // Create the paint region object.
-    let rgn: Private.PaintRegion = {
+    let rgn: DataGrid.PaintRegion = {
       region: 'row-header',
       xMin: x1, yMin: y1,
       xMax: x2, yMax: y2,
@@ -4022,7 +4022,7 @@ class DataGrid extends Widget {
     }
 
     // Create the paint region object.
-    let rgn: Private.PaintRegion = {
+    let rgn: DataGrid.PaintRegion = {
       region: 'column-header',
       xMin: x1, yMin: y1,
       xMax: x2, yMax: y2,
@@ -4128,7 +4128,7 @@ class DataGrid extends Widget {
     }
 
     // Create the paint region object.
-    let rgn: Private.PaintRegion = {
+    let rgn: DataGrid.PaintRegion = {
       region: 'corner-header',
       xMin: x1, yMin: y1,
       xMax: x2, yMax: y2,
@@ -4159,7 +4159,7 @@ class DataGrid extends Widget {
   /**
    * Draw the background for the given paint region.
    */
-  private _drawBackground(rgn: Private.PaintRegion, color: string | undefined): void {
+  private _drawBackground(rgn: DataGrid.PaintRegion, color: string | undefined): void {
     // Bail if there is no color to draw.
     if (!color) {
       return;
@@ -4176,7 +4176,7 @@ class DataGrid extends Widget {
   /**
    * Draw the row background for the given paint region.
    */
-  private _drawRowBackground(rgn: Private.PaintRegion, colorFn: ((i: number) => string) | undefined): void {
+  private _drawRowBackground(rgn: DataGrid.PaintRegion, colorFn: ((i: number) => string) | undefined): void {
     // Bail if there is no color function.
     if (!colorFn) {
       return;
@@ -4215,7 +4215,7 @@ class DataGrid extends Widget {
   /**
    * Draw the column background for the given paint region.
    */
-  private _drawColumnBackground(rgn: Private.PaintRegion, colorFn: ((i: number) => string) | undefined): void {
+  private _drawColumnBackground(rgn: DataGrid.PaintRegion, colorFn: ((i: number) => string) | undefined): void {
     // Bail if there is no color function.
     if (!colorFn) {
       return;
@@ -4254,7 +4254,7 @@ class DataGrid extends Widget {
   /**
    * Draw the cells for the given paint region.
    */
-  private _drawCells(rgn: Private.PaintRegion): void {
+  private _drawCells(rgn: DataGrid.PaintRegion): void {
     // Bail if there is no data model.
     if (!this._dataModel) {
       return;
@@ -4388,7 +4388,7 @@ class DataGrid extends Widget {
   /**
    * Draw the horizontal grid lines for the given paint region.
    */
-  private _drawHorizontalGridLines(rgn: Private.PaintRegion, color: string | undefined): void {
+  private _drawHorizontalGridLines(rgn: DataGrid.PaintRegion, color: string | undefined): void {
     // Bail if there is no color to draw.
     if (!color) {
       return;
@@ -4449,7 +4449,7 @@ class DataGrid extends Widget {
   /**
    * Draw the vertical grid lines for the given paint region.
    */
-  private _drawVerticalGridLines(rgn: Private.PaintRegion, color: string | undefined): void {
+  private _drawVerticalGridLines(rgn: DataGrid.PaintRegion, color: string | undefined): void {
     // Bail if there is no color to draw.
     if (!color) {
       return;
@@ -5451,6 +5451,101 @@ namespace DataGrid {
   };
 
   /**
+   * An object which represents a region to be painted.
+   */
+  export
+  type PaintRegion = {
+    /**
+     * The min X coordinate the of the dirty viewport rect.
+     *
+     * #### Notes
+     * The data grid must not draw outside of this boundary.
+     */
+    xMin: number;
+
+    /**
+     * The min Y coordinate the of the dirty viewport rect.
+     *
+     * #### Notes
+     * The data grid must not draw outside of this boundary.
+     */
+    yMin: number;
+
+    /**
+     * The max X coordinate the of the dirty viewport rect.
+     *
+     * #### Notes
+     * The data grid must not draw outside of this boundary.
+     */
+    xMax: number;
+
+    /**
+     * The max Y coordinate the of the dirty viewport rect.
+     *
+     * #### Notes
+     * The data grid must not draw outside of this boundary.
+     */
+    yMax: number;
+
+    /**
+     * The X coordinate the of the region, in viewport coordinates.
+     *
+     * #### Notes
+     * This is aligned to the first cell boundary.
+     */
+    x: number;
+
+    /**
+     * The Y coordinate the of the region, in viewport coordinates.
+     *
+     * #### Notes
+     * This is aligned to the first cell boundary.
+     */
+    y: number;
+
+    /**
+     * The total width of the region.
+     *
+     * #### Notes
+     * This is aligned to the cell boundaries.
+     */
+    width: number;
+
+    /**
+     * The total height of the region.
+     *
+     * #### Notes
+     * This is aligned to the cell boundaries.
+     */
+    height: number;
+
+    /**
+     * The cell region being painted.
+     */
+    region: DataModel.CellRegion;
+
+    /**
+     * The row index of the first cell in the region.
+     */
+    row: number;
+
+    /**
+     * The column index of the first cell in the region.
+     */
+    column: number;
+
+    /**
+     * The row sizes for the rows in the region.
+     */
+    rowSizes: number[];
+
+    /**
+     * The column sizes for the columns in the region.
+     */
+    columnSizes: number[];
+  };
+
+  /**
    * An options object for initializing a data grid.
    */
   export
@@ -5784,101 +5879,6 @@ namespace Private {
     canvas.height = 0;
     return canvas;
   }
-
-  /**
-   * An object which represents a region to be painted.
-   */
-  export
-  type PaintRegion = {
-    /**
-     * The min X coordinate the of the dirty viewport rect.
-     *
-     * #### Notes
-     * The data grid must not draw outside of this boundary.
-     */
-    xMin: number;
-
-    /**
-     * The min Y coordinate the of the dirty viewport rect.
-     *
-     * #### Notes
-     * The data grid must not draw outside of this boundary.
-     */
-    yMin: number;
-
-    /**
-     * The max X coordinate the of the dirty viewport rect.
-     *
-     * #### Notes
-     * The data grid must not draw outside of this boundary.
-     */
-    xMax: number;
-
-    /**
-     * The max Y coordinate the of the dirty viewport rect.
-     *
-     * #### Notes
-     * The data grid must not draw outside of this boundary.
-     */
-    yMax: number;
-
-    /**
-     * The X coordinate the of the region, in viewport coordinates.
-     *
-     * #### Notes
-     * This is aligned to the first cell boundary.
-     */
-    x: number;
-
-    /**
-     * The Y coordinate the of the region, in viewport coordinates.
-     *
-     * #### Notes
-     * This is aligned to the first cell boundary.
-     */
-    y: number;
-
-    /**
-     * The total width of the region.
-     *
-     * #### Notes
-     * This is aligned to the cell boundaries.
-     */
-    width: number;
-
-    /**
-     * The total height of the region.
-     *
-     * #### Notes
-     * This is aligned to the cell boundaries.
-     */
-    height: number;
-
-    /**
-     * The cell region being painted.
-     */
-    region: DataModel.CellRegion;
-
-    /**
-     * The row index of the first cell in the region.
-     */
-    row: number;
-
-    /**
-     * The column index of the first cell in the region.
-     */
-    column: number;
-
-    /**
-     * The row sizes for the rows in the region.
-     */
-    rowSizes: number[];
-
-    /**
-     * The column sizes for the columns in the region.
-     */
-    columnSizes: number[];
-  };
 
   /**
    * A conflatable message which merges dirty paint regions.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -729,37 +729,37 @@ class DataGrid extends Widget {
   }
 
   /**
-   * The renduring context for painting the data grid.
+   * The rendering context for painting the data grid.
    */
-  get canvasGC(): CanvasRenderingContext2D {
+  protected get canvasGC(): CanvasRenderingContext2D {
     return this._canvasGC;
   }
 
   /**
    * The row sections of the data grid.
    */
-  get rowSections(): SectionList {
+  protected get rowSections(): SectionList {
     return this._rowSections;
   }
 
   /**
    * The column sections of the data grid. 
    */
-  get columnSections(): SectionList {
+  protected get columnSections(): SectionList {
     return this._columnSections;
   }
 
   /**
    * The row header sections of the data grid.
    */
-  get rowHeaderSections(): SectionList {
+  protected get rowHeaderSections(): SectionList {
     return this._rowHeaderSections;
   }
 
   /**
    * The column header sections of the data grid.
    */
-  get columnHeaderSections(): SectionList {
+  protected get columnHeaderSections(): SectionList {
     return this._columnHeaderSections;
   }
 

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3807,7 +3807,7 @@ class DataGrid extends Widget {
     }
 
     // Create the paint region object.
-    let rgn: DataGrid.PaintRegion = {
+    let rgn: Private.PaintRegion = {
       region: 'body',
       xMin: x1, yMin: y1,
       xMax: x2, yMax: y2,
@@ -3935,7 +3935,7 @@ class DataGrid extends Widget {
     }
 
     // Create the paint region object.
-    let rgn: DataGrid.PaintRegion = {
+    let rgn: Private.PaintRegion = {
       region: 'row-header',
       xMin: x1, yMin: y1,
       xMax: x2, yMax: y2,
@@ -4057,7 +4057,7 @@ class DataGrid extends Widget {
     }
 
     // Create the paint region object.
-    let rgn: DataGrid.PaintRegion = {
+    let rgn: Private.PaintRegion = {
       region: 'column-header',
       xMin: x1, yMin: y1,
       xMax: x2, yMax: y2,
@@ -4163,7 +4163,7 @@ class DataGrid extends Widget {
     }
 
     // Create the paint region object.
-    let rgn: DataGrid.PaintRegion = {
+    let rgn: Private.PaintRegion = {
       region: 'corner-header',
       xMin: x1, yMin: y1,
       xMax: x2, yMax: y2,
@@ -4194,7 +4194,7 @@ class DataGrid extends Widget {
   /**
    * Draw the background for the given paint region.
    */
-  private _drawBackground(rgn: DataGrid.PaintRegion, color: string | undefined): void {
+  private _drawBackground(rgn: Private.PaintRegion, color: string | undefined): void {
     // Bail if there is no color to draw.
     if (!color) {
       return;
@@ -4211,7 +4211,7 @@ class DataGrid extends Widget {
   /**
    * Draw the row background for the given paint region.
    */
-  private _drawRowBackground(rgn: DataGrid.PaintRegion, colorFn: ((i: number) => string) | undefined): void {
+  private _drawRowBackground(rgn: Private.PaintRegion, colorFn: ((i: number) => string) | undefined): void {
     // Bail if there is no color function.
     if (!colorFn) {
       return;
@@ -4250,7 +4250,7 @@ class DataGrid extends Widget {
   /**
    * Draw the column background for the given paint region.
    */
-  private _drawColumnBackground(rgn: DataGrid.PaintRegion, colorFn: ((i: number) => string) | undefined): void {
+  private _drawColumnBackground(rgn: Private.PaintRegion, colorFn: ((i: number) => string) | undefined): void {
     // Bail if there is no color function.
     if (!colorFn) {
       return;
@@ -4289,7 +4289,7 @@ class DataGrid extends Widget {
   /**
    * Draw the cells for the given paint region.
    */
-  private _drawCells(rgn: DataGrid.PaintRegion): void {
+  private _drawCells(rgn: Private.PaintRegion): void {
     // Bail if there is no data model.
     if (!this._dataModel) {
       return;
@@ -4423,7 +4423,7 @@ class DataGrid extends Widget {
   /**
    * Draw the horizontal grid lines for the given paint region.
    */
-  private _drawHorizontalGridLines(rgn: DataGrid.PaintRegion, color: string | undefined): void {
+  private _drawHorizontalGridLines(rgn: Private.PaintRegion, color: string | undefined): void {
     // Bail if there is no color to draw.
     if (!color) {
       return;
@@ -4484,7 +4484,7 @@ class DataGrid extends Widget {
   /**
    * Draw the vertical grid lines for the given paint region.
    */
-  private _drawVerticalGridLines(rgn: DataGrid.PaintRegion, color: string | undefined): void {
+  private _drawVerticalGridLines(rgn: Private.PaintRegion, color: string | undefined): void {
     // Bail if there is no color to draw.
     if (!color) {
       return;
@@ -5486,101 +5486,6 @@ namespace DataGrid {
   };
 
   /**
-   * An object which represents a region to be painted.
-   */
-  export
-  type PaintRegion = {
-    /**
-     * The min X coordinate the of the dirty viewport rect.
-     *
-     * #### Notes
-     * The data grid must not draw outside of this boundary.
-     */
-    xMin: number;
-
-    /**
-     * The min Y coordinate the of the dirty viewport rect.
-     *
-     * #### Notes
-     * The data grid must not draw outside of this boundary.
-     */
-    yMin: number;
-
-    /**
-     * The max X coordinate the of the dirty viewport rect.
-     *
-     * #### Notes
-     * The data grid must not draw outside of this boundary.
-     */
-    xMax: number;
-
-    /**
-     * The max Y coordinate the of the dirty viewport rect.
-     *
-     * #### Notes
-     * The data grid must not draw outside of this boundary.
-     */
-    yMax: number;
-
-    /**
-     * The X coordinate the of the region, in viewport coordinates.
-     *
-     * #### Notes
-     * This is aligned to the first cell boundary.
-     */
-    x: number;
-
-    /**
-     * The Y coordinate the of the region, in viewport coordinates.
-     *
-     * #### Notes
-     * This is aligned to the first cell boundary.
-     */
-    y: number;
-
-    /**
-     * The total width of the region.
-     *
-     * #### Notes
-     * This is aligned to the cell boundaries.
-     */
-    width: number;
-
-    /**
-     * The total height of the region.
-     *
-     * #### Notes
-     * This is aligned to the cell boundaries.
-     */
-    height: number;
-
-    /**
-     * The cell region being painted.
-     */
-    region: DataModel.CellRegion;
-
-    /**
-     * The row index of the first cell in the region.
-     */
-    row: number;
-
-    /**
-     * The column index of the first cell in the region.
-     */
-    column: number;
-
-    /**
-     * The row sizes for the rows in the region.
-     */
-    rowSizes: number[];
-
-    /**
-     * The column sizes for the columns in the region.
-     */
-    columnSizes: number[];
-  };
-
-  /**
    * An options object for initializing a data grid.
    */
   export
@@ -5914,6 +5819,101 @@ namespace Private {
     canvas.height = 0;
     return canvas;
   }
+
+  /**
+   * An object which represents a region to be painted.
+   */
+  export
+  type PaintRegion = {
+    /**
+     * The min X coordinate the of the dirty viewport rect.
+     *
+     * #### Notes
+     * The data grid must not draw outside of this boundary.
+     */
+    xMin: number;
+
+    /**
+     * The min Y coordinate the of the dirty viewport rect.
+     *
+     * #### Notes
+     * The data grid must not draw outside of this boundary.
+     */
+    yMin: number;
+
+    /**
+     * The max X coordinate the of the dirty viewport rect.
+     *
+     * #### Notes
+     * The data grid must not draw outside of this boundary.
+     */
+    xMax: number;
+
+    /**
+     * The max Y coordinate the of the dirty viewport rect.
+     *
+     * #### Notes
+     * The data grid must not draw outside of this boundary.
+     */
+    yMax: number;
+
+    /**
+     * The X coordinate the of the region, in viewport coordinates.
+     *
+     * #### Notes
+     * This is aligned to the first cell boundary.
+     */
+    x: number;
+
+    /**
+     * The Y coordinate the of the region, in viewport coordinates.
+     *
+     * #### Notes
+     * This is aligned to the first cell boundary.
+     */
+    y: number;
+
+    /**
+     * The total width of the region.
+     *
+     * #### Notes
+     * This is aligned to the cell boundaries.
+     */
+    width: number;
+
+    /**
+     * The total height of the region.
+     *
+     * #### Notes
+     * This is aligned to the cell boundaries.
+     */
+    height: number;
+
+    /**
+     * The cell region being painted.
+     */
+    region: DataModel.CellRegion;
+
+    /**
+     * The row index of the first cell in the region.
+     */
+    row: number;
+
+    /**
+     * The column index of the first cell in the region.
+     */
+    column: number;
+
+    /**
+     * The row sizes for the rows in the region.
+     */
+    rowSizes: number[];
+
+    /**
+     * The column sizes for the columns in the region.
+     */
+    columnSizes: number[];
+  };
 
   /**
    * A conflatable message which merges dirty paint regions.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -729,6 +729,13 @@ class DataGrid extends Widget {
   }
 
   /**
+   * The renduring context for painting the data grid.
+   */
+  get canvasGC(): CanvasRenderingContext2D {
+    return this._canvasGC;
+  }
+
+  /**
    * Scroll the grid to the specified row.
    *
    * @param row - The row index of the cell.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -336,7 +336,7 @@ class DataGrid extends Widget {
     this._selectionModel = value;
 
     // Schedule a repaint of the overlay.
-    this._repaintOverlay();
+    this.repaintOverlay();
   }
 
   /**
@@ -396,10 +396,10 @@ class DataGrid extends Widget {
     this._style = { ...value };
 
     // Schedule a repaint of the content.
-    this._repaintContent();
+    this.repaintContent();
 
     // Schedule a repaint of the overlay.
-    this._repaintOverlay();
+    this.repaintOverlay();
   }
 
   /**
@@ -428,7 +428,7 @@ class DataGrid extends Widget {
     this._cellRenderers = value;
 
     // Schedule a repaint of the grid content.
-    this._repaintContent();
+    this.repaintContent();
   }
 
   /**
@@ -1428,8 +1428,8 @@ class DataGrid extends Widget {
     default:
       throw 'unreachable';
     }
-    this._repaintContent();
-    this._repaintOverlay();
+    this.repaintContent();
+    this.repaintOverlay();
   }
 
   /**
@@ -1452,8 +1452,8 @@ class DataGrid extends Widget {
     default:
       throw 'unreachable';
     }
-    this._repaintContent();
-    this._repaintOverlay();
+    this.repaintContent();
+    this.repaintOverlay();
   }
 
   /**
@@ -1949,8 +1949,8 @@ class DataGrid extends Widget {
     this._viewport.node.addEventListener('dblclick', this);
     this._viewport.node.addEventListener('mouseleave', this);
     this._viewport.node.addEventListener('contextmenu', this);
-    this._repaintContent();
-    this._repaintOverlay();
+    this.repaintContent();
+    this.repaintOverlay();
   }
 
   /**
@@ -1972,8 +1972,8 @@ class DataGrid extends Widget {
    * A message handler invoked on a `'before-show'` message.
    */
   protected onBeforeShow(msg: Message): void {
-    this._repaintContent();
-    this._repaintOverlay();
+    this.repaintContent();
+    this.repaintOverlay();
   }
 
   /**
@@ -1990,7 +1990,7 @@ class DataGrid extends Widget {
   /**
    * Schedule a repaint of all of the grid content.
    */
-  private _repaintContent(): void {
+  protected repaintContent(): void {
     let msg = new Private.PaintRequest('all', 0, 0, 0, 0);
     MessageLoop.postMessage(this._viewport, msg);
   }
@@ -2006,7 +2006,7 @@ class DataGrid extends Widget {
   /**
    * Schedule a repaint of the overlay.
    */
-  private _repaintOverlay(): void {
+  protected repaintOverlay(): void {
     MessageLoop.postMessage(this._viewport, Private.OverlayPaintRequest);
   }
 
@@ -2182,8 +2182,8 @@ class DataGrid extends Widget {
    * This schedules a full repaint and syncs the scroll state.
    */
   private _syncViewport(): void {
-    this._repaintContent();
-    this._repaintOverlay();
+    this.repaintContent();
+    this.repaintOverlay();
     this._syncScrollState();
   }
 
@@ -2508,7 +2508,7 @@ class DataGrid extends Widget {
    * A signal handler for the selection model `changed` signal.
    */
   private _onSelectionsChanged(sender: SelectionModel): void {
-    this._repaintOverlay();
+    this.repaintOverlay();
   }
 
   /**
@@ -2839,7 +2839,7 @@ class DataGrid extends Widget {
    * A signal handler for the renderer map `changed` signal.
    */
   private _onRenderersChanged(): void {
-    this._repaintContent();
+    this.repaintContent();
   }
 
   /**
@@ -3035,10 +3035,10 @@ class DataGrid extends Widget {
     this._dpiRatio = dpiRatio;
 
     // Schedule a repaint of the content.
-    this._repaintContent();
+    this.repaintContent();
 
     // Schedule a repaint of the overlay.
-    this._repaintOverlay();
+    this.repaintOverlay();
 
     // Update the canvas size for the new dpi ratio.
     this._resizeCanvasIfNeeded(this._viewportWidth, this._viewportHeight);

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -736,6 +736,20 @@ class DataGrid extends Widget {
   }
 
   /**
+   * The row sections of the data grid.
+   */
+  get rowSections(): SectionList {
+    return this._rowSections;
+  }
+
+  /**
+   * The column sections of the data grid. 
+   */
+  get columnSections(): SectionList {
+    return this._columnSections;
+  }
+
+  /**
    * Scroll the grid to the specified row.
    *
    * @param row - The row index of the cell.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -2236,7 +2236,7 @@ class DataGrid extends Widget {
 
     // Paint the whole grid if the old size was zero.
     if (oldWidth === 0 || oldHeight === 0) {
-      this._paintContent(0, 0, width, height);
+      this.paintContent(0, 0, width, height);
       this._paintOverlay();
       return;
     }
@@ -2245,18 +2245,18 @@ class DataGrid extends Widget {
     if (this._stretchLastColumn && this.pageWidth > this.bodyWidth) {
       let bx = this._columnSections.offsetOf(this._columnSections.count - 1);
       let x = Math.min(this.headerWidth + bx, oldWidth);
-      this._paintContent(x, 0, width - x, height);
+      this.paintContent(x, 0, width - x, height);
     } else if (width > oldWidth) {
-      this._paintContent(oldWidth, 0, width - oldWidth, height);
+      this.paintContent(oldWidth, 0, width - oldWidth, height);
     }
 
     // Paint the bottom edge as needed.
     if (this._stretchLastRow && this.pageHeight > this.bodyHeight) {
       let by = this._rowSections.offsetOf(this._rowSections.count - 1);
       let y = Math.min(this.headerHeight + by, oldHeight);
-      this._paintContent(0, y, width, height - y);
+      this.paintContent(0, y, width, height - y);
     } else if (height > oldHeight) {
-      this._paintContent(0, oldHeight, width, height - oldHeight);
+      this.paintContent(0, oldHeight, width, height - oldHeight);
     }
 
     // Paint the overlay.
@@ -2377,7 +2377,7 @@ class DataGrid extends Widget {
     y2 = Math.max(yMin, Math.min(y2, yMax));
 
     // Paint the content of the dirty rect.
-    this._paintContent(x1, y1, x2 - x1 + 1, y2 - y1 + 1);
+    this.paintContent(x1, y1, x2 - x1 + 1, y2 - y1 + 1);
   }
 
   /**
@@ -3094,7 +3094,7 @@ class DataGrid extends Widget {
 
     // Paint from the section onward if it spans the viewport.
     if (offset + oldSize >= vh || offset + newSize >= vh) {
-      this._paintContent(0, pos, vw, vh - pos);
+      this.paintContent(0, pos, vw, vh - pos);
       this._paintOverlay();
       this._syncScrollState();
       return;
@@ -3124,16 +3124,16 @@ class DataGrid extends Widget {
 
     // Repaint the section if needed.
     if (newSize > 0 && offset + newSize > hh) {
-      this._paintContent(0, pos, vw, offset + newSize - pos);
+      this.paintContent(0, pos, vw, offset + newSize - pos);
     }
 
     // Paint the trailing space as needed.
     if (this._stretchLastRow && this.pageHeight > this.bodyHeight) {
       let r = this._rowSections.count - 1;
       let y = hh + this._rowSections.offsetOf(r);
-      this._paintContent(0, y, vw, vh - y);
+      this.paintContent(0, y, vw, vh - y);
     } else if (delta < 0) {
-      this._paintContent(0, vh + delta, vw, -delta);
+      this.paintContent(0, vh + delta, vw, -delta);
     }
 
     // Paint the overlay.
@@ -3206,7 +3206,7 @@ class DataGrid extends Widget {
 
     // Paint from the section onward if it spans the viewport.
     if (offset + oldSize >= vw || offset + newSize >= vw) {
-      this._paintContent(pos, 0, vw - pos, vh);
+      this.paintContent(pos, 0, vw - pos, vh);
       this._paintOverlay();
       this._syncScrollState();
       return;
@@ -3236,16 +3236,16 @@ class DataGrid extends Widget {
 
     // Repaint the section if needed.
     if (newSize > 0 && offset + newSize > hw) {
-      this._paintContent(pos, 0, offset + newSize - pos, vh);
+      this.paintContent(pos, 0, offset + newSize - pos, vh);
     }
 
     // Paint the trailing space as needed.
     if (this._stretchLastColumn && this.pageWidth > this.bodyWidth) {
       let c = this._columnSections.count - 1;
       let x = hw + this._columnSections.offsetOf(c);
-      this._paintContent(x, 0, vw - x, vh);
+      this.paintContent(x, 0, vw - x, vh);
     } else if (delta < 0) {
-      this._paintContent(vw + delta, 0, -delta, vh);
+      this.paintContent(vw + delta, 0, -delta, vh);
     }
 
     // Paint the overlay.
@@ -3305,7 +3305,7 @@ class DataGrid extends Widget {
 
     // Paint the entire tail if the section spans the viewport.
     if (offset + oldSize >= vw || offset + newSize >= vw) {
-      this._paintContent(offset, 0, vw - offset, vh);
+      this.paintContent(offset, 0, vw - offset, vh);
       this._paintOverlay();
       this._syncScrollState();
       return;
@@ -3324,16 +3324,16 @@ class DataGrid extends Widget {
 
     // Repaint the header section if needed.
     if (newSize > 0) {
-      this._paintContent(offset, 0, newSize, vh);
+      this.paintContent(offset, 0, newSize, vh);
     }
 
     // Paint the trailing space as needed.
     if (this._stretchLastColumn && this.pageWidth > this.bodyWidth) {
       let c = this._columnSections.count - 1;
       let x = this.headerWidth + this._columnSections.offsetOf(c);
-      this._paintContent(x, 0, vw - x, vh);
+      this.paintContent(x, 0, vw - x, vh);
     } else if (delta < 0) {
-      this._paintContent(vw + delta, 0, -delta, vh);
+      this.paintContent(vw + delta, 0, -delta, vh);
     }
 
     // Paint the overlay.
@@ -3396,7 +3396,7 @@ class DataGrid extends Widget {
 
     // Paint the entire tail if the section spans the viewport.
     if (offset + oldSize >= vh || offset + newSize >= vh) {
-      this._paintContent(0, offset, vw, vh - offset);
+      this.paintContent(0, offset, vw, vh - offset);
       this._paintOverlay();
       this._syncScrollState();
       return;
@@ -3415,16 +3415,16 @@ class DataGrid extends Widget {
 
     // Repaint the header section if needed.
     if (newSize > 0) {
-      this._paintContent(0, offset, vw, newSize);
+      this.paintContent(0, offset, vw, newSize);
     }
 
     // Paint the trailing space as needed.
     if (this._stretchLastRow && this.pageHeight > this.bodyHeight) {
       let r = this._rowSections.count - 1;
       let y = this.headerHeight + this._rowSections.offsetOf(r);
-      this._paintContent(0, y, vw, vh - y);
+      this.paintContent(0, y, vw, vh - y);
     } else if (delta < 0) {
-      this._paintContent(0, vh + delta, vw, -delta);
+      this.paintContent(0, vh + delta, vw, -delta);
     }
 
     // Paint the overlay.
@@ -3512,7 +3512,7 @@ class DataGrid extends Widget {
     if ((dxArea + dyArea) >= (width * height)) {
       this._scrollX = x;
       this._scrollY = y;
-      this._paintContent(0, 0, width, height);
+      this.paintContent(0, 0, width, height);
       this._paintOverlay();
       return;
     }
@@ -3525,14 +3525,14 @@ class DataGrid extends Widget {
     // valid content and paint the dirty region.
     if (dy !== 0 && contentHeight > 0) {
       if (Math.abs(dy) >= contentHeight) {
-        this._paintContent(0, contentY, width, contentHeight);
+        this.paintContent(0, contentY, width, contentHeight);
       } else {
         let x = 0;
         let y = dy < 0 ? contentY : contentY + dy;
         let w = width;
         let h = contentHeight - Math.abs(dy);
         this._blitContent(this._canvas, x, y, w, h, x, y - dy);
-        this._paintContent(0, dy < 0 ? contentY : height - dy, width, Math.abs(dy));
+        this.paintContent(0, dy < 0 ? contentY : height - dy, width, Math.abs(dy));
       }
     }
 
@@ -3544,14 +3544,14 @@ class DataGrid extends Widget {
     // valid content and paint the dirty region.
     if (dx !== 0 && contentWidth > 0) {
       if (Math.abs(dx) >= contentWidth) {
-        this._paintContent(contentX, 0, contentWidth, height);
+        this.paintContent(contentX, 0, contentWidth, height);
       } else {
         let x = dx < 0 ? contentX : contentX + dx;
         let y = 0;
         let w = contentWidth - Math.abs(dx);
         let h = height;
         this._blitContent(this._canvas, x, y, w, h, x - dx, y);
-        this._paintContent(dx < 0 ? contentX : width - dx, 0, Math.abs(dx), height);
+        this.paintContent(dx < 0 ? contentX : width - dx, 0, Math.abs(dx), height);
       }
     }
 
@@ -3597,7 +3597,7 @@ class DataGrid extends Widget {
    * methods should not be invoked directly. This method dispatches
    * to the drawing methods in the correct order.
    */
-  private _paintContent(rx: number, ry: number, rw: number, rh: number): void {
+  protected paintContent(rx: number, ry: number, rw: number, rh: number): void {
     // Scale the canvas and buffer GC for the dpi ratio.
     this._canvasGC.setTransform(this._dpiRatio, 0, 0, this._dpiRatio, 0, 0);
     this._bufferGC.setTransform(this._dpiRatio, 0, 0, this._dpiRatio, 0, 0);

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -750,6 +750,20 @@ class DataGrid extends Widget {
   }
 
   /**
+   * The row header sections of the data grid.
+   */
+  get rowHeaderSections(): SectionList {
+    return this._rowHeaderSections;
+  }
+
+  /**
+   * The column header sections of the data grid.
+   */
+  get columnHeaderSections(): SectionList {
+    return this._columnHeaderSections;
+  }
+
+  /**
    * Scroll the grid to the specified row.
    *
    * @param row - The row index of the cell.


### PR DESCRIPTION
Hi, my name is Logan McNichols. I am an intern for Jupyter Cal Poly. I am working on a tabular data editor powered by the `DataGrid` along with @kgoo124 and @ryuntalan.

We are working on a design that involves painting `LabIcons` onto the `DataGrid`'s canvas to correspond the the type of field in a given column. To achieve this, we would like to provide getters for some of the `DataGrid`'s properties and change some `private` methods to `protected`.

This PR would change the access modifier from `private` to `protected` on the following methods.
- `paintContent`
`repaintContent` 
& `repaintOverlay`

It would also add getters for the following properties.
- `_canvasGC`
- `_rowSections`
- `_columnSections`
- `_columnHeaderSections`
- `_rowHeaderSections`.

Fixes #110 