### PR TITLE
Batch Add Items to Command Pallette

### DIFF
--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -139,6 +139,20 @@ class CommandPalette extends Widget {
   }
 
   /**
+   * Adds command items to the command palette.
+   *
+   * @param items - An array of options for creating each command item.
+   *
+   * @returns The command items added to the palette.
+   */
+  addItems(items: CommandPalette.IItemOptions[]): CommandPalette.IItem[] {
+    const newItems = items.map(item => Private.createItem(this.commands, item));
+    newItems.forEach(item => this._items.push(item));
+    this.refresh();
+    return newItems;
+  }
+
+  /**
    * Remove an item from the command palette.
    *
    * @param item - The item to remove from the palette.

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -142,6 +142,26 @@ describe('@lumino/widgets', () => {
 
     });
 
+    describe('#addItems()', () => {
+
+      it('should add items to a command palette using options', () => {
+
+        const item =  {
+          command: 'test2',
+          category: 'Test Category',
+          args: { foo: 'bar' },
+          rank: 100
+        }
+
+        expect(palette.items.length).to.equal(0);
+        palette.addItems(defaultOptions.concat([item]));
+        expect(palette.items.length).to.equal(2);
+        expect(palette.items[0].command).to.equal('test');
+        expect(palette.items[1].command).to.equal('test2');
+      });
+
+    })
+
     describe('#addItem()', () => {
 
       it('should add an item to a command palette using options', () => {

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -154,7 +154,7 @@ describe('@lumino/widgets', () => {
         }
 
         expect(palette.items.length).to.equal(0);
-        palette.addItems(defaultOptions.concat([item]));
+        palette.addItems([defaultOptions, item]);
         expect(palette.items.length).to.equal(2);
         expect(palette.items[0].command).to.equal('test');
         expect(palette.items[1].command).to.equal('test2');


### PR DESCRIPTION
Currently, the `CommandPallette` has no item to batch add an Array of commands. Instead, users must add an item one at a time via the `addItem` method. This has a performance impact if the user wants to add a large list of items since `refresh` is called after adding each item. In a 3rd party plugin we are trying to leverage, the performance impact of refreshing after adding every item was making it unusable which has motivated this proposed enhancement to the API.

This pull request adds a new method: `addItems` which allows the user to supplies an Array of items to be added rather than needing to iterate and call `addItem` for each.  Upon all the items being added, `refresh` is called then only once.