### PR TITLE
Add ARIA roles to tabs - lumino update

### DIFF
--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -1994,14 +1994,17 @@ namespace Private {
   }
 
   export
-  async function addAria(widget: Widget, tabBar: TabBar<Widget>) {
-    let tabId = tabBar.renderer.createTabKey({title: widget.title, current: false, zIndex: 0});
+  function addAria(widget: Widget, tabBar: TabBar<Widget>) {
     widget.node.setAttribute('role', 'tabpanel');
-    widget.node.setAttribute('aria-labelledby', tabId);
+    let renderer = tabBar.renderer;
+    if (renderer instanceof TabBar.Renderer) {
+      let tabId = renderer.createTabKey({ title: widget.title, current: false, zIndex: 0 });
+      widget.node.setAttribute('aria-labelledby', tabId);  
+    }
   }
 
   export
-  async function removeAria(widget: Widget) {
+  function removeAria(widget: Widget) {
     widget.node.removeAttribute('role');
     widget.node.removeAttribute('aria-labelledby');
   }

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -1996,11 +1996,8 @@ namespace Private {
   export
   async function addAria(widget: Widget, tabBar: TabBar<Widget>) {
     let tabId = tabBar.renderer.createTabKey({title: widget.title, current: false, zIndex: 0});
-
-    if (tabId) {
-      widget.node.setAttribute('role', 'tabpanel');
-      widget.node.setAttribute('aria-labelledby', tabId);
-    }
+    widget.node.setAttribute('role', 'tabpanel');
+    widget.node.setAttribute('aria-labelledby', tabId);
   }
 
   export

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -639,6 +639,8 @@ class DockLayout extends Layout {
       return;
     }
 
+    Private.removeAria(widget);
+
     // If there are multiple tabs, just remove the widget's tab.
     if (tabNode.tabBar.titles.length > 1) {
       tabNode.tabBar.removeTab(widget.title);
@@ -770,6 +772,7 @@ class DockLayout extends Layout {
       let tabNode = new Private.TabLayoutNode(this._createTabBar());
       tabNode.tabBar.addTab(widget.title);
       this._root = tabNode;
+      Private.addAria(widget, tabNode.tabBar);
       return;
     }
 
@@ -795,6 +798,7 @@ class DockLayout extends Layout {
 
     // Insert the widget's tab relative to the target index.
     refNode.tabBar.insertTab(index + (after ? 1 : 0), widget.title);
+    Private.addAria(widget, refNode.tabBar);
   }
 
   /**
@@ -815,6 +819,7 @@ class DockLayout extends Layout {
     // Create the tab layout node to hold the widget.
     let tabNode = new Private.TabLayoutNode(this._createTabBar());
     tabNode.tabBar.addTab(widget.title);
+    Private.addAria(widget, tabNode.tabBar);
 
     // Set the root if it does not exist.
     if (!this._root) {
@@ -1988,6 +1993,22 @@ namespace Private {
     }
   }
 
+  export
+  async function addAria(widget: Widget, tabBar: TabBar<Widget>) {
+    let tabId = tabBar.renderer.createTabKey({title: widget.title, current: false, zIndex: 0});
+
+    if (tabId) {
+      widget.node.setAttribute('role', 'tabpanel');
+      widget.node.setAttribute('aria-labelledby', tabId);
+    }
+  }
+
+  export
+  async function removeAria(widget: Widget) {
+    widget.node.removeAttribute('role');
+    widget.node.removeAttribute('aria-labelledby');
+  }
+
   /**
    * Normalize a tab area config and collect the visited widgets.
    */
@@ -2077,6 +2098,7 @@ namespace Private {
     each(config.widgets, widget => {
       widget.hide();
       tabBar.addTab(widget.title);
+      Private.addAria(widget, tabBar);
     });
 
     // Set the current index of the tab bar.

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -1299,7 +1299,7 @@ namespace DockPanel {
      * @returns A new tab bar for a dock panel.
      */
     createTabBar(): TabBar<Widget> {
-      let bar = new TabBar<Widget>();
+      let bar = new TabBar<Widget>({name: `Activities ${this._tabBarCounter++}`});
       bar.addClass('lm-DockPanel-tabBar');
       /* <DEPRECATED> */
       bar.addClass('p-DockPanel-tabBar');
@@ -1320,6 +1320,7 @@ namespace DockPanel {
       /* </DEPRECATED> */;
       return handle;
     }
+    private _tabBarCounter = 0;
   }
 
   /**

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -1299,7 +1299,7 @@ namespace DockPanel {
      * @returns A new tab bar for a dock panel.
      */
     createTabBar(): TabBar<Widget> {
-      let bar = new TabBar<Widget>({name: `Activities ${this._tabBarCounter++}`});
+      let bar = new TabBar<Widget>();
       bar.addClass('lm-DockPanel-tabBar');
       /* <DEPRECATED> */
       bar.addClass('p-DockPanel-tabBar');
@@ -1320,7 +1320,6 @@ namespace DockPanel {
       /* </DEPRECATED> */;
       return handle;
     }
-    private _tabBarCounter = 0;
   }
 
   /**

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -65,22 +65,16 @@ class TabBar<T extends Widget> extends Widget {
     /* <DEPRECATED> */
     this.addClass('p-TabBar');
     /* </DEPRECATED> */
+    this.contentNode.setAttribute('role', 'tablist');
     this.setFlag(Widget.Flag.DisallowLayout);
     this.tabsMovable = options.tabsMovable || false;
     this.titlesEditable = options.titlesEditable || false;
     this.allowDeselect = options.allowDeselect || false;
     this.insertBehavior = options.insertBehavior || 'select-tab-if-needed';
+    this.name = options.name || '';
+    this.orientation = options.orientation || 'horizontal';
     this.removeBehavior = options.removeBehavior || 'select-tab-after';
     this.renderer = options.renderer || TabBar.defaultRenderer;
-    this._orientation = options.orientation || 'horizontal';
-    this.dataset['orientation'] = this._orientation;
-
-    let contentNode = this.contentNode;
-    contentNode.setAttribute('role', 'tablist');
-    contentNode.setAttribute('aria-orientation', this.orientation);
-
-    // TODO: what should this be?
-    contentNode.setAttribute('aria-label', 'Tabs');
   }
 
   /**
@@ -273,6 +267,25 @@ class TabBar<T extends Widget> extends Widget {
       previousIndex: pi, previousTitle: pt,
       currentIndex: ci, currentTitle: ct
     });
+  }
+
+  /**
+   * Get the name of the tab bar.
+   */
+  get name(): string {
+    return this._name;
+  }
+
+  /**
+   * Set the name of the tab bar.
+   */
+  set name(value: string) {
+    this._name = value;
+    if (value) {
+      this.contentNode.setAttribute('aria-label', value);
+    } else {
+      this.contentNode.removeAttribute('aria-label');
+    }
   }
 
   /**
@@ -1118,6 +1131,7 @@ class TabBar<T extends Widget> extends Widget {
     this.update();
   }
 
+  private _name: string;
   private _currentIndex = -1;
   private _titles: Title<T>[] = [];
   private _orientation: TabBar.Orientation;
@@ -1209,6 +1223,13 @@ namespace TabBar {
    */
   export
   interface IOptions<T> {
+    /**
+     * Name of the tab bar.
+     *
+     * This is used for accessibility reasons. The default is the empty string.
+     */
+    name?: string;
+
     /**
      * The layout orientation of the tab bar.
      *

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -74,6 +74,12 @@ class TabBar<T> extends Widget {
     this.renderer = options.renderer || TabBar.defaultRenderer;
     this._orientation = options.orientation || 'horizontal';
     this.dataset['orientation'] = this._orientation;
+
+    // Should tablist be on the contentNode, or on this.node? (the div or the ul
+    // containing the li elements?)
+    let contentNode = this.contentNode;
+    contentNode.setAttribute('role', 'tablist');
+    contentNode.setAttribute('aria-orientation', this.orientation);
   }
 
   /**

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -75,8 +75,6 @@ class TabBar<T extends Widget> extends Widget {
     this._orientation = options.orientation || 'horizontal';
     this.dataset['orientation'] = this._orientation;
 
-    // Should tablist be on the contentNode, or on this.node? (the div or the ul
-    // containing the li elements?)
     let contentNode = this.contentNode;
     contentNode.setAttribute('role', 'tablist');
     contentNode.setAttribute('aria-orientation', this.orientation);
@@ -1590,7 +1588,7 @@ namespace TabBar {
      * @returns The ARIA attributes for the tab.
      */
     createTabARIA(data: IRenderData<T>): ElementARIAAttrs {
-      return {role: 'tab', 'aria-controls': data.title.owner.id, 'aria-selected': data.current.toString()};
+      return {role: 'tab', 'aria-selected': data.current.toString()};
     }
 
     /**

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1430,6 +1430,17 @@ namespace TabBar {
      */
     renderTab(data: IRenderData<T>): VirtualElement;
 
+    /**
+     * Create a stable unique id for a tab based on the title.
+     *
+     * @param data - The data to use for the tab.
+     *
+     * @returns The unique id for a tab.
+     *
+     * #### Notes
+     * This method returns a stable unique id for a tab, depending only on the
+     * title. The tab DOM `id` is set to this value.
+     */
     createTabKey(data: IRenderData<T>): string;
   }
 

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -80,6 +80,9 @@ class TabBar<T extends Widget> extends Widget {
     let contentNode = this.contentNode;
     contentNode.setAttribute('role', 'tablist');
     contentNode.setAttribute('aria-orientation', this.orientation);
+
+    // TODO: what should this be?
+    contentNode.setAttribute('aria-label', 'Tabs');
   }
 
   /**
@@ -1587,7 +1590,7 @@ namespace TabBar {
      * @returns The ARIA attributes for the tab.
      */
     createTabARIA(data: IRenderData<T>): ElementARIAAttrs {
-      return {role: 'tab', 'aria-controls': data.title.owner.id};
+      return {role: 'tab', 'aria-controls': data.title.owner.id, 'aria-selected': data.current.toString()};
     }
 
     /**

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -32,7 +32,7 @@ import {
 } from '@lumino/signaling';
 
 import {
-  ElementDataset, ElementInlineStyle, VirtualDOM, VirtualElement, h
+  ElementARIAAttrs, ElementDataset, ElementInlineStyle, VirtualDOM, VirtualElement, h
 } from '@lumino/virtualdom';
 
 import {
@@ -1433,8 +1433,9 @@ namespace TabBar {
       let style = this.createTabStyle(data);
       let className = this.createTabClass(data);
       let dataset = this.createTabDataset(data);
+      let aria = this.createTabARIA(data);
       return (
-        h.li({ key, className, title, style, dataset },
+        h.li({ key, className, title, style, dataset, ...aria },
           this.renderIcon(data),
           this.renderLabel(data),
           this.renderCloseIcon(data)
@@ -1566,6 +1567,17 @@ namespace TabBar {
      */
     createTabDataset(data: IRenderData<any>): ElementDataset {
       return data.title.dataset;
+    }
+
+    /**
+     * Create the ARIA attributes for a tab.
+     *
+     * @param data - The data to use for the tab.
+     *
+     * @returns The ARIA attributes for the tab.
+     */
+    createTabARIA(data: IRenderData<any>): ElementARIAAttrs {
+      return {role: 'tab'};
     }
 
     /**
@@ -1730,6 +1742,7 @@ namespace Private {
   function createNode(): HTMLDivElement {
     let node = document.createElement('div');
     let content = document.createElement('ul');
+    content.setAttribute('role', 'tablist');
     content.className = 'lm-TabBar-content';
     /* <DEPRECATED> */
     content.classList.add('p-TabBar-content');

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1018,6 +1018,9 @@ class TabBar<T> extends Widget {
     let ci = this._currentIndex;
     let bh = this.insertBehavior;
 
+
+    // TODO: do we need to do an update to update the aria-selected attribute?
+
     // Handle the behavior where the new tab is always selected,
     // or the behavior where the new tab is selected if needed.
     if (bh === 'select-tab' || (bh === 'select-tab-if-needed' && ci === -1)) {
@@ -1070,6 +1073,8 @@ class TabBar<T> extends Widget {
       }
       return;
     }
+
+    // TODO: do we need to do an update to adjust the aria-selected value?
 
     // No tab gets selected if the tab bar is empty.
     if (this._titles.length === 0) {

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1434,19 +1434,6 @@ namespace TabBar {
      * @returns A virtual element representing the tab.
      */
     renderTab(data: IRenderData<T>): VirtualElement;
-
-    /**
-     * Create a stable unique id for a tab based on the title.
-     *
-     * @param data - The data to use for the tab.
-     *
-     * @returns The unique id for a tab.
-     *
-     * #### Notes
-     * This method returns a stable unique id for a tab, depending only on the
-     * title. The tab DOM `id` is set to this value.
-     */
-    createTabKey(data: IRenderData<T>): string;
   }
 
   /**

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -53,7 +53,7 @@ import {
  * property should be set to `false` when rotating nodes from CSS.
  */
 export
-class TabBar<T extends Widget> extends Widget {
+class TabBar<T> extends Widget {
   /**
    * Construct a new tab bar.
    *
@@ -1440,7 +1440,7 @@ namespace TabBar {
    * Subclasses are free to reimplement rendering methods as needed.
    */
   export
-  class Renderer<T extends Widget = Widget> implements IRenderer<T> {
+  class Renderer implements IRenderer<any> {
     /**
      * Construct a new renderer.
      */
@@ -1458,7 +1458,7 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab.
      */
-    renderTab(data: IRenderData<T>): VirtualElement {
+    renderTab(data: IRenderData<any>): VirtualElement {
       let title = data.title.caption;
       let key = this.createTabKey(data);
       let id = key;
@@ -1482,7 +1482,7 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab icon.
      */
-    renderIcon(data: IRenderData<T>): VirtualElement {
+    renderIcon(data: IRenderData<any>): VirtualElement {
       const { title } = data;
       let className = this.createIconClass(data);
 
@@ -1503,7 +1503,7 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab label.
      */
-    renderLabel(data: IRenderData<T>): VirtualElement {
+    renderLabel(data: IRenderData<any>): VirtualElement {
       return h.div({
         className: 'lm-TabBar-tabLabel'
           /* <DEPRECATED> */
@@ -1519,7 +1519,7 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab close icon.
      */
-    renderCloseIcon(data: IRenderData<T>): VirtualElement {
+    renderCloseIcon(data: IRenderData<any>): VirtualElement {
       return h.div({
         className: 'lm-TabBar-tabCloseIcon'
           /* <DEPRECATED> */
@@ -1540,7 +1540,7 @@ namespace TabBar {
      * the key is generated. This enables efficient rendering of moved
      * tabs and avoids subtle hover style artifacts.
      */
-    createTabKey(data: IRenderData<T>): string {
+    createTabKey(data: IRenderData<any>): string {
       let key = this._tabKeys.get(data.title);
       if (key === undefined) {
         key = `tab-key-${this._tabID++}`;
@@ -1556,7 +1556,7 @@ namespace TabBar {
      *
      * @returns The inline style data for the tab.
      */
-    createTabStyle(data: IRenderData<T>): ElementInlineStyle {
+    createTabStyle(data: IRenderData<any>): ElementInlineStyle {
       return { zIndex: `${data.zIndex}` };
     }
 
@@ -1567,7 +1567,7 @@ namespace TabBar {
      *
      * @returns The full class name for the tab.
      */
-    createTabClass(data: IRenderData<T>): string {
+    createTabClass(data: IRenderData<any>): string {
       let name = 'lm-TabBar-tab';
       /* <DEPRECATED> */
       name += ' p-TabBar-tab';
@@ -1597,7 +1597,7 @@ namespace TabBar {
      *
      * @returns The dataset for the tab.
      */
-    createTabDataset(data: IRenderData<T>): ElementDataset {
+    createTabDataset(data: IRenderData<any>): ElementDataset {
       return data.title.dataset;
     }
 
@@ -1608,7 +1608,7 @@ namespace TabBar {
      *
      * @returns The ARIA attributes for the tab.
      */
-    createTabARIA(data: IRenderData<T>): ElementARIAAttrs {
+    createTabARIA(data: IRenderData<any>): ElementARIAAttrs {
       return {role: 'tab', 'aria-selected': data.current.toString()};
     }
 
@@ -1619,7 +1619,7 @@ namespace TabBar {
      *
      * @returns The full class name for the tab icon.
      */
-    createIconClass(data: IRenderData<T>): string {
+    createIconClass(data: IRenderData<any>): string {
       let name = 'lm-TabBar-tabIcon';
       /* <DEPRECATED> */
       name += ' p-TabBar-tabIcon';
@@ -1629,7 +1629,7 @@ namespace TabBar {
     }
 
     private _tabID = 0;
-    private _tabKeys = new WeakMap<Title<T>, string>();
+    private _tabKeys = new WeakMap<Title<any>, string>();
   }
 
   /**

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -53,7 +53,7 @@ import {
  * property should be set to `false` when rotating nodes from CSS.
  */
 export
-class TabBar<T> extends Widget {
+class TabBar<T extends Widget> extends Widget {
   /**
    * Construct a new tab bar.
    *
@@ -302,6 +302,7 @@ class TabBar<T> extends Widget {
     // Toggle the orientation values.
     this._orientation = value;
     this.dataset['orientation'] = value;
+    this.contentNode.setAttribute('aria-orientation', value);
   }
 
   /**
@@ -1406,6 +1407,8 @@ namespace TabBar {
      * @returns A virtual element representing the tab.
      */
     renderTab(data: IRenderData<T>): VirtualElement;
+
+    createTabKey(data: IRenderData<T>): string;
   }
 
   /**
@@ -1415,7 +1418,7 @@ namespace TabBar {
    * Subclasses are free to reimplement rendering methods as needed.
    */
   export
-  class Renderer implements IRenderer<any> {
+  class Renderer<T extends Widget = Widget> implements IRenderer<T> {
     /**
      * Construct a new renderer.
      */
@@ -1433,15 +1436,16 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab.
      */
-    renderTab(data: IRenderData<any>): VirtualElement {
+    renderTab(data: IRenderData<T>): VirtualElement {
       let title = data.title.caption;
       let key = this.createTabKey(data);
+      let id = key;
       let style = this.createTabStyle(data);
       let className = this.createTabClass(data);
       let dataset = this.createTabDataset(data);
       let aria = this.createTabARIA(data);
       return (
-        h.li({ key, className, title, style, dataset, ...aria },
+        h.li({ id, key, className, title, style, dataset, ...aria },
           this.renderIcon(data),
           this.renderLabel(data),
           this.renderCloseIcon(data)
@@ -1456,7 +1460,7 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab icon.
      */
-    renderIcon(data: IRenderData<any>): VirtualElement {
+    renderIcon(data: IRenderData<T>): VirtualElement {
       const { title } = data;
       let className = this.createIconClass(data);
 
@@ -1477,7 +1481,7 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab label.
      */
-    renderLabel(data: IRenderData<any>): VirtualElement {
+    renderLabel(data: IRenderData<T>): VirtualElement {
       return h.div({
         className: 'lm-TabBar-tabLabel'
           /* <DEPRECATED> */
@@ -1493,7 +1497,7 @@ namespace TabBar {
      *
      * @returns A virtual element representing the tab close icon.
      */
-    renderCloseIcon(data: IRenderData<any>): VirtualElement {
+    renderCloseIcon(data: IRenderData<T>): VirtualElement {
       return h.div({
         className: 'lm-TabBar-tabCloseIcon'
           /* <DEPRECATED> */
@@ -1514,7 +1518,7 @@ namespace TabBar {
      * the key is generated. This enables efficient rendering of moved
      * tabs and avoids subtle hover style artifacts.
      */
-    createTabKey(data: IRenderData<any>): string {
+    createTabKey(data: IRenderData<T>): string {
       let key = this._tabKeys.get(data.title);
       if (key === undefined) {
         key = `tab-key-${this._tabID++}`;
@@ -1530,7 +1534,7 @@ namespace TabBar {
      *
      * @returns The inline style data for the tab.
      */
-    createTabStyle(data: IRenderData<any>): ElementInlineStyle {
+    createTabStyle(data: IRenderData<T>): ElementInlineStyle {
       return { zIndex: `${data.zIndex}` };
     }
 
@@ -1541,7 +1545,7 @@ namespace TabBar {
      *
      * @returns The full class name for the tab.
      */
-    createTabClass(data: IRenderData<any>): string {
+    createTabClass(data: IRenderData<T>): string {
       let name = 'lm-TabBar-tab';
       /* <DEPRECATED> */
       name += ' p-TabBar-tab';
@@ -1571,7 +1575,7 @@ namespace TabBar {
      *
      * @returns The dataset for the tab.
      */
-    createTabDataset(data: IRenderData<any>): ElementDataset {
+    createTabDataset(data: IRenderData<T>): ElementDataset {
       return data.title.dataset;
     }
 
@@ -1582,8 +1586,8 @@ namespace TabBar {
      *
      * @returns The ARIA attributes for the tab.
      */
-    createTabARIA(data: IRenderData<any>): ElementARIAAttrs {
-      return {role: 'tab'};
+    createTabARIA(data: IRenderData<T>): ElementARIAAttrs {
+      return {role: 'tab', 'aria-controls': data.title.owner.id};
     }
 
     /**
@@ -1593,7 +1597,7 @@ namespace TabBar {
      *
      * @returns The full class name for the tab icon.
      */
-    createIconClass(data: IRenderData<any>): string {
+    createIconClass(data: IRenderData<T>): string {
       let name = 'lm-TabBar-tabIcon';
       /* <DEPRECATED> */
       name += ' p-TabBar-tabIcon';
@@ -1603,7 +1607,7 @@ namespace TabBar {
     }
 
     private _tabID = 0;
-    private _tabKeys = new WeakMap<Title<any>, string>();
+    private _tabKeys = new WeakMap<Title<T>, string>();
   }
 
   /**

--- a/packages/widgets/src/tabpanel.ts
+++ b/packages/widgets/src/tabpanel.ts
@@ -270,7 +270,6 @@ class TabPanel extends Widget {
     if (widget !== this.currentWidget) {
       widget.hide();
     }
-
     this.stackedPanel.insertWidget(index, widget);
     this.tabBar.insertTab(index, widget.title);
 

--- a/packages/widgets/src/tabpanel.ts
+++ b/packages/widgets/src/tabpanel.ts
@@ -34,7 +34,6 @@ import {
 import {
   Widget
 } from './widget';
-import { UUID } from '@phosphor/coreutils';
 
 
 /**
@@ -272,15 +271,12 @@ class TabPanel extends Widget {
       widget.hide();
     }
 
-    widget.id = widget.id || `aria-${UUID.uuid4()}`;
-
     this.stackedPanel.insertWidget(index, widget);
     this.tabBar.insertTab(index, widget.title);
 
-    let tab = this.tabBar.contentNode.children[this.tabBar.titles.indexOf(widget.title)];
-
+    let tabId = this.tabBar.renderer.createTabKey({title: widget.title, current: false, zIndex: 0});
     widget.node.setAttribute('role', 'tabpanel');
-    widget.node.setAttribute('aria-labelledby', tab.id);
+    widget.node.setAttribute('aria-labelledby', tabId);
   }
 
   /**
@@ -342,9 +338,6 @@ class TabPanel extends Widget {
   private _onWidgetRemoved(sender: StackedPanel, widget: Widget): void {
     widget.node.removeAttribute('role');
     widget.node.removeAttribute('aria-labelledby');
-    if (widget.id.slice(5) === 'aria-') {
-      widget.id = '';
-    }
     this.tabBar.removeTab(widget.title);
   }
 

--- a/packages/widgets/src/tabpanel.ts
+++ b/packages/widgets/src/tabpanel.ts
@@ -273,9 +273,13 @@ class TabPanel extends Widget {
     this.stackedPanel.insertWidget(index, widget);
     this.tabBar.insertTab(index, widget.title);
 
-    let tabId = this.tabBar.renderer.createTabKey({title: widget.title, current: false, zIndex: 0});
     widget.node.setAttribute('role', 'tabpanel');
-    widget.node.setAttribute('aria-labelledby', tabId);
+
+    let renderer = this.tabBar.renderer
+    if (renderer instanceof TabBar.Renderer) {
+      let tabId = renderer.createTabKey({title: widget.title, current: false, zIndex: 0});
+      widget.node.setAttribute('aria-labelledby', tabId);
+    }
   }
 
   /**

--- a/packages/widgets/src/tabpanel.ts
+++ b/packages/widgets/src/tabpanel.ts
@@ -34,6 +34,7 @@ import {
 import {
   Widget
 } from './widget';
+import { UUID } from '@phosphor/coreutils';
 
 
 /**
@@ -270,8 +271,16 @@ class TabPanel extends Widget {
     if (widget !== this.currentWidget) {
       widget.hide();
     }
+
+    widget.id = widget.id || `aria-${UUID.uuid4()}`;
+
     this.stackedPanel.insertWidget(index, widget);
     this.tabBar.insertTab(index, widget.title);
+
+    let tab = this.tabBar.contentNode.children[this.tabBar.titles.indexOf(widget.title)];
+
+    widget.node.setAttribute('role', 'tabpanel');
+    widget.node.setAttribute('aria-labelledby', tab.id);
   }
 
   /**
@@ -331,6 +340,11 @@ class TabPanel extends Widget {
    * Handle the `widgetRemoved` signal from the stacked panel.
    */
   private _onWidgetRemoved(sender: StackedPanel, widget: Widget): void {
+    widget.node.removeAttribute('role');
+    widget.node.removeAttribute('aria-labelledby');
+    if (widget.id.slice(5) === 'aria-') {
+      widget.id = '';
+    }
     this.tabBar.removeTab(widget.title);
   }
 


### PR DESCRIPTION
From the original PR:

> This builds on phosphorjs/phosphor#405 to also add ARIA roles to tabs. Merge phosphorjs/phosphor#405 first.

This PR takes all of the work done for phosphorjs/phosphor#406, a PR onto the old phosphor repo, and rebases it onto the latest lumino master.

This PR covers all of the following commits: https://github.com/jasongrout/phosphor/compare/aria-menus...jasongrout:aria-tabs. In theory, all of the other commits listed in phosphorjs/phosphor#406 should be covered by #131, which merged all of the work from phosphorjs/phosphor#405 into lumino.

@jasongrout Can you please take a look and make sure this reflects your original work? Also, what would be a good way to double check that this work is still working as intended in the context of lumino?