### PR TITLE
Switch to TypeScript 3.9

### DIFF
--- a/examples/example-datagrid/package.json
+++ b/examples/example-datagrid/package.json
@@ -18,7 +18,7 @@
     "file-loader": "^5.0.2",
     "rimraf": "^2.5.2",
     "style-loader": "^1.0.2",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   }

--- a/examples/example-datastore/package.json
+++ b/examples/example-datastore/package.json
@@ -27,7 +27,7 @@
     "file-loader": "^5.0.2",
     "rimraf": "^2.5.2",
     "style-loader": "^1.0.2",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3"
   }
 }

--- a/examples/example-dockpanel/package.json
+++ b/examples/example-dockpanel/package.json
@@ -20,7 +20,7 @@
     "rimraf": "^2.5.2",
     "source-map-loader": "0.2.4",
     "style-loader": "^1.0.2",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   }

--- a/packages/algorithm/package.json
+++ b/packages/algorithm/package.json
@@ -61,7 +61,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -67,7 +67,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -65,7 +65,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -80,7 +80,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -66,7 +66,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -55,7 +55,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3"
+    "typescript": "~3.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -59,7 +59,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack-cli": "^3.3.10"
   },
   "publishConfig": {

--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -66,7 +66,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/domutils/package.json
+++ b/packages/domutils/package.json
@@ -62,7 +62,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -74,7 +74,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -63,7 +63,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -67,7 +67,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/polling/package.json
+++ b/packages/polling/package.json
@@ -68,7 +68,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.12.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -62,7 +62,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/signaling/package.json
+++ b/packages/signaling/package.json
@@ -65,7 +65,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -72,7 +72,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -90,7 +90,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~4.1.3",
+    "typescript": "~3.9.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/tsconfigdoc.json
+++ b/tsconfigdoc.json
@@ -20,6 +20,7 @@
     "types": [
       "@types/node"
     ],
+    "baseUrl": ".",
     "paths": {
       "@lumino/*": ["./packages/*/src"]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8388,10 +8388,10 @@ typescript@~3.5.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@~4.1.3:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+typescript@~3.9.0:
+  version "3.9.9"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
+  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
 
 uglify-js@^3.1.4:
   version "3.7.2"


### PR DESCRIPTION
Fixes jupyterlab/lumino#170

We will have to save TypeScript 4.0 for a major version bump.

For reference, it looks like TS was last updated in https://github.com/jupyterlab/lumino/pull/157
