### PR TITLE
Add checkbox aria role to toggleable commands

### DIFF
--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -653,6 +653,11 @@ namespace CommandPalette {
     readonly isToggled: boolean;
 
     /**
+     * Whether the command item is toggleable.
+     */
+    readonly isToggleable: boolean;
+
+    /**
      * Whether the command item is visible.
      */
     readonly isVisible: boolean;
@@ -1549,6 +1554,13 @@ namespace Private {
      */
     get isToggled(): boolean {
       return this._commands.isToggled(this.command, this.args);
+    }
+
+    /**
+     * Whether the command item is toggleable.
+     */
+    get isToggleable(): boolean {
+      return this._commands.isToggleable(this.command, this.args);
     }
 
     /**

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -784,8 +784,24 @@ namespace CommandPalette {
     renderItem(data: IItemRenderData): VirtualElement {
       let className = this.createItemClass(data);
       let dataset = this.createItemDataset(data);
+      if (data.item.isToggleable) {
+        return (
+          h.li({
+            className,
+            dataset,
+            role: 'checkbox',
+            'aria-checked': `${data.item.isToggleable}`
+          },
+          this.renderItemIcon(data),
+          this.renderItemContent(data),
+          this.renderItemShortcut(data))
+        )
+      }
       return (
-        h.li({ className, dataset },
+        h.li({
+            className,
+            dataset
+          },
           this.renderItemIcon(data),
           this.renderItemContent(data),
           this.renderItemShortcut(data),

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -790,7 +790,7 @@ namespace CommandPalette {
             className,
             dataset,
             role: 'checkbox',
-            'aria-checked': `${data.item.isToggleable}`
+            'aria-checked': `${data.item.isToggled}`
           },
           this.renderItemIcon(data),
           this.renderItemContent(data),


### PR DESCRIPTION
Follow-up to #129 to add the aria role of checkbox and the checked state to toggleable commands in the command palette. 