### PR TITLE
Switch back to TypeScript 3.6

### DIFF
--- a/docs/source/api_index.html
+++ b/docs/source/api_index.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html class="default no-js">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>@lumino</title>
+    <meta name="description" content="Documentation for @lumino">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="algorithm/assets/css/main.css">
+    <script async src="algorithm/assets/js/search.js" id="search-script"></script>
+</head>
+
+<body>
+    <header>
+        <div class="tsd-page-toolbar">
+            <div class="container">
+                <div class="table-wrap">
+                    <div class="table-cell" id="tsd-search" data-index="algorithm/assets/js/search.js" data-base=".">
+                        <div class="field">
+                            <label for="tsd-search-field" class="tsd-widget search no-caption">Search</label>
+                            <input id="tsd-search-field" type="text" />
+                        </div>
+                        <ul class="results">
+                            <li class="state loading">Preparing search index...</li>
+                            <li class="state failure">The search index is not available</li>
+                        </ul>
+                        <h2>Lumino</h2>
+                    </div>
+                    <div class="table-cell" id="tsd-widgets">
+                        <div id="tsd-filter">
+                            <a href="#" class="tsd-widget options no-caption" data-toggle="options">Options</a>
+                            <div class="tsd-filter-group">
+                                <div class="tsd-select" id="tsd-filter-visibility">
+                                    <span class="tsd-select-label">All</span>
+                                    <ul class="tsd-select-list">
+                                        <li data-value="public">Public</li>
+                                        <li data-value="protected">Public/Protected</li>
+                                        <li data-value="private" class="selected">All</li>
+                                    </ul>
+                                </div>
+                                <input type="checkbox" id="tsd-filter-inherited" checked />
+                                <label class="tsd-widget" for="tsd-filter-inherited">Inherited</label>
+                                <input type="checkbox" id="tsd-filter-externals" checked />
+                                <label class="tsd-widget" for="tsd-filter-externals">Externals</label>
+                                <input type="checkbox" id="tsd-filter-only-exported" />
+                                <label class="tsd-widget" for="tsd-filter-only-exported">Only exported</label>
+                            </div>
+                        </div>
+                        <a href="#" class="tsd-widget menu no-caption" data-toggle="menu">Menu</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="tsd-page-title">
+            <div class="container">
+                <h1>@lumino</h1>
+            </div>
+        </div>
+    </header>
+    <div class="container container-main">
+        <div class="row">
+            <div class="col-8 col-content">
+                <section class="tsd-panel-group tsd-index-group">
+                    <h2>Index</h2>
+                    <section class="tsd-panel tsd-index-panel">
+                        <div class="tsd-index-content">
+                            <section class="tsd-index-section ">
+                                <h3>Modules</h3>
+                                <ul class="tsd-index-list">
+                                    <li class="tsd-kind-module"><a href="algorithm/index.html"
+                                            class="tsd-kind-icon">algorithm/src</a></li>
+                                    <li class="tsd-kind-module"><a href="application/index.html"
+                                            class="tsd-kind-icon">application/src</a></li>
+                                    <li class="tsd-kind-module"><a href="collections/index.html"
+                                            class="tsd-kind-icon">collections/src</a></li>
+                                    <li class="tsd-kind-module"><a href="commands/index.html"
+                                            class="tsd-kind-icon">commands/src</a></li>
+                                    <li class="tsd-kind-module"><a href="coreutils/index.html"
+                                            class="tsd-kind-icon">coreutils/src</a></li>
+                                    <li class="tsd-kind-module"><a href="datagrid/index.html"
+                                            class="tsd-kind-icon">datagrid/src</a></li>
+                                    <li class="tsd-kind-module"><a href="datastore/index.html"
+                                            class="tsd-kind-icon">datastore/src</a></li>
+                                    <li class="tsd-kind-module"><a href="disposable/index.html"
+                                            class="tsd-kind-icon">disposable/src</a></li>
+                                    <li class="tsd-kind-module"><a href="domutils/index.html"
+                                            class="tsd-kind-icon">domutils/src</a></li>
+                                    <li class="tsd-kind-module"><a href="dragdrop/index.html"
+                                            class="tsd-kind-icon">dragdrop/src</a></li>
+                                    <li class="tsd-kind-module"><a href="keyboard/index.html"
+                                            class="tsd-kind-icon">keyboard/src</a></li>
+                                    <li class="tsd-kind-module"><a href="messaging/index.html"
+                                            class="tsd-kind-icon">messaging/src</a></li>
+                                    <li class="tsd-kind-module"><a href="polling/index.html"
+                                            class="tsd-kind-icon">polling/src</a></li>
+                                    <li class="tsd-kind-module"><a href="properties/index.html"
+                                            class="tsd-kind-icon">properties/src</a></li>
+                                    <li class="tsd-kind-module"><a href="signaling/index.html"
+                                            class="tsd-kind-icon">signaling/src</a></li>
+                                    <li class="tsd-kind-module"><a href="virtualdom/index.html"
+                                            class="tsd-kind-icon">virtualdom/src</a></li>
+                                    <li class="tsd-kind-module"><a href="widgets/index.html"
+                                            class="tsd-kind-icon">widgets/src</a></li>
+                                </ul>
+                            </section>
+                        </div>
+                    </section>
+                </section>
+            </div>
+            <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
+                <nav class="tsd-navigation primary">
+                    <ul>
+                        <li class=" tsd-kind-module">
+                            <a href="algorithm/index.html">algorithm/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="application/index.html">application/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="collections/index.html">collections/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="commands/index.html">commands/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="coreutils/index.html">coreutils/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="datagrid/index.html">datagrid/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="datastore/index.html">datastore/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="disposable/index.html">disposable/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="domutils/index.html">domutils/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="dragdrop/index.html">dragdrop/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="keyboard/index.html">keyboard/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="messaging/index.html">messaging/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="polling/index.html">polling/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="properties/index.html">properties/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="signaling/index.html">signaling/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="virtualdom/index.html">virtualdom/src</a>
+                        </li>
+                        <li class=" tsd-kind-module">
+                            <a href="widgets/index.html">widgets/src</a>
+                        </li>
+                    </ul>
+                </nav>
+                <nav class="tsd-navigation secondary menu-sticky">
+                    <ul class="before-current">
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </div>
+    <footer class="with-border-bottom">
+        <div class="container">
+            <h2>Legend</h2>
+            <div class="tsd-legend-group">
+                <ul class="tsd-legend">
+                    <li class="tsd-kind-namespace"><span class="tsd-kind-icon">Namespace</span></li>
+                    <li class="tsd-kind-variable"><span class="tsd-kind-icon">Variable</span></li>
+                    <li class="tsd-kind-function"><span class="tsd-kind-icon">Function</span></li>
+                    <li class="tsd-kind-function tsd-has-type-parameter"><span class="tsd-kind-icon">Function with type
+                            parameter</span></li>
+                    <li class="tsd-kind-type-alias"><span class="tsd-kind-icon">Type alias</span></li>
+                    <li class="tsd-kind-type-alias tsd-has-type-parameter"><span class="tsd-kind-icon">Type alias with
+                            type parameter</span></li>
+                </ul>
+                <ul class="tsd-legend">
+                    <li class="tsd-kind-interface"><span class="tsd-kind-icon">Interface</span></li>
+                    <li class="tsd-kind-interface tsd-has-type-parameter"><span class="tsd-kind-icon">Interface with
+                            type parameter</span></li>
+                </ul>
+                <ul class="tsd-legend">
+                    <li class="tsd-kind-class"><span class="tsd-kind-icon">Class</span></li>
+                    <li class="tsd-kind-class tsd-has-type-parameter"><span class="tsd-kind-icon">Class with type
+                            parameter</span></li>
+                </ul>
+            </div>
+        </div>
+    </footer>
+    <div class="container tsd-generator">
+        <p>Generated using <a href="https://typedoc.org/" target="_blank">TypeDoc</a></p>
+    </div>
+    <div class="overlay"></div>
+    <script src="algorithm/assets/js/main.js"></script>
+</body>
+
+</html>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -123,6 +123,9 @@ def build_api_docs(out_dir):
         shutil.rmtree(dest_dir)
     shutil.copytree(docs_api, dest_dir)
 
