### PR TITLE
Fix docs target for polling

### DIFF
--- a/packages/polling/tdoptions.json
+++ b/packages/polling/tdoptions.json
@@ -4,7 +4,7 @@
   "target": "es5",
   "module": "es5",
   "lib": ["lib.es2015.d.ts", "lib.es2015.collection.d.ts", "lib.es2015.promise.d.ts", "lib.dom.d.ts"],
-  "out": "../../docs/api/disposable",
+  "out": "../../docs/api/polling",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]


### PR DESCRIPTION
## References
- fixes #154

## Test Procedure
- `yarn docs`
- see that `docs/api/polling/index.html` exists and looks right
- see that `docs/api/disposable/index.html` exists and looks right

## Other Options
If not a bridge too far, I would happily these to this PR:

- add a `yarn docs:check` to verify the integrity of the docs build
- add to docs step on `.github/workflows`
  - the docs _do_ get built, but adding the `check` would avoid future issues
  - upload them as an artifact so they can be reviewed