### PR TITLE
Remove Chrome default scroll on focus

### DIFF
--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -1955,7 +1955,7 @@ class DataGrid extends Widget {
    * A message handler invoked on an `'activate-request'` message.
    */
   protected onActivateRequest(msg: Message): void {
-    this.viewport.node.focus();
+    this.viewport.node.focus({preventScroll: true});
   }
 
   /**


### PR DESCRIPTION
This PR fixes an issue where Chrome automatically scrolls to the center of an element when the `.focus()` method is triggered on a Node element. This behaviour results in context menus being rendered out of position when they are opened on an element which is not focused.

For reference: https://www.chromestatus.com/feature/5745122025144320

Signed-off-by: Itay Dafna <i.b.dafna@gmail.com>