+    dest = osp.join(dest_dir, 'index.html')
+    shutil.copy(osp.join(HERE, 'api_index.html'), dest)
+
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/examples/example-datagrid/package.json
+++ b/examples/example-datagrid/package.json
@@ -18,7 +18,7 @@
     "file-loader": "^5.0.2",
     "rimraf": "^2.5.2",
     "style-loader": "^1.0.2",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   }

--- a/examples/example-datastore/package.json
+++ b/examples/example-datastore/package.json
@@ -27,7 +27,7 @@
     "file-loader": "^5.0.2",
     "rimraf": "^2.5.2",
     "style-loader": "^1.0.2",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3"
   }
 }

--- a/examples/example-dockpanel/package.json
+++ b/examples/example-dockpanel/package.json
@@ -20,7 +20,7 @@
     "rimraf": "^2.5.2",
     "source-map-loader": "0.2.4",
     "style-loader": "^1.0.2",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean:examples": "lerna run clean --scope \"@lumino/example-*\"",
     "clean:src": "lerna run clean --scope \"@lumino/!(test-|example-)*\"",
     "clean:tests": "lerna run clean:tests",
-    "docs": "rimraf docs/api && lerna run build:src --concurrency 1 && typedoc --options typedoc.js",
+    "docs": "rimraf docs/api && lerna run build:src --concurrency 1 && lerna run docs",
     "get:dependency": "get-dependency",
     "minimize": "lerna run minimize",
     "publish": "npm run clean && npm run build:dist && lerna publish --yes -m \"Publish\" from-package",

--- a/packages/algorithm/package.json
+++ b/packages/algorithm/package.json
@@ -61,7 +61,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -67,7 +67,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -65,7 +65,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -80,7 +80,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -66,7 +66,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -55,7 +55,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0"
+    "typescript": "~3.6.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/datastore/package.json
+++ b/packages/datastore/package.json
@@ -59,7 +59,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack-cli": "^3.3.10"
   },
   "publishConfig": {

--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -66,7 +66,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/domutils/package.json
+++ b/packages/domutils/package.json
@@ -62,7 +62,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -74,7 +74,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -63,7 +63,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -67,7 +67,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/polling/package.json
+++ b/packages/polling/package.json
@@ -68,7 +68,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.12.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -62,7 +62,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/signaling/package.json
+++ b/packages/signaling/package.json
@@ -65,7 +65,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -72,7 +72,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -90,7 +90,7 @@
     "terser": "^4.6.2",
     "tslib": "1.10.0",
     "typedoc": "~0.15.0",
-    "typescript": "~3.9.0",
+    "typescript": "~3.6.0",
     "webpack": "^4.41.3",
     "webpack-cli": "^3.3.10"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8388,10 +8388,10 @@ typescript@~3.5.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@~3.9.0:
-  version "3.9.9"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
-  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
+typescript@~3.6.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
+  integrity sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==
 
 uglify-js@^3.1.4:
   version "3.7.2"


### PR DESCRIPTION
Follow-up to #172 

Fixes https://github.com/jupyterlab/lumino/issues/170

Adds a hard-coded `api/index.html` file for now until we can upgrade TypeScript.
