### PR TITLE
Ctrl-click to toggle single row or column selections

### DIFF
--- a/packages/datagrid/src/basicselectionmodel.ts
+++ b/packages/datagrid/src/basicselectionmodel.ts
@@ -195,18 +195,18 @@ class BasicSelectionModel extends SelectionModel {
       c1 = 0;
       c2 = columnCount - 1;
       alreadySelected = this._selections.filter(selection => selection.r1 === r1).length !== 0;
-      if (alreadySelected) {
-        // Remove from selection if already selected
-        this._selections = this._selections.filter(selection => selection.r1 !== r1);
-      }
+      // Remove from selections if already selected.
+      this._selections = alreadySelected
+        ? this._selections.filter(selection => selection.r1 !== r1)
+        : this._selections;
     } else if (this.selectionMode === 'column') {
       r1 = 0;
       r2 = rowCount - 1;
       alreadySelected = this._selections.filter(selection => selection.c1 === c1).length !== 0;
-      if (alreadySelected) {
-        // Remove from selection if already selected
-        this._selections = this._selections.filter(selection => selection.c1 !== c1);
-      }
+      // Remove from selections if already selected.
+      this._selections = alreadySelected
+        ? this._selections.filter(selection => selection.c1 !== c1)
+        : this._selections;
     }
 
     // Alias the cursor row and column.

--- a/packages/datagrid/src/basicselectionmodel.ts
+++ b/packages/datagrid/src/basicselectionmodel.ts
@@ -187,13 +187,26 @@ class BasicSelectionModel extends SelectionModel {
     c1 = Math.max(0, Math.min(c1, columnCount - 1));
     c2 = Math.max(0, Math.min(c2, columnCount - 1));
 
+    // Indicate if a row/column has already been selected.
+    let alreadySelected = false;
+
     // Handle the selection mode.
     if (this.selectionMode === 'row') {
       c1 = 0;
       c2 = columnCount - 1;
+      alreadySelected = this._selections.filter(selection => selection.r1 === r1).length !== 0;
+      if (alreadySelected) {
+        // Remove from selection if already selected
+        this._selections = this._selections.filter(selection => selection.r1 !== r1);
+      }
     } else if (this.selectionMode === 'column') {
       r1 = 0;
       r2 = rowCount - 1;
+      alreadySelected = this._selections.filter(selection => selection.c1 === c1).length !== 0;
+      if (alreadySelected) {
+        // Remove from selection if already selected
+        this._selections = this._selections.filter(selection => selection.c1 !== c1);
+      }
     }
 
     // Alias the cursor row and column.
@@ -213,8 +226,10 @@ class BasicSelectionModel extends SelectionModel {
     this._cursorColumn = cc;
     this._cursorRectIndex = this._selections.length;
 
-    // Add the new selection.
-    this._selections.push({ r1, c1, r2, c2 });
+    // Add the new selection if it wasn't already selected.
+    if (!alreadySelected) {
+      this._selections.push({ r1, c1, r2, c2 });
+    }
 
     // Emit the changed signal.
     this.emitChanged();


### PR DESCRIPTION
Signed-off-by: Itay Dafna <i.b.dafna@gmail.com>

This PR adds the ability to toggle single row or column selections when clicking on a row or column whilst holding the Ctrl key.

![lumino_ctrl_click_toggle_selection](https://user-images.githubusercontent.com/24281433/113083769-a33e8100-9191-11eb-9a7b-50838bac1caf.gif)
