### PR TITLE
Fix sluggish tab dragging in the tab bar.

### DIFF
--- a/packages/widgets/style/tabbar.css
+++ b/packages/widgets/style/tabbar.css
@@ -121,7 +121,7 @@
 
 
 /* <DEPRECATED> */
-.p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging
+.p-TabBar.p-mod-dragging .p-TabBar-tab.p-mod-dragging,
 /* </DEPRECATED> */
 .lm-TabBar.lm-mod-dragging .lm-TabBar-tab.lm-mod-dragging {
   transition: none;


### PR DESCRIPTION
This fixes a typo from commit 45c6f21.

If you need to reproduce the issue, you can roll back an application with a dock panel to widgets@1.9.7 and default-theme@0.1.8, and compare the responsiveness of the tab bar to an application built at the latest versions.