### PR TITLE
Update poll instantiation logic to normalize frequence max to respect interval

### DIFF
--- a/packages/polling/src/poll.ts
+++ b/packages/polling/src/poll.ts
@@ -50,10 +50,16 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
     this._standby = options.standby || Private.DEFAULT_STANDBY;
     this._state = { ...Private.DEFAULT_STATE, timestamp: new Date().getTime() };
 
-    this.frequency = {
-      ...Private.DEFAULT_FREQUENCY,
-      ...(options.frequency || {})
-    };
+    // Normalize poll frequency `max` to be the greater of
+    // default `max`, `options.frequency.max`, or `options.frequency.interval`.
+    const frequency = options.frequency || {};
+    const max = Math.max(
+      frequency.interval || 0,
+      frequency.max || 0,
+      Private.DEFAULT_FREQUENCY.max
+    );
+    this.frequency = { ...Private.DEFAULT_FREQUENCY, ...frequency, ...{ max } };
+
     this.name = options.name || Private.DEFAULT_NAME;
 
     if ('auto' in options ? options.auto : true) {

--- a/packages/polling/tests/src/poll.spec.ts
+++ b/packages/polling/tests/src/poll.spec.ts
@@ -127,15 +127,29 @@ describe('Poll', () => {
         });
         expect(poll.frequency.max).to.equal(max);
       });
-      it('should default max to 30s', () => {
-        const interval = 500;
-        const max = 30 * 1000;
+
+      it('should normalize max to be biggest of default, max, interval', () => {
+        const interval = 25 * 1000;
+        const max = 20 * 1000;
         poll = new Poll({
           frequency: { interval },
           factory: () => Promise.resolve(),
-          name: '@lumino/polling:Poll#frequency:max-2'
+          name: '@lumino/polling:Poll#frequency:max-3'
         });
-        expect(poll.frequency.max).to.equal(max);
+        expect(poll.frequency.max).to.not.equal(max);
+        expect(poll.frequency.max).to.equal(30 * 1000); // Poll default max
+      });
+
+      it('should normalize max to be biggest of default, max, interval', () => {
+        const interval = 40 * 1000;
+        const max = 20 * 1000;
+        poll = new Poll({
+          frequency: { interval },
+          factory: () => Promise.resolve(),
+          name: '@lumino/polling:Poll#frequency:max-4'
+        });
+        expect(poll.frequency.max).to.not.equal(max);
+        expect(poll.frequency.max).to.equal(interval);
       });
     });
   });


### PR DESCRIPTION
- Update `Poll` instantiation behavior to normalize the `frequency.max` value to be the larger of: `options.frequency.max`, `options.frequency.interval`, or the default `max` (30 * 1000 milliseconds).
- Update tests to include new behavior