### PR TITLE
Add style index.js files to optionally consume the CSS via a js module import

### DIFF
--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -19,7 +19,8 @@
     "src/*",
     "types/*",
     "images/*.png",
-    "style/*.css"
+    "style/*.css",
+    "style/index.js"
   ],
   "style": "style/index.css",
   "repository": {

--- a/packages/default-theme/style/index.js
+++ b/packages/default-theme/style/index.js
@@ -1,0 +1,16 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2018, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+import '@lumino/dragdrop/style/index';
+import '@lumino/widgets/style/index';
+import './commandpalette.css';
+import './datagrid.css';
+import './dockpanel.css';
+import './menu.css';
+import './menubar.css';
+import './scrollbar.css';
+import './tabbar.css';

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -22,7 +22,8 @@
     "dist/*",
     "src/*",
     "types/*",
-    "style/*.css"
+    "style/*.css",
+    "style/index.js"
   ],
   "main": "dist/index.js",
   "unpkg": "dist/index.min.js",

--- a/packages/dragdrop/style/index.js
+++ b/packages/dragdrop/style/index.js
@@ -1,0 +1,10 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+import './index.css';

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -22,7 +22,8 @@
     "dist/*",
     "src/*",
     "types/*",
-    "style/*.css"
+    "style/*.css",
+    "style/index.js"
   ],
   "main": "dist/index.js",
   "unpkg": "dist/index.min.js",

--- a/packages/widgets/style/index.js
+++ b/packages/widgets/style/index.js
@@ -1,0 +1,10 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Copyright (c) 2014-2017, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+import './index.css';


### PR DESCRIPTION
The webpack css-loader plugin does not deduplicate css that is imported via the css @import. Making the css available via a js module import lets webpack do deduplication at the module level in a way that respects the dependency ordering.

Adding these index.js files should not affect anything in Lumino itself, but just make it easier to consume the Lumino CSS and have deduplication.

This will help fix a problem in JupyterLab, for example, where the Lumino widget CSS will be duplicated on the page dozens of times because many modules require the CSS files directly (so css-loader is used). With this change, modules will be able to require the style/index.js module, so Webpack itself will deduplicate the imports, and the Lumino CSS will only be put on the page once.

The default-theme package needs a more complicated index.js since it uses @import in its index.css (in this case, css-loader would make a copy of the css).