### PR TITLE
Automated Changelog Entry for 2021.7.21 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2021.7.21
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/example-datagrid@0.22.2...d09f1fc86a97f7b48ae21b1a32b9ad9578675087))
+
+### Enhancements made
+
+- Don't sort context menu item by selector [#203](https://github.com/jupyterlab/lumino/pull/203) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2021-07-19&to=2021-07-21&type=c))
+
+[@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2021-07-19..2021-07-21&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2021-07-19..2021-07-21&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2021.7.19
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/v2021.6.10...52aee424552e8af82d65fcd8a18b6e80ca5fab77))
@@ -18,8 +34,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2021-06-10&to=2021-07-19&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2021-06-10..2021-07-19&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2021-06-10..2021-07-19&type=Issues) | [@ibdafna](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aibdafna+updated%3A2021-06-10..2021-07-19&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2021.6.10
 


### PR DESCRIPTION
Automated Changelog Entry for 2021.7.21 on master
Python version: 2021.7.21
npm version: lumino-top-level: 2021.7.19
npm workspace versions:
@lumino/example-datastore: 0.13.0
@lumino/example-datagrid: 0.23.0
@lumino/example-dockpanel-iife: 0.1.0
@lumino/example-dockpanel-amd: 0.1.0
@lumino/example-dockpanel: 0.13.0
@lumino/commands: 1.15.0
@lumino/messaging: 1.7.0
@lumino/domutils: 1.5.0
@lumino/disposable: 1.7.0
@lumino/coreutils: 1.8.0
@lumino/polling: 1.6.0
@lumino/widgets: 1.24.0
@lumino/properties: 1.5.0
@lumino/virtualdom: 1.11.0
@lumino/datagrid: 0.26.0
@lumino/keyboard: 1.5.0
@lumino/default-theme: 0.15.0
@lumino/collections: 1.6.0
@lumino/application: 1.21.0
@lumino/dragdrop: 1.10.0
@lumino/signaling: 1.7.0
@lumino/datastore: 0.14.0
@lumino/algorithm: 1.6.0

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | master  |
| Version Spec | 2021.7.21 |
