### PR TITLE
mouseDown now uses cell, column, and row selection modes

### DIFF
--- a/packages/datagrid/src/basicmousehandler.ts
+++ b/packages/datagrid/src/basicmousehandler.ts
@@ -203,6 +203,9 @@ class BasicMouseHandler implements DataGrid.IMouseHandler {
         clear = 'all';
       }
 
+      // Use selection mode 'cell'
+      model.selectionMode = 'cell'
+
       // Make the selection.
       model.select({ r1, c1, r2, c2, cursorRow, cursorColumn, clear });
 
@@ -331,6 +334,19 @@ class BasicMouseHandler implements DataGrid.IMouseHandler {
       cursorRow = accel ? row : shift ? model.cursorRow : row;
       cursorColumn = accel ? column : shift ? model.cursorColumn : column;
       clear = accel ? 'none' : shift ? 'current' : 'all';
+    }
+
+    // Set selection mode based on region
+    switch (region) {
+      case 'column-header':
+        model.selectionMode = 'column';
+        break;
+      case 'row-header':
+        model.selectionMode = 'row';
+        break;
+      default:
+        model.selectionMode = 'cell';
+        break;
     }
 
     // Make the selection.

--- a/packages/datagrid/src/basicmousehandler.ts
+++ b/packages/datagrid/src/basicmousehandler.ts
@@ -204,7 +204,7 @@ class BasicMouseHandler implements DataGrid.IMouseHandler {
       }
 
       // Use selection mode 'cell'
-      model.selectionMode = 'cell'
+      model.selectionMode = 'cell';
 
       // Make the selection.
       model.select({ r1, c1, r2, c2, cursorRow, cursorColumn, clear });


### PR DESCRIPTION
I am currently working on the Tabular Data Editor extension with @lmcnichols and @ryuntalan. We noticed the BasicMouseHandler doesn't utilize the different selection modes onMouseDown. This change would set the proper `selectionMode` during the `onMouseDown()` function. There are other places in the mouse handler where the grid is selecting certain areas, so those could also be changed as well.
