### PR TITLE
Make private _drawCornerHeaderRegion protected drawCornerHeaderRegion

### DIFF
--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3653,7 +3653,7 @@ class DataGrid extends Widget {
     this._drawColumnHeaderRegion(rx, ry, rw, rh);
 
     // Draw the corner header region.
-    this._drawCornerHeaderRegion(rx, ry, rw, rh);
+    this.drawCornerHeaderRegion(rx, ry, rw, rh);
   }
 
   /**
@@ -4088,7 +4088,7 @@ class DataGrid extends Widget {
   /**
    * Draw the corner header region which intersects the dirty rect.
    */
-  private _drawCornerHeaderRegion(rx: number, ry: number, rw: number, rh: number): void {
+  protected drawCornerHeaderRegion(rx: number, ry: number, rw: number, rh: number): void {
     // Get the visible content dimensions.
     let contentW = this.headerWidth;
     let contentH = this.headerHeight;


### PR DESCRIPTION
Hi, my name is Logan McNichols. I am an intern for Jupyter Cal Poly. I am working on a tabular data editor powered by the DataGrid along with @kgoo124 and @ryuntalan.

This pull request would make the `DataGrid`'s private method `_drawCornerHeaderRegion` a protected `drawCornerHeaderRegion`. It is helpful for extending classes to be able to access this method to repaint the `'corner-header'` as the last paint operation.

Fixes #115