### PR TITLE
Fix tabindex for menu bar

### DIFF
--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -937,7 +937,7 @@ namespace Private {
     /* </DEPRECATED> */
     node.appendChild(content);
     content.setAttribute('role', 'menubar');
-    node.tabIndex = -1;
+    node.tabIndex = 0;
     return node;
   }
 


### PR DESCRIPTION
This change is for accessibility - it allows ambulatory users to access the menu bar without using a mouse. Not sure what the motivation behind setting tabindex to -1 was - @sccolbert it looks like you added that in, what was the purpose of that? 

## Code Changes
Changes the tabindex for the menu bar DOM element to be 0 instead of -1.

## User-facing Changes
Allows users to bring focus to the menu bar without using a mouse. 