### PR TITLE
Fix selection mode

### DIFF
--- a/packages/datagrid/src/basicmousehandler.ts
+++ b/packages/datagrid/src/basicmousehandler.ts
@@ -203,9 +203,6 @@ class BasicMouseHandler implements DataGrid.IMouseHandler {
         clear = 'all';
       }
 
-      // Use selection mode 'cell'
-      model.selectionMode = 'cell';
-
       // Make the selection.
       model.select({ r1, c1, r2, c2, cursorRow, cursorColumn, clear });
 
@@ -334,19 +331,6 @@ class BasicMouseHandler implements DataGrid.IMouseHandler {
       cursorRow = accel ? row : shift ? model.cursorRow : row;
       cursorColumn = accel ? column : shift ? model.cursorColumn : column;
       clear = accel ? 'none' : shift ? 'current' : 'all';
-    }
-
-    // Set selection mode based on region
-    switch (region) {
-      case 'column-header':
-        model.selectionMode = 'column';
-        break;
-      case 'row-header':
-        model.selectionMode = 'row';
-        break;
-      default:
-        model.selectionMode = 'cell';
-        break;
     }
 
     // Make the selection.


### PR DESCRIPTION
Signed-off-by: Itay Dafna <i.b.dafna@gmail.com>

This PR reverts the changes from commit https://github.com/jupyterlab/lumino/commit/4a685fc4697910daf49ccc7fc6036668b16a8ed5 as they break the `selectionMode` parameter of `BasicSelectionModel`, resulting in 'cell' selection regardless of the parameter passed to the constructor:

```js
new BasicSelectionModel({
    dataModel: model6,
    selectionMode: "row", // won't work
  });
```
That change was arguably not needed to begin with as 'cell' selection mode will select full rows or columns when they are clicked on. 