### PR TITLE
Specify the CSS javascript module imports explicitly in package.json.

### DIFF
--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -23,6 +23,7 @@
     "style/index.js"
   ],
   "style": "style/index.css",
+  "styleModule": "style/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/jupyterlab/lumino.git"

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -30,6 +30,7 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "style": "style/index.css",
+  "styleModule": "style/index.js",
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "build": "tsc --build && rollup -c",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -30,6 +30,7 @@
   "module": "dist/index.es6",
   "types": "types/index.d.ts",
   "style": "style/index.css",
+  "styleModule": "style/index.js",
   "scripts": {
     "api": "api-extractor run --local --verbose",
     "build": "tsc --build && rollup -c",


### PR DESCRIPTION
This styleModule key is the convention we are adopting in JupyterLab for specifying such imports.

See https://github.com/jupyterlab/jupyterlab/pull/9427
