### PR TITLE
Allow passing of `tag` into `widget` constructor

### DIFF
--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -739,6 +739,14 @@ namespace Widget {
      * The default is a new `<div>`.
      */
     node?: HTMLElement;
+
+    /**
+     * The optional element tag, used for constructing the widget's node.
+     *
+     * If a pre-constructed node is provided via the `node` arg, this
+     * value is ignored.
+     */
+    tag?: keyof HTMLElementTagNameMap;
   }
 
   /**
@@ -1061,6 +1069,6 @@ namespace Private {
    */
   export
   function createNode(options: Widget.IOptions): HTMLElement {
-    return options.node || document.createElement('div');
+    return options.node || document.createElement(options.tag || 'div');
   }
 }


### PR DESCRIPTION
This fix is related to jupyterlab/jupyterlab#9491

This PR adds `tag` to the `IOptions` object that can be passed into the `widget` constructor:

- if `node` is unset and:
  - `tag` is unset: the widget's node will be a new `div` element (same as before) 
  - `tag` is set: the widget's node will be a new element of tag `tag`
- if `node` is set, `tag` will always be ignored, since no new element construction will occur

