### PR TITLE
Add accordion panel

### DIFF
--- a/examples/example-accordionpanel/index.html
+++ b/examples/example-accordionpanel/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script type="text/javascript" src="build/bundle.example.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/examples/example-accordionpanel/index.html
+++ b/examples/example-accordionpanel/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
   <script type="text/javascript" src="build/bundle.example.js"></script>
 </head>
 <body>

--- a/examples/example-accordionpanel/package.json
+++ b/examples/example-accordionpanel/package.json
@@ -7,16 +7,16 @@
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/datagrid": "^0.25.2",
-    "@lumino/default-theme": "^0.14.0",
-    "@lumino/dragdrop": "^1.10.0",
-    "@lumino/widgets": "^1.23.0",
+    "@lumino/default-theme": "^0.16.0",
+    "@lumino/messaging": "^1.7.0",
+    "@lumino/widgets": "^1.25.0",
     "es6-promise": "^4.0.5"
   },
   "devDependencies": {
     "css-loader": "^3.4.0",
     "file-loader": "^5.0.2",
     "rimraf": "^2.5.2",
+    "source-map-loader": "0.2.4",
     "style-loader": "^1.0.2",
     "typescript": "~3.6.0",
     "webpack": "^4.41.3",

--- a/examples/example-accordionpanel/package.json
+++ b/examples/example-accordionpanel/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@lumino/example-accordionpanel",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc && webpack",
+    "clean": "rimraf build"
+  },
+  "dependencies": {
+    "@lumino/datagrid": "^0.25.2",
+    "@lumino/default-theme": "^0.14.0",
+    "@lumino/dragdrop": "^1.10.0",
+    "@lumino/widgets": "^1.23.0",
+    "es6-promise": "^4.0.5"
+  },
+  "devDependencies": {
+    "css-loader": "^3.4.0",
+    "file-loader": "^5.0.2",
+    "rimraf": "^2.5.2",
+    "style-loader": "^1.0.2",
+    "typescript": "~3.6.0",
+    "webpack": "^4.41.3",
+    "webpack-cli": "^3.3.10"
+  }
+}

--- a/examples/example-accordionpanel/src/index.ts
+++ b/examples/example-accordionpanel/src/index.ts
@@ -1,20 +1,20 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import "es6-promise/auto"; // polyfill Promise on IE
+import 'es6-promise/auto'; // polyfill Promise on IE
 
-import { Message } from "@lumino/messaging";
+import { Message } from '@lumino/messaging';
 
-import { AccordionPanel, BoxPanel, Widget } from "@lumino/widgets";
+import { AccordionPanel, BoxPanel, Widget } from '@lumino/widgets';
 
-import "../style/index.css";
+import '../style/index.css';
 
 class ContentWidget extends Widget {
   static createNode(): HTMLElement {
-    let node = document.createElement("div");
-    let content = document.createElement("div");
-    let input = document.createElement("input");
-    input.placeholder = "Placeholder...";
+    let node = document.createElement('div');
+    let content = document.createElement('div');
+    let input = document.createElement('input');
+    input.placeholder = 'Placeholder...';
     content.appendChild(input);
     node.appendChild(content);
     return node;
@@ -23,7 +23,7 @@ class ContentWidget extends Widget {
   constructor(name: string) {
     super({ node: ContentWidget.createNode() });
     this.setFlag(Widget.Flag.DisallowLayout);
-    this.addClass("content");
+    this.addClass('content');
     this.addClass(name.toLowerCase());
     this.title.label = name;
     this.title.closable = true;
@@ -31,7 +31,7 @@ class ContentWidget extends Widget {
   }
 
   get inputNode(): HTMLInputElement {
-    return this.node.getElementsByTagName("input")[0] as HTMLInputElement;
+    return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
   }
 
   protected onActivateRequest(msg: Message): void {
@@ -42,25 +42,21 @@ class ContentWidget extends Widget {
 }
 
 function main(): void {
-  const accordion = new AccordionPanel({ orientation: "vertical" });
-  accordion.id = "accordion";
+  const accordion = new AccordionPanel();
+  accordion.id = 'accordion';
 
-  const r1 = new ContentWidget("Red");
-  const b1 = new ContentWidget("Blue");
-  const g1 = new ContentWidget("Green");
-  // const y1 = new ContentWidget("Yellow");
-
-  // const r2 = new ContentWidget('Red');
-  // const b2 = new ContentWidget('Blue');
+  const r1 = new ContentWidget('Red');
+  const b1 = new ContentWidget('Blue');
+  const g1 = new ContentWidget('Green');
+  
   accordion.addWidget(r1);
   accordion.addWidget(b1);
   accordion.addWidget(g1);
-  // accordion.addWidget(y1);
 
   BoxPanel.setStretch(accordion, 1);
 
-  const main = new BoxPanel({ direction: "left-to-right", spacing: 0 });
-  main.id = "main";
+  const main = new BoxPanel({ direction: 'left-to-right', spacing: 0 });
+  main.id = 'main';
   main.addWidget(accordion);
 
   window.onresize = () => {

--- a/examples/example-accordionpanel/src/index.ts
+++ b/examples/example-accordionpanel/src/index.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import "es6-promise/auto"; // polyfill Promise on IE
+
+import { Message } from "@lumino/messaging";
+
+import { AccordionPanel, BoxPanel, Widget } from "@lumino/widgets";
+
+import "../style/index.css";
+
+class ContentWidget extends Widget {
+  static createNode(): HTMLElement {
+    let node = document.createElement("div");
+    let content = document.createElement("div");
+    let input = document.createElement("input");
+    input.placeholder = "Placeholder...";
+    content.appendChild(input);
+    node.appendChild(content);
+    return node;
+  }
+
+  constructor(name: string) {
+    super({ node: ContentWidget.createNode() });
+    this.setFlag(Widget.Flag.DisallowLayout);
+    this.addClass("content");
+    this.addClass(name.toLowerCase());
+    this.title.label = name;
+    this.title.closable = true;
+    this.title.caption = `Long description for: ${name}`;
+  }
+
+  get inputNode(): HTMLInputElement {
+    return this.node.getElementsByTagName("input")[0] as HTMLInputElement;
+  }
+
+  protected onActivateRequest(msg: Message): void {
+    if (this.isAttached) {
+      this.inputNode.focus();
+    }
+  }
+}
+
+function main(): void {
+  const accordion = new AccordionPanel({ orientation: "vertical" });
+  accordion.id = "accordion";
+
+  const r1 = new ContentWidget("Red");
+  const b1 = new ContentWidget("Blue");
+  const g1 = new ContentWidget("Green");
+  // const y1 = new ContentWidget("Yellow");
+
+  // const r2 = new ContentWidget('Red');
+  // const b2 = new ContentWidget('Blue');
+  accordion.addWidget(r1);
+  accordion.addWidget(b1);
+  accordion.addWidget(g1);
+  // accordion.addWidget(y1);
+
+  BoxPanel.setStretch(accordion, 1);
+
+  const main = new BoxPanel({ direction: "left-to-right", spacing: 0 });
+  main.id = "main";
+  main.addWidget(accordion);
+
+  window.onresize = () => {
+    main.update();
+  };
+
+  Widget.attach(main, document.body);
+}
+
+window.onload = main;

--- a/examples/example-accordionpanel/style/content.css
+++ b/examples/example-accordionpanel/style/content.css
@@ -1,0 +1,48 @@
+/*
+ Copyright (c) Jupyter Development Team.
+ Distributed under the terms of the Modified BSD License.
+*/
+
+.content {
+  min-width: 50px;
+  min-height: 50px;
+  display: flex;
+  flex-direction: column;
+  padding: 8px;
+  border: 1px solid #C0C0C0;
+  border-top: none;
+  background: white;
+  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+
+.content > div {
+  flex: 1 1 auto;
+  border: 1px solid #505050;
+  overflow: auto;
+}
+
+
+.content  input {
+  margin: 8px;
+}
+
+
+.red > div {
+  background: #E74C3C;
+}
+
+
+.yellow > div {
+  background: #F1C40F;
+}
+
+
+.green > div {
+  background: #27AE60;
+}
+
+
+.blue > div {
+  background: #3498DB;
+}

--- a/examples/example-accordionpanel/style/content.css
+++ b/examples/example-accordionpanel/style/content.css
@@ -10,18 +10,23 @@
   flex-direction: column;
   padding: 8px;
   border: 1px solid #C0C0C0;
-  border-top: none;
   background: white;
   box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
 }
 
+.lm-AccordionPanel[data-orientation="vertical"] .content {
+  border-top: none;
+}
+
+.lm-AccordionPanel[data-orientation="horizontal"] .content {
+  border-left: none;
+}
 
 .content > div {
   flex: 1 1 auto;
   border: 1px solid #505050;
   overflow: auto;
 }
-
 
 .content  input {
   margin: 8px;

--- a/examples/example-accordionpanel/style/index.css
+++ b/examples/example-accordionpanel/style/index.css
@@ -1,0 +1,29 @@
+/* 
+ Copyright (c) Jupyter Development Team.
+ Distributed under the terms of the Modified BSD License.
+*/
+@import '~@lumino/default-theme/style/index.css';
+@import './content.css';
+
+
+body {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+#main {
+  flex: 1 1 auto;
+}
+
+#accordion {
+  flex: 1 1 auto;
+  padding: 4px;
+}

--- a/examples/example-accordionpanel/tsconfig.json
+++ b/examples/example-accordionpanel/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "declaration": false,
+    "noImplicitAny": true,
+    "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "strictNullChecks": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES5",
+    "outDir": "./build",
+    "lib": ["ES5", "ES2015.Promise", "ES2015.Iterable", "DOM"],
+    "types": []
+  },
+  "include": ["src/*"]
+}

--- a/examples/example-accordionpanel/tsconfig.json
+++ b/examples/example-accordionpanel/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmitOnError": true,
     "noUnusedLocals": true,
     "strictNullChecks": true,
+    "sourceMap": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES5",

--- a/examples/example-accordionpanel/webpack.config.js
+++ b/examples/example-accordionpanel/webpack.config.js
@@ -1,17 +1,19 @@
-var path = require('path');
+var path = require("path");
 
 module.exports = {
-  entry: './build/index.js',
-  mode: 'development',
+  entry: "./build/index.js",
+  mode: "development",
+  devtool: "source-map",
   output: {
-    path: __dirname + '/build/',
-    filename: 'bundle.example.js',
-    publicPath: './build/'
+    path: __dirname + "/build/",
+    filename: "bundle.example.js",
+    publicPath: "./build/",
   },
   module: {
     rules: [
-      { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-      { test: /\.png$/, use: 'file-loader' }
-    ]
-  }
+      { test: /\.js$/, use: ["source-map-loader"], enforce: "pre" },
+      { test: /\.css$/, use: ["style-loader", "css-loader"] },
+      { test: /\.png$/, use: "file-loader" },
+    ],
+  },
 };

--- a/examples/example-accordionpanel/webpack.config.js
+++ b/examples/example-accordionpanel/webpack.config.js
@@ -1,0 +1,17 @@
+var path = require('path');
+
+module.exports = {
+  entry: './build/index.js',
+  mode: 'development',
+  output: {
+    path: __dirname + '/build/',
+    filename: 'bundle.example.js',
+    publicPath: './build/'
+  },
+  module: {
+    rules: [
+      { test: /\.css$/, use: ['style-loader', 'css-loader'] },
+      { test: /\.png$/, use: 'file-loader' }
+    ]
+  }
+};

--- a/examples/example-dockpanel/webpack.config.js
+++ b/examples/example-dockpanel/webpack.config.js
@@ -1,19 +1,19 @@
-var path = require('path');
+var path = require("path");
 
 module.exports = {
-  entry: './build/index.js',
-  mode: 'development',
-  devtool: 'source-map',
+  entry: "./build/index.js",
+  mode: "development",
+  devtool: "source-map",
   output: {
-    path: __dirname + '/build/',
-    filename: 'bundle.example.js',
-    publicPath: './build/'
+    path: __dirname + "/build/",
+    filename: "bundle.example.js",
+    publicPath: "./build/",
   },
   module: {
     rules: [
       { test: /\.js$/, use: ["source-map-loader"], enforce: "pre" },
-      { test: /\.css$/, use: ['style-loader', 'css-loader'] },
-      { test: /\.png$/, use: 'file-loader' }
-    ]
-  }
+      { test: /\.css$/, use: ["style-loader", "css-loader"] },
+      { test: /\.png$/, use: "file-loader" },
+    ],
+  },
 };

--- a/packages/default-theme/style/accordionpanel.css
+++ b/packages/default-theme/style/accordionpanel.css
@@ -9,16 +9,33 @@
   max-height: 22px;
   min-width: 35px;
   line-height: 20px;
+  margin: 0px;
+}
+
+.lm-AccordionPanel .lm-AccordionPanel-title:focus, 
+.lm-AccordionPanel .lm-AccordionPanel-title:hover {
+  background: #dbdbdb;
+}
+
+.lm-AccordionPanel .lm-AccordionPanel-title:focus,
+.lm-AccordionPanel .lm-AccordionPanel-title:last-of-type:focus:not(.lm-mod-expanded) {
+  border: 1px solid lightskyblue;
+}
+
+.lm-AccordionPanel .lm-AccordionPanel-title:last-of-type:not(.lm-mod-expanded) {
+  border-bottom: 1px solid #C0C0C0;
 }
 
 .lm-AccordionPanel .lm-AccordionPanel-title.lm-mod-expanded .lm-AccordionPanel-titleCollapser:before {
-  content: "\f0d7";
+  content: "\f0d8";
   font-family: FontAwesome;
 }
 
 .lm-AccordionPanel .lm-AccordionPanel-title .lm-AccordionPanel-titleCollapser:before {
-  content: "\f0da";
+  content: "\f0d7";
   font-family: FontAwesome;
+  position: absolute;
+  right: 10px;
 }
 
 .lm-AccordionPanel .lm-AccordionPanel-titleLabel {

--- a/packages/default-theme/style/accordionpanel.css
+++ b/packages/default-theme/style/accordionpanel.css
@@ -1,0 +1,26 @@
+.lm-AccordionPanel .lm-AccordionPanel-title {
+  box-sizing: border-box;
+  padding: 0px 10px;
+  background: #E5E5E5;
+  border: 1px solid #C0C0C0;
+  border-bottom: none;
+  font: 12px Helvetica, Arial, sans-serif;
+  min-height: 22px;
+  max-height: 22px;
+  min-width: 35px;
+  line-height: 20px;
+}
+
+.lm-AccordionPanel .lm-AccordionPanel-title.lm-mod-expanded .lm-AccordionPanel-titleCollapser:before {
+  content: "\f0d7";
+  font-family: FontAwesome;
+}
+
+.lm-AccordionPanel .lm-AccordionPanel-title .lm-AccordionPanel-titleCollapser:before {
+  content: "\f0da";
+  font-family: FontAwesome;
+}
+
+.lm-AccordionPanel .lm-AccordionPanel-titleLabel {
+  padding: 0px 5px;
+}

--- a/packages/default-theme/style/index.css
+++ b/packages/default-theme/style/index.css
@@ -7,6 +7,7 @@
 |----------------------------------------------------------------------------*/
 @import '~@lumino/dragdrop/style/index.css';
 @import '~@lumino/widgets/style/index.css';
+@import './accordionpanel.css';
 @import './commandpalette.css';
 @import './datagrid.css';
 @import './dockpanel.css';

--- a/packages/default-theme/style/index.js
+++ b/packages/default-theme/style/index.js
@@ -7,6 +7,7 @@
 |----------------------------------------------------------------------------*/
 import '@lumino/dragdrop/style/index';
 import '@lumino/widgets/style/index';
+import './accordionpanel.css';
 import './commandpalette.css';
 import './datagrid.css';
 import './dockpanel.css';

--- a/packages/widgets/src/accordionlayout.ts
+++ b/packages/widgets/src/accordionlayout.ts
@@ -12,12 +12,14 @@ export class AccordionLayout extends SplitLayout {
    * Construct a new accordion layout.
    *
    * @param options - The options for initializing the layout.
-   * 
-   * #### Note
+   *
+   * #### Notes
    * The default orientation will be vertical.
+   *
+   * Titles must be rotated for horizontal accordion panel using CSS: see accordionpanel.css
    */
   constructor(options: AccordionLayout.IOptions) {
-    super({...options, orientation: options.orientation || 'vertical'});
+    super({ ...options, orientation: options.orientation || 'vertical' });
     this.titleSpace = options.titleSpace || 22;
   }
 
@@ -86,8 +88,8 @@ export class AccordionLayout extends SplitLayout {
     // Add the title node to the parent before the widget.
     this.parent!.node.appendChild(title);
 
-    widget.node.setAttribute('role', 'region')
-    widget.node.setAttribute('aria-labelledby', title.id)
+    widget.node.setAttribute('role', 'region');
+    widget.node.setAttribute('aria-labelledby', title.id);
 
     super.attachWidget(index, widget);
   }
@@ -122,7 +124,7 @@ export class AccordionLayout extends SplitLayout {
    */
   protected detachWidget(index: number, widget: Widget): void {
     const title = ArrayExt.removeAt(this._titles, index);
-    
+
     this.parent!.node.removeChild(title!);
 
     super.detachWidget(index, widget);
@@ -130,7 +132,7 @@ export class AccordionLayout extends SplitLayout {
 
   /**
    * Update the item position.
-   * 
+   *
    * @param i Item index
    * @param isHorizontal Whether the layout is horizontal or not
    * @param left Left position in pixels
@@ -150,16 +152,14 @@ export class AccordionLayout extends SplitLayout {
   ): void {
     const titleStyle = this._titles[i].style;
 
+    // Titles must be rotated for horizontal accordion panel using CSS: see accordionpanel.css
+    titleStyle.top = `${top}px`;
+    titleStyle.left = `${left}px`;
+    titleStyle.height = `${this.widgetOffset}px`;
     if (isHorizontal) {
-      titleStyle.top = `${top}px`;
-      titleStyle.left = `${left}px`;
-      titleStyle.width = `${this.widgetOffset}px`;
-      titleStyle.height = `${height}px`;
+      titleStyle.width = `${height}px`;
     } else {
-      titleStyle.top = `${top}px`;
-      titleStyle.left = `${left}px`;
       titleStyle.width = `${width}px`;
-      titleStyle.height = `${this.widgetOffset}px`;
     }
 
     super.updateItemPosition(i, isHorizontal, left, top, height, width, size);

--- a/packages/widgets/src/accordionlayout.ts
+++ b/packages/widgets/src/accordionlayout.ts
@@ -76,25 +76,10 @@ export class AccordionLayout extends SplitLayout {
   protected attachWidget(index: number, widget: Widget): void {
     const title = Private.createTitle(this.renderer, widget.title);
     title.style.position = 'absolute';
-    title.setAttribute("role", "button");
     title.setAttribute("aria-label", `${widget.title.label} Section`);
     title.setAttribute("aria-expanded", "true");
     title.setAttribute("aria-controls", widget.id);
-    title.classList.add("lm-mod-expanded")
-
-    const onClick = () => {
-      if (widget.isHidden) {
-        title.classList.add("lm-mod-expanded")
-        title.setAttribute("aria-expanded", "true");
-        widget.show();
-      } else {
-        title.classList.remove("lm-mod-expanded")
-        title.setAttribute("aria-expanded", "false");
-        widget.hide();
-      }
-    };
-    ArrayExt.insert(this._onClickTitles, index, onClick);
-    title.addEventListener('click', onClick);
+    title.classList.add("lm-mod-expanded");
 
     ArrayExt.insert(this._titles, index, title);
 
@@ -137,11 +122,7 @@ export class AccordionLayout extends SplitLayout {
    */
   protected detachWidget(index: number, widget: Widget): void {
     const title = ArrayExt.removeAt(this._titles, index);
-
-    title!.removeEventListener(
-      'click',
-      ArrayExt.removeAt(this._onClickTitles, index)!
-    );
+    
     this.parent!.node.removeChild(title!);
 
     super.detachWidget(index, widget);
@@ -174,7 +155,6 @@ export class AccordionLayout extends SplitLayout {
   }
 
   private _titles: HTMLElement[] = [];
-  private _onClickTitles: (() => void)[] = [];
 }
 
 export namespace AccordionLayout {
@@ -209,6 +189,11 @@ export namespace AccordionLayout {
    * A renderer for use with an accordion layout.
    */
   export interface IRenderer extends SplitLayout.IRenderer {
+    /**
+     * Common class name for all accordion titles.
+     */
+    readonly titleClassName: string;
+
     /**
      * Render the element for a section title.
      *

--- a/packages/widgets/src/accordionlayout.ts
+++ b/packages/widgets/src/accordionlayout.ts
@@ -1,0 +1,230 @@
+import { ArrayExt } from '@lumino/algorithm';
+import { SplitLayout } from './splitlayout';
+import { Title } from './title';
+import Utils from './utils';
+import { Widget } from './widget';
+
+/**
+ * A layout which arranges its widgets into collapsible resizable sections.
+ */
+export class AccordionLayout extends SplitLayout {
+  /**
+   * Construct a new accordion layout.
+   *
+   * @param options - The options for initializing the layout.
+   * 
+   * #### Note
+   * The default orientation will be vertical.
+   */
+  constructor(options: AccordionLayout.IOptions) {
+    super({...options, orientation: options.orientation || 'vertical'});
+    this.titleSpace = options.titleSpace || 22;
+  }
+
+  /**
+   * The section title height or width depending on the orientation.
+   */
+  get titleSpace(): number {
+    return this.widgetOffset;
+  }
+  set titleSpace(value: number) {
+    value = Utils.clampDimension(value);
+    if (this.widgetOffset === value) {
+      return;
+    }
+    this.widgetOffset = value;
+    if (!this.parent) {
+      return;
+    }
+    this.parent.fit();
+  }
+
+  /**
+   * A read-only array of the section titles in the panel.
+   */
+  get titles(): ReadonlyArray<HTMLElement> {
+    return this._titles;
+  }
+
+  /**
+   * Dispose of the resources held by the layout.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    // Clear the layout state.
+    this._titles.length = 0;
+
+    // Dispose of the rest of the layout.
+    super.dispose();
+  }
+
+  /**
+   * The renderer used by the accordion layout.
+   */
+  readonly renderer: AccordionLayout.IRenderer;
+
+  /**
+   * Attach a widget to the parent's DOM node.
+   *
+   * @param index - The current index of the widget in the layout.
+   *
+   * @param widget - The widget to attach to the parent.
+   */
+  protected attachWidget(index: number, widget: Widget): void {
+    const title = Private.createTitle(this.renderer, widget.title);
+    title.style.position = 'absolute';
+    title.setAttribute("role", "button");
+    title.setAttribute("aria-label", `${widget.title.label} Section`);
+    title.setAttribute("aria-expanded", "true");
+    title.setAttribute("aria-controls", widget.id);
+    title.classList.add("lm-mod-expanded")
+
+    const onClick = () => {
+      if (widget.isHidden) {
+        title.classList.add("lm-mod-expanded")
+        title.setAttribute("aria-expanded", "true");
+        widget.show();
+      } else {
+        title.classList.remove("lm-mod-expanded")
+        title.setAttribute("aria-expanded", "false");
+        widget.hide();
+      }
+    };
+    ArrayExt.insert(this._onClickTitles, index, onClick);
+    title.addEventListener('click', onClick);
+
+    ArrayExt.insert(this._titles, index, title);
+
+    // Add the title node to the parent before the widget.
+    this.parent!.node.appendChild(title);
+
+    widget.node.setAttribute("role", "region")
+    widget.node.setAttribute("aria-labelledby", title.id)
+
+    super.attachWidget(index, widget);
+  }
+
+  /**
+   * Move a widget in the parent's DOM node.
+   *
+   * @param fromIndex - The previous index of the widget in the layout.
+   *
+   * @param toIndex - The current index of the widget in the layout.
+   *
+   * @param widget - The widget to move in the parent.
+   */
+  protected moveWidget(
+    fromIndex: number,
+    toIndex: number,
+    widget: Widget
+  ): void {
+    ArrayExt.move(this._titles, fromIndex, toIndex);
+    super.moveWidget(fromIndex, toIndex, widget);
+  }
+
+  /**
+   * Detach a widget from the parent's DOM node.
+   *
+   * @param index - The previous index of the widget in the layout.
+   *
+   * @param widget - The widget to detach from the parent.
+   *
+   * #### Notes
+   * This is a reimplementation of the superclass method.
+   */
+  protected detachWidget(index: number, widget: Widget): void {
+    const title = ArrayExt.removeAt(this._titles, index);
+
+    title!.removeEventListener(
+      'click',
+      ArrayExt.removeAt(this._onClickTitles, index)!
+    );
+    this.parent!.node.removeChild(title!);
+
+    super.detachWidget(index, widget);
+  }
+
+  protected updateItemPosition(
+    i: number,
+    isHorizontal: boolean,
+    left: number,
+    top: number,
+    height: number,
+    width: number,
+    size: number
+  ): void {
+    const titleStyle = this._titles[i].style;
+
+    if (isHorizontal) {
+      titleStyle.top = `${top}px`;
+      titleStyle.left = `${left}px`;
+      titleStyle.width = `${this.widgetOffset}px`;
+      titleStyle.height = `${height}px`;
+    } else {
+      titleStyle.top = `${top}px`;
+      titleStyle.left = `${left}px`;
+      titleStyle.width = `${width}px`;
+      titleStyle.height = `${this.widgetOffset}px`;
+    }
+
+    super.updateItemPosition(i, isHorizontal, left, top, height, width, size);
+  }
+
+  private _titles: HTMLElement[] = [];
+  private _onClickTitles: (() => void)[] = [];
+}
+
+export namespace AccordionLayout {
+  /**
+   * A type alias for a accordion layout orientation.
+   */
+  export type Orientation = SplitLayout.Orientation;
+
+  /**
+   * A type alias for a accordion layout alignment.
+   */
+  export type Alignment = SplitLayout.Alignment;
+
+  /**
+   * An options object for initializing a accordion layout.
+   */
+  export interface IOptions extends SplitLayout.IOptions {
+    /**
+     * The renderer to use for the split layout.
+     */
+    renderer: IRenderer;
+
+    /**
+     * The section title height or width depending on the orientation.
+     *
+     * The default is `22`.
+     */
+    titleSpace?: number;
+  }
+
+  /**
+   * A renderer for use with an accordion layout.
+   */
+  export interface IRenderer extends SplitLayout.IRenderer {
+    /**
+     * Render the element for a section title.
+     *
+     * @param data - The data to use for rendering the section title.
+     *
+     * @returns A element representing the section title.
+     */
+    createSectionTitle(title: Title<Widget>): HTMLElement;
+  }
+}
+
+namespace Private {
+  export function createTitle(
+    renderer: AccordionLayout.IRenderer,
+    data: Title<Widget>
+  ): HTMLElement {
+    return renderer.createSectionTitle(data);
+  }
+}

--- a/packages/widgets/src/accordionlayout.ts
+++ b/packages/widgets/src/accordionlayout.ts
@@ -76,18 +76,18 @@ export class AccordionLayout extends SplitLayout {
   protected attachWidget(index: number, widget: Widget): void {
     const title = Private.createTitle(this.renderer, widget.title);
     title.style.position = 'absolute';
-    title.setAttribute("aria-label", `${widget.title.label} Section`);
-    title.setAttribute("aria-expanded", "true");
-    title.setAttribute("aria-controls", widget.id);
-    title.classList.add("lm-mod-expanded");
+    title.setAttribute('aria-label', `${widget.title.label} Section`);
+    title.setAttribute('aria-expanded', 'true');
+    title.setAttribute('aria-controls', widget.id);
+    title.classList.add('lm-mod-expanded');
 
     ArrayExt.insert(this._titles, index, title);
 
     // Add the title node to the parent before the widget.
     this.parent!.node.appendChild(title);
 
-    widget.node.setAttribute("role", "region")
-    widget.node.setAttribute("aria-labelledby", title.id)
+    widget.node.setAttribute('role', 'region')
+    widget.node.setAttribute('aria-labelledby', title.id)
 
     super.attachWidget(index, widget);
   }
@@ -128,6 +128,17 @@ export class AccordionLayout extends SplitLayout {
     super.detachWidget(index, widget);
   }
 
+  /**
+   * Update the item position.
+   * 
+   * @param i Item index
+   * @param isHorizontal Whether the layout is horizontal or not
+   * @param left Left position in pixels
+   * @param top Top position in pixels
+   * @param height Item height
+   * @param width Item width
+   * @param size Item size
+   */
   protected updateItemPosition(
     i: number,
     isHorizontal: boolean,
@@ -173,7 +184,7 @@ export namespace AccordionLayout {
    */
   export interface IOptions extends SplitLayout.IOptions {
     /**
-     * The renderer to use for the split layout.
+     * The renderer to use for the accordion layout.
      */
     renderer: IRenderer;
 
@@ -206,6 +217,13 @@ export namespace AccordionLayout {
 }
 
 namespace Private {
+  /**
+   * Create the title HTML element.
+   *
+   * @param renderer Accordion renderer
+   * @param data Widget title
+   * @returns Title HTML element
+   */
   export function createTitle(
     renderer: AccordionLayout.IRenderer,
     data: Title<Widget>

--- a/packages/widgets/src/accordionpanel.ts
+++ b/packages/widgets/src/accordionpanel.ts
@@ -1,0 +1,174 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { AccordionLayout } from "./accordionlayout";
+import { SplitLayout } from "./splitlayout";
+import { SplitPanel } from "./splitpanel";
+import { Title } from "./title";
+import { Widget } from "./widget";
+
+/**
+ * A panel which arranges its widgets into resizable sections separated by a title widget.
+ *
+ * #### Notes
+ * This class provides a convenience wrapper around [[AccordionLayout]]. // TODO
+ */
+export class AccordionPanel extends SplitPanel {
+  /**
+   * Construct a new accordion panel.
+   *
+   * @param options - The options for initializing the accordion panel.
+   */
+  constructor(options: AccordionPanel.IOptions = {}) {
+    super({ ...options, layout: Private.createLayout(options) });
+    this.addClass("lm-AccordionPanel");
+  }
+
+  /**
+   * Get the section title height.
+   */
+  get titleSpace(): number {
+    return (this.layout as AccordionLayout).titleSpace;
+  }
+
+  /**
+   * Set the section title height.
+   */
+  set titleSpace(value: number) {
+    (this.layout as AccordionLayout).titleSpace = value;
+  }
+
+  /**
+   * A read-only array of the section titles in the panel.
+   */
+  get titles(): ReadonlyArray<HTMLElement> {
+    return (this.layout as AccordionLayout).titles;
+  }
+}
+
+/**
+ * The namespace for the `AccordionPanel` class statics.
+ */
+export namespace AccordionPanel {
+  /**
+   * A type alias for a split panel orientation.
+   */
+  export type Orientation = SplitLayout.Orientation;
+
+  /**
+   * A type alias for a split panel alignment.
+   */
+  export type Alignment = SplitLayout.Alignment;
+
+  /**
+   * A type alias for a split panel renderer.
+   */
+  export type IRenderer = AccordionLayout.IRenderer;
+
+  /**
+   * An options object for initializing a split panel.
+   */
+  export interface IOptions extends Partial<AccordionLayout.IOptions> {
+    /**
+     * The accordion layout to use for the accordion panel.
+     *
+     * If this is provided, the other options are ignored.
+     *
+     * The default is a new `AccordionLayout`.
+     */
+    layout?: AccordionLayout;
+  }
+
+  /**
+   * The default implementation of `IRenderer`.
+   */
+  export class Renderer extends SplitPanel.Renderer implements IRenderer {
+    /**
+     * Render the collapse indicator for a section title.
+     *
+     * @param data - The data to use for rendering the section title.
+     *
+     * @returns A element representing the collapse indicator.
+     */
+    createCollapseIcon(data: Title<Widget>): HTMLElement {
+      return document.createElement("span");
+    }
+
+    /**
+     * Render the element for a section title.
+     *
+     * @param data - The data to use for rendering the section title.
+     *
+     * @returns A element representing the section title.
+     */
+    createSectionTitle(data: Title<Widget>): HTMLElement {
+      const handle = document.createElement("h3");
+      handle.id = this.createTitleKey(data);
+      handle.className = "lm-AccordionPanel-title";
+      handle.title = data.caption;
+      for (const aData in data.dataset) {
+        handle.dataset[aData] = data.dataset[aData];
+      }
+
+      const collapser = handle.appendChild(this.createCollapseIcon(data));
+      collapser.className = "lm-AccordionPanel-titleCollapser";
+
+      const label = handle.appendChild(document.createElement("span"));
+      label.className = "lm-AccordionPanel-titleLabel";
+      label.textContent = data.label;
+
+      return handle;
+    }
+
+    /**
+     * Create a unique render key for the title.
+     *
+     * @param data - The data to use for the title.
+     *
+     * @returns The unique render key for the title.
+     *
+     * #### Notes
+     * This method caches the key against the section title the first time
+     * the key is generated.
+     */
+    createTitleKey(data: Title<Widget>): string {
+      let key = this._titleKeys.get(data);
+      if (key === undefined) {
+        key = `title-key-${this._titleID++}`;
+        this._titleKeys.set(data, key);
+      }
+      return key;
+    }
+
+    private _titleID = 0;
+    private _titleKeys = new WeakMap<Title<Widget>, string>();
+  }
+
+  /**
+   * The default `Renderer` instance.
+   */
+  export const defaultRenderer = new Renderer();
+}
+
+namespace Private {
+  /**
+   * Create an accordion layout for the given panel options.
+   *
+   * @param options Panel options
+   * @returns Panel layout
+   */
+  export function createLayout(
+    options: AccordionPanel.IOptions
+  ): AccordionLayout {
+    return (
+      options.layout ||
+      new AccordionLayout({
+        renderer: options.renderer || AccordionPanel.defaultRenderer,
+        orientation: options.orientation,
+        alignment: options.alignment,
+        spacing: options.spacing,
+        titleSpace: options.titleSpace,
+      })
+    );
+  }
+}

--- a/packages/widgets/src/accordionpanel.ts
+++ b/packages/widgets/src/accordionpanel.ts
@@ -13,7 +13,7 @@ import { Widget } from './widget';
  * A panel which arranges its widgets into resizable sections separated by a title widget.
  *
  * #### Notes
- * This class provides a convenience wrapper around [[AccordionLayout]]. // TODO
+ * This class provides a convenience wrapper around [[AccordionLayout]].
  */
 export class AccordionPanel extends SplitPanel {
   /**
@@ -34,15 +34,14 @@ export class AccordionPanel extends SplitPanel {
   }
 
   /**
-   * Get the section title height.
+   * The section title space.
+   * 
+   * This is the height if the panel is vertical and the width if it is
+   * horizontal.
    */
   get titleSpace(): number {
     return (this.layout as AccordionLayout).titleSpace;
   }
-
-  /**
-   * Set the section title height.
-   */
   set titleSpace(value: number) {
     (this.layout as AccordionLayout).titleSpace = value;
   }

--- a/packages/widgets/src/boxlayout.ts
+++ b/packages/widgets/src/boxlayout.ts
@@ -35,6 +35,8 @@ import {
   PanelLayout
 } from './panellayout';
 
+import Utils from './utils';
+
 import {
   Widget
 } from './widget';
@@ -59,7 +61,7 @@ class BoxLayout extends PanelLayout {
       this._alignment = options.alignment;
     }
     if (options.spacing !== undefined) {
-      this._spacing = Private.clampSpacing(options.spacing);
+      this._spacing = Utils.clampDimension(options.spacing);
     }
   }
 
@@ -146,7 +148,7 @@ class BoxLayout extends PanelLayout {
    * Set the inter-element spacing for the box layout.
    */
   set spacing(value: number) {
-    value = Private.clampSpacing(value);
+    value = Utils.clampDimension(value);
     if (this._spacing === value) {
       return;
     }

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -31,6 +31,8 @@ import {
   TabBar
 } from './tabbar';
 
+import Utils from './utils';
+
 import {
   Widget
 } from './widget';
@@ -55,7 +57,7 @@ class DockLayout extends Layout {
     super();
     this.renderer = options.renderer;
     if (options.spacing !== undefined) {
-      this._spacing = Private.clampSpacing(options.spacing);
+      this._spacing = Utils.clampDimension(options.spacing);
     }
   }
 
@@ -100,7 +102,7 @@ class DockLayout extends Layout {
    * Set the inter-element spacing for the dock layout.
    */
   set spacing(value: number) {
-    value = Private.clampSpacing(value);
+    value = Utils.clampDimension(value);
     if (this._spacing === value) {
       return;
     }
@@ -1379,14 +1381,6 @@ namespace Private {
    */
   export
   type ItemMap = Map<Widget, LayoutItem>;
-
-  /**
-   * Clamp a spacing value to an integer >= 0.
-   */
-  export
-  function clampSpacing(value: number): number {
-    return Math.max(0, Math.floor(value));
-  }
 
   /**
    * Create a box sizer with an initial size hint.

--- a/packages/widgets/src/index.ts
+++ b/packages/widgets/src/index.ts
@@ -7,6 +7,8 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
+export * from './accordionlayout';
+export * from './accordionpanel';
 export * from './boxengine';
 export * from './boxlayout';
 export * from './boxpanel';

--- a/packages/widgets/src/splitlayout.ts
+++ b/packages/widgets/src/splitlayout.ts
@@ -7,23 +7,23 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
-import { ArrayExt, each } from "@lumino/algorithm";
+import { ArrayExt, each } from '@lumino/algorithm';
 
-import { ElementExt } from "@lumino/domutils";
+import { ElementExt } from '@lumino/domutils';
 
-import { Message, MessageLoop } from "@lumino/messaging";
+import { Message, MessageLoop } from '@lumino/messaging';
 
-import { AttachedProperty } from "@lumino/properties";
+import { AttachedProperty } from '@lumino/properties';
 
-import { BoxEngine, BoxSizer } from "./boxengine";
+import { BoxEngine, BoxSizer } from './boxengine';
 
-import { LayoutItem } from "./layout";
+import { LayoutItem } from './layout';
 
-import { PanelLayout } from "./panellayout";
+import { PanelLayout } from './panellayout';
 
-import { Utils } from "./utils";
+import { Utils } from './utils';
 
-import { Widget } from "./widget";
+import { Widget } from './widget';
 
 /**
  * A layout which arranges its widgets into resizable sections.
@@ -90,7 +90,7 @@ export class SplitLayout extends PanelLayout {
     if (!this.parent) {
       return;
     }
-    this.parent.dataset["orientation"] = value;
+    this.parent.dataset['orientation'] = value;
     this.parent.fit();
   }
 
@@ -124,7 +124,7 @@ export class SplitLayout extends PanelLayout {
     if (!this.parent) {
       return;
     }
-    this.parent.dataset["alignment"] = value;
+    this.parent.dataset['alignment'] = value;
     this.parent.update();
   }
 
@@ -225,13 +225,13 @@ export class SplitLayout extends PanelLayout {
   moveHandle(index: number, position: number): void {
     // Bail if the index is invalid or the handle is hidden.
     let handle = this._handles[index];
-    if (!handle || handle.classList.contains("lm-mod-hidden")) {
+    if (!handle || handle.classList.contains('lm-mod-hidden')) {
       return;
     }
 
     // Compute the desired delta movement for the handle.
     let delta: number;
-    if (this._orientation === "horizontal") {
+    if (this._orientation === 'horizontal') {
       delta = position - handle.offsetLeft;
     } else {
       delta = position - handle.offsetTop;
@@ -262,8 +262,8 @@ export class SplitLayout extends PanelLayout {
    * Perform layout initialization which requires the parent widget.
    */
   protected init(): void {
-    this.parent!.dataset["orientation"] = this.orientation;
-    this.parent!.dataset["alignment"] = this.alignment;
+    this.parent!.dataset['orientation'] = this.orientation;
+    this.parent!.dataset['alignment'] = this.alignment;
     super.init();
   }
 
@@ -427,6 +427,17 @@ export class SplitLayout extends PanelLayout {
     }
   }
 
+  /**
+   * Update the item position.
+   * 
+   * @param i Item index
+   * @param isHorizontal Whether the layout is horizontal or not
+   * @param left Left position in pixels
+   * @param top Top position in pixels
+   * @param height Item height
+   * @param width Item width
+   * @param size Item size
+   */
   protected updateItemPosition(
     i: number,
     isHorizontal: boolean,
@@ -473,14 +484,14 @@ export class SplitLayout extends PanelLayout {
     let lastHandleIndex = -1;
     for (let i = 0, n = this._items.length; i < n; ++i) {
       if (this._items[i].isHidden) {
-        this._handles[i].classList.add("lm-mod-hidden");
+        this._handles[i].classList.add('lm-mod-hidden');
         /* <DEPRECATED> */
-        this._handles[i].classList.add("p-mod-hidden");
+        this._handles[i].classList.add('p-mod-hidden');
         /* </DEPRECATED> */
       } else {
-        this._handles[i].classList.remove("lm-mod-hidden");
+        this._handles[i].classList.remove('lm-mod-hidden');
         /* <DEPRECATED> */
-        this._handles[i].classList.remove("p-mod-hidden");
+        this._handles[i].classList.remove('p-mod-hidden');
         /* </DEPRECATED> */
         lastHandleIndex = i;
         nVisible++;
@@ -489,9 +500,9 @@ export class SplitLayout extends PanelLayout {
 
     // Hide the handle for the last visible widget.
     if (lastHandleIndex !== -1) {
-      this._handles[lastHandleIndex].classList.add("lm-mod-hidden");
+      this._handles[lastHandleIndex].classList.add('lm-mod-hidden');
       /* <DEPRECATED> */
-      this._handles[lastHandleIndex].classList.add("p-mod-hidden");
+      this._handles[lastHandleIndex].classList.add('p-mod-hidden');
       /* </DEPRECATED> */
     }
 
@@ -501,7 +512,7 @@ export class SplitLayout extends PanelLayout {
       this.widgetOffset * this._items.length;
 
     // Setup the computed minimum size.
-    let horz = this._orientation === "horizontal";
+    let horz = this._orientation === 'horizontal';
     let minW = horz ? this._fixed : 0;
     let minH = horz ? 0 : this._fixed;
 
@@ -611,7 +622,7 @@ export class SplitLayout extends PanelLayout {
     // Set up the variables for justification and alignment offset.
     let extra = 0;
     let offset = 0;
-    let horz = this._orientation === "horizontal";
+    let horz = this._orientation === 'horizontal';
 
     if (nVisible > 0) {
       // Compute the adjusted layout space.
@@ -638,22 +649,22 @@ export class SplitLayout extends PanelLayout {
       // Account for alignment if there is extra layout space.
       if (delta > 0) {
         switch (this._alignment) {
-          case "start":
+          case 'start':
             break;
-          case "center":
+          case 'center':
             extra = 0;
             offset = delta / 2;
             break;
-          case "end":
+          case 'end':
             extra = 0;
             offset = delta;
             break;
-          case "justify":
+          case 'justify':
             extra = delta / nVisible;
             offset = 0;
             break;
           default:
-            throw "unreachable";
+            throw 'unreachable';
         }
       }
     }
@@ -678,7 +689,7 @@ export class SplitLayout extends PanelLayout {
 
       const fullOffset =
         this.widgetOffset +
-        (this._handles[i].classList.contains("lm-mod-hidden")
+        (this._handles[i].classList.contains('lm-mod-hidden')
           ? 0
           : this._spacing);
 
@@ -699,8 +710,8 @@ export class SplitLayout extends PanelLayout {
   private _items: LayoutItem[] = [];
   private _handles: HTMLDivElement[] = [];
   private _box: ElementExt.IBoxSizing | null = null;
-  private _alignment: SplitLayout.Alignment = "start";
-  private _orientation: SplitLayout.Orientation = "horizontal";
+  private _alignment: SplitLayout.Alignment = 'start';
+  private _orientation: SplitLayout.Orientation = 'horizontal';
 }
 
 /**
@@ -710,12 +721,12 @@ export namespace SplitLayout {
   /**
    * A type alias for a split layout orientation.
    */
-  export type Orientation = "horizontal" | "vertical";
+  export type Orientation = 'horizontal' | 'vertical';
 
   /**
    * A type alias for a split layout alignment.
    */
-  export type Alignment = "start" | "center" | "end" | "justify";
+  export type Alignment = 'start' | 'center' | 'end' | 'justify';
 
   /**
    * An options object for initializing a split layout.
@@ -791,7 +802,7 @@ namespace Private {
    * The property descriptor for a widget stretch factor.
    */
   export const stretchProperty = new AttachedProperty<Widget, number>({
-    name: "stretch",
+    name: 'stretch',
     create: () => 0,
     coerce: (owner, value) => Math.max(0, Math.floor(value)),
     changed: onChildSizingChanged,
@@ -813,7 +824,7 @@ namespace Private {
     renderer: SplitLayout.IRenderer
   ): HTMLDivElement {
     let handle = renderer.createHandle();
-    handle.style.position = "absolute";
+    handle.style.position = 'absolute';
     return handle;
   }
 

--- a/packages/widgets/src/splitlayout.ts
+++ b/packages/widgets/src/splitlayout.ts
@@ -7,23 +7,23 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
-import { ArrayExt, each } from '@lumino/algorithm';
+import { ArrayExt, each } from "@lumino/algorithm";
 
-import { ElementExt } from '@lumino/domutils';
+import { ElementExt } from "@lumino/domutils";
 
-import { Message, MessageLoop } from '@lumino/messaging';
+import { Message, MessageLoop } from "@lumino/messaging";
 
-import { AttachedProperty } from '@lumino/properties';
+import { AttachedProperty } from "@lumino/properties";
 
-import { BoxEngine, BoxSizer } from './boxengine';
+import { BoxEngine, BoxSizer } from "./boxengine";
 
-import { LayoutItem } from './layout';
+import { LayoutItem } from "./layout";
 
-import { PanelLayout } from './panellayout';
+import { PanelLayout } from "./panellayout";
 
-import { Utils } from './utils';
+import { Utils } from "./utils";
 
-import { Widget } from './widget';
+import { Widget } from "./widget";
 
 /**
  * A layout which arranges its widgets into resizable sections.
@@ -90,7 +90,7 @@ export class SplitLayout extends PanelLayout {
     if (!this.parent) {
       return;
     }
-    this.parent.dataset['orientation'] = value;
+    this.parent.dataset["orientation"] = value;
     this.parent.fit();
   }
 
@@ -124,7 +124,7 @@ export class SplitLayout extends PanelLayout {
     if (!this.parent) {
       return;
     }
-    this.parent.dataset['alignment'] = value;
+    this.parent.dataset["alignment"] = value;
     this.parent.update();
   }
 
@@ -225,13 +225,13 @@ export class SplitLayout extends PanelLayout {
   moveHandle(index: number, position: number): void {
     // Bail if the index is invalid or the handle is hidden.
     let handle = this._handles[index];
-    if (!handle || handle.classList.contains('lm-mod-hidden')) {
+    if (!handle || handle.classList.contains("lm-mod-hidden")) {
       return;
     }
 
     // Compute the desired delta movement for the handle.
     let delta: number;
-    if (this._orientation === 'horizontal') {
+    if (this._orientation === "horizontal") {
       delta = position - handle.offsetLeft;
     } else {
       delta = position - handle.offsetTop;
@@ -262,8 +262,8 @@ export class SplitLayout extends PanelLayout {
    * Perform layout initialization which requires the parent widget.
    */
   protected init(): void {
-    this.parent!.dataset['orientation'] = this.orientation;
-    this.parent!.dataset['alignment'] = this.alignment;
+    this.parent!.dataset["orientation"] = this.orientation;
+    this.parent!.dataset["alignment"] = this.alignment;
     super.init();
   }
 
@@ -473,14 +473,14 @@ export class SplitLayout extends PanelLayout {
     let lastHandleIndex = -1;
     for (let i = 0, n = this._items.length; i < n; ++i) {
       if (this._items[i].isHidden) {
-        this._handles[i].classList.add('lm-mod-hidden');
+        this._handles[i].classList.add("lm-mod-hidden");
         /* <DEPRECATED> */
-        this._handles[i].classList.add('p-mod-hidden');
+        this._handles[i].classList.add("p-mod-hidden");
         /* </DEPRECATED> */
       } else {
-        this._handles[i].classList.remove('lm-mod-hidden');
+        this._handles[i].classList.remove("lm-mod-hidden");
         /* <DEPRECATED> */
-        this._handles[i].classList.remove('p-mod-hidden');
+        this._handles[i].classList.remove("p-mod-hidden");
         /* </DEPRECATED> */
         lastHandleIndex = i;
         nVisible++;
@@ -489,9 +489,9 @@ export class SplitLayout extends PanelLayout {
 
     // Hide the handle for the last visible widget.
     if (lastHandleIndex !== -1) {
-      this._handles[lastHandleIndex].classList.add('lm-mod-hidden');
+      this._handles[lastHandleIndex].classList.add("lm-mod-hidden");
       /* <DEPRECATED> */
-      this._handles[lastHandleIndex].classList.add('p-mod-hidden');
+      this._handles[lastHandleIndex].classList.add("p-mod-hidden");
       /* </DEPRECATED> */
     }
 
@@ -501,7 +501,7 @@ export class SplitLayout extends PanelLayout {
       this.widgetOffset * this._items.length;
 
     // Setup the computed minimum size.
-    let horz = this._orientation === 'horizontal';
+    let horz = this._orientation === "horizontal";
     let minW = horz ? this._fixed : 0;
     let minH = horz ? 0 : this._fixed;
 
@@ -585,8 +585,8 @@ export class SplitLayout extends PanelLayout {
     }
 
     // Bail early if there are no visible items to layout.
-    if (nVisible === 0) {
-      return; // TODO handle all widgets collapsed
+    if (nVisible === 0 && this.widgetOffset === 0) {
+      return;
     }
 
     // Measure the parent if the offset dimensions are unknown.
@@ -608,51 +608,53 @@ export class SplitLayout extends PanelLayout {
     let width = offsetWidth - this._box.horizontalSum;
     let height = offsetHeight - this._box.verticalSum;
 
-    // Compute the adjusted layout space.
-    let space: number;
-    let horz = this._orientation === 'horizontal';
-    if (horz) {
-      // left += this.widgetOffset;
-      space = Math.max(0, width - this._fixed);
-    } else {
-      // top += this.widgetOffset;
-      space = Math.max(0, height - this._fixed);
-    }
-
-    // Scale the size hints if they are normalized.
-    if (this._hasNormedSizes) {
-      for (let sizer of this._sizers) {
-        sizer.sizeHint *= space;
-      }
-      this._hasNormedSizes = false;
-    }
-
-    // Distribute the layout space to the box sizers.
-    let delta = BoxEngine.calc(this._sizers, space);
-
     // Set up the variables for justification and alignment offset.
     let extra = 0;
     let offset = 0;
+    let horz = this._orientation === "horizontal";
 
-    // Account for alignment if there is extra layout space.
-    if (delta > 0) {
-      switch (this._alignment) {
-        case 'start':
-          break;
-        case 'center':
-          extra = 0;
-          offset = delta / 2;
-          break;
-        case 'end':
-          extra = 0;
-          offset = delta;
-          break;
-        case 'justify':
-          extra = delta / nVisible;
-          offset = 0;
-          break;
-        default:
-          throw 'unreachable';
+    if (nVisible > 0) {
+      // Compute the adjusted layout space.
+      let space: number;
+      if (horz) {
+        // left += this.widgetOffset;
+        space = Math.max(0, width - this._fixed);
+      } else {
+        // top += this.widgetOffset;
+        space = Math.max(0, height - this._fixed);
+      }
+
+      // Scale the size hints if they are normalized.
+      if (this._hasNormedSizes) {
+        for (let sizer of this._sizers) {
+          sizer.sizeHint *= space;
+        }
+        this._hasNormedSizes = false;
+      }
+
+      // Distribute the layout space to the box sizers.
+      let delta = BoxEngine.calc(this._sizers, space);
+
+      // Account for alignment if there is extra layout space.
+      if (delta > 0) {
+        switch (this._alignment) {
+          case "start":
+            break;
+          case "center":
+            extra = 0;
+            offset = delta / 2;
+            break;
+          case "end":
+            extra = 0;
+            offset = delta;
+            break;
+          case "justify":
+            extra = delta / nVisible;
+            offset = 0;
+            break;
+          default:
+            throw "unreachable";
+        }
       }
     }
 
@@ -676,7 +678,7 @@ export class SplitLayout extends PanelLayout {
 
       const fullOffset =
         this.widgetOffset +
-        (this._handles[i].classList.contains('lm-mod-hidden')
+        (this._handles[i].classList.contains("lm-mod-hidden")
           ? 0
           : this._spacing);
 
@@ -697,8 +699,8 @@ export class SplitLayout extends PanelLayout {
   private _items: LayoutItem[] = [];
   private _handles: HTMLDivElement[] = [];
   private _box: ElementExt.IBoxSizing | null = null;
-  private _alignment: SplitLayout.Alignment = 'start';
-  private _orientation: SplitLayout.Orientation = 'horizontal';
+  private _alignment: SplitLayout.Alignment = "start";
+  private _orientation: SplitLayout.Orientation = "horizontal";
 }
 
 /**
@@ -708,12 +710,12 @@ export namespace SplitLayout {
   /**
    * A type alias for a split layout orientation.
    */
-  export type Orientation = 'horizontal' | 'vertical';
+  export type Orientation = "horizontal" | "vertical";
 
   /**
    * A type alias for a split layout alignment.
    */
-  export type Alignment = 'start' | 'center' | 'end' | 'justify';
+  export type Alignment = "start" | "center" | "end" | "justify";
 
   /**
    * An options object for initializing a split layout.
@@ -789,7 +791,7 @@ namespace Private {
    * The property descriptor for a widget stretch factor.
    */
   export const stretchProperty = new AttachedProperty<Widget, number>({
-    name: 'stretch',
+    name: "stretch",
     create: () => 0,
     coerce: (owner, value) => Math.max(0, Math.floor(value)),
     changed: onChildSizingChanged,
@@ -811,7 +813,7 @@ namespace Private {
     renderer: SplitLayout.IRenderer
   ): HTMLDivElement {
     let handle = renderer.createHandle();
-    handle.style.position = 'absolute';
+    handle.style.position = "absolute";
     return handle;
   }
 

--- a/packages/widgets/src/splitlayout.ts
+++ b/packages/widgets/src/splitlayout.ts
@@ -7,44 +7,28 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
-import {
-  ArrayExt, each
-} from '@lumino/algorithm';
+import { ArrayExt, each } from '@lumino/algorithm';
 
-import {
-  ElementExt
-} from '@lumino/domutils';
+import { ElementExt } from '@lumino/domutils';
 
-import {
-  Message, MessageLoop
-} from '@lumino/messaging';
+import { Message, MessageLoop } from '@lumino/messaging';
 
-import {
-  AttachedProperty
-} from '@lumino/properties';
+import { AttachedProperty } from '@lumino/properties';
 
-import {
-  BoxEngine, BoxSizer
-} from './boxengine';
+import { BoxEngine, BoxSizer } from './boxengine';
 
-import {
-  LayoutItem
-} from './layout';
+import { LayoutItem } from './layout';
 
-import {
-  PanelLayout
-} from './panellayout';
+import { PanelLayout } from './panellayout';
 
-import {
-  Widget
-} from './widget';
+import { Utils } from './utils';
 
+import { Widget } from './widget';
 
 /**
  * A layout which arranges its widgets into resizable sections.
  */
-export
-class SplitLayout extends PanelLayout {
+export class SplitLayout extends PanelLayout {
   /**
    * Construct a new split layout.
    *
@@ -60,7 +44,7 @@ class SplitLayout extends PanelLayout {
       this._alignment = options.alignment;
     }
     if (options.spacing !== undefined) {
-      this._spacing = Private.clampSpacing(options.spacing);
+      this._spacing = Utils.clampDimension(options.spacing);
     }
   }
 
@@ -69,7 +53,9 @@ class SplitLayout extends PanelLayout {
    */
   dispose(): void {
     // Dispose of the layout items.
-    each(this._items, item => { item.dispose(); });
+    each(this._items, (item) => {
+      item.dispose();
+    });
 
     // Clear the layout state.
     this._box = null;
@@ -153,7 +139,7 @@ class SplitLayout extends PanelLayout {
    * Set the inter-element spacing for the split layout.
    */
   set spacing(value: number) {
-    value = Private.clampSpacing(value);
+    value = Utils.clampDimension(value);
     if (this._spacing === value) {
       return;
     }
@@ -183,7 +169,7 @@ class SplitLayout extends PanelLayout {
    * This method **does not** measure the DOM nodes.
    */
   relativeSizes(): number[] {
-    return Private.normalize(this._sizers.map(sizer => sizer.size));
+    return Private.normalize(this._sizers.map((sizer) => sizer.size));
   }
 
   /**
@@ -333,7 +319,11 @@ class SplitLayout extends PanelLayout {
    * #### Notes
    * This is a reimplementation of the superclass method.
    */
-  protected moveWidget(fromIndex: number, toIndex: number, widget: Widget): void {
+  protected moveWidget(
+    fromIndex: number,
+    toIndex: number,
+    widget: Widget
+  ): void {
     // Move the item, sizer, and handle for the widget.
     ArrayExt.move(this._items, fromIndex, toIndex);
     ArrayExt.move(this._sizers, fromIndex, toIndex);
@@ -437,6 +427,43 @@ class SplitLayout extends PanelLayout {
     }
   }
 
+  protected updateItemPosition(
+    i: number,
+    isHorizontal: boolean,
+    left: number,
+    top: number,
+    height: number,
+    width: number,
+    size: number
+  ): void {
+    const item = this._items[i];
+    if (item.isHidden) {
+      return;
+    }
+
+    // Fetch the style for the handle.
+    let handleStyle = this._handles[i].style;
+
+    // Update the widget and handle, and advance the relevant edge.
+    if (isHorizontal) {
+      left += this.widgetOffset;
+      item.update(left, top, size, height);
+      left += size;
+      handleStyle.top = `${top}px`;
+      handleStyle.left = `${left}px`;
+      handleStyle.width = `${this._spacing}px`;
+      handleStyle.height = `${height}px`;
+    } else {
+      top += this.widgetOffset;
+      item.update(left, top, width, size);
+      top += size;
+      handleStyle.top = `${top}px`;
+      handleStyle.left = `${left}px`;
+      handleStyle.width = `${width}px`;
+      handleStyle.height = `${this._spacing}px`;
+    }
+  }
+
   /**
    * Fit the layout to the total size required by the widgets.
    */
@@ -469,7 +496,9 @@ class SplitLayout extends PanelLayout {
     }
 
     // Update the fixed space for the visible items.
-    this._fixed = this._spacing * Math.max(0, nVisible - 1);
+    this._fixed =
+      this._spacing * Math.max(0, nVisible - 1) +
+      this.widgetOffset * this._items.length;
 
     // Setup the computed minimum size.
     let horz = this._orientation === 'horizontal';
@@ -515,7 +544,7 @@ class SplitLayout extends PanelLayout {
     }
 
     // Update the box sizing and add it to the computed min size.
-    let box = this._box = ElementExt.boxSizing(this.parent!.node);
+    let box = (this._box = ElementExt.boxSizing(this.parent!.node));
     minW += box.horizontalSum;
     minH += box.verticalSum;
 
@@ -557,7 +586,7 @@ class SplitLayout extends PanelLayout {
 
     // Bail early if there are no visible items to layout.
     if (nVisible === 0) {
-      return;
+      return; // TODO handle all widgets collapsed
     }
 
     // Measure the parent if the offset dimensions are unknown.
@@ -583,8 +612,10 @@ class SplitLayout extends PanelLayout {
     let space: number;
     let horz = this._orientation === 'horizontal';
     if (horz) {
+      // left += this.widgetOffset;
       space = Math.max(0, width - this._fixed);
     } else {
+      // top += this.widgetOffset;
       space = Math.max(0, height - this._fixed);
     }
 
@@ -606,62 +637,58 @@ class SplitLayout extends PanelLayout {
     // Account for alignment if there is extra layout space.
     if (delta > 0) {
       switch (this._alignment) {
-      case 'start':
-        break;
-      case 'center':
-        extra = 0;
-        offset = delta / 2;
-        break;
-      case 'end':
-        extra = 0;
-        offset = delta;
-        break;
-      case 'justify':
-        extra = delta / nVisible;
-        offset = 0;
-        break;
-      default:
-        throw 'unreachable';
+        case 'start':
+          break;
+        case 'center':
+          extra = 0;
+          offset = delta / 2;
+          break;
+        case 'end':
+          extra = 0;
+          offset = delta;
+          break;
+        case 'justify':
+          extra = delta / nVisible;
+          offset = 0;
+          break;
+        default:
+          throw 'unreachable';
       }
     }
 
     // Layout the items using the computed box sizes.
     for (let i = 0, n = this._items.length; i < n; ++i) {
       // Fetch the item.
-      let item = this._items[i];
-
-      // Ignore hidden items.
-      if (item.isHidden) {
-        continue;
-      }
+      const item = this._items[i];
 
       // Fetch the computed size for the widget.
-      let size = this._sizers[i].size;
+      const size = item.isHidden ? 0 : this._sizers[i].size + extra;
 
-      // Fetch the style for the handle.
-      let handleStyle = this._handles[i].style;
+      this.updateItemPosition(
+        i,
+        horz,
+        horz ? left + offset : left,
+        horz ? top : top + offset,
+        height,
+        width,
+        size
+      );
 
-      // Update the widget and handle, and advance the relevant edge.
+      const fullOffset =
+        this.widgetOffset +
+        (this._handles[i].classList.contains('lm-mod-hidden')
+          ? 0
+          : this._spacing);
+
       if (horz) {
-        item.update(left + offset, top, size + extra, height);
-        left += size + extra;
-        handleStyle.top = `${top}px`;
-        handleStyle.left = `${left + offset}px`;
-        handleStyle.width = `${this._spacing}px`;
-        handleStyle.height = `${height}px`;
-        left += this._spacing;
+        left += size + fullOffset;
       } else {
-        item.update(left, top + offset, width, size + extra);
-        top += size + extra;
-        handleStyle.top = `${top + offset}px`;
-        handleStyle.left = `${left}px`;
-        handleStyle.width = `${width}px`;
-        handleStyle.height = `${this._spacing}px`;
-        top += this._spacing;
+        top += size + fullOffset;
       }
     }
   }
 
+  protected widgetOffset = 0;
   private _fixed = 0;
   private _spacing = 4;
   private _dirty = false;
@@ -674,29 +701,24 @@ class SplitLayout extends PanelLayout {
   private _orientation: SplitLayout.Orientation = 'horizontal';
 }
 
-
 /**
  * The namespace for the `SplitLayout` class statics.
  */
-export
-namespace SplitLayout {
+export namespace SplitLayout {
   /**
    * A type alias for a split layout orientation.
    */
-  export
-  type Orientation = 'horizontal' | 'vertical';
+  export type Orientation = 'horizontal' | 'vertical';
 
   /**
    * A type alias for a split layout alignment.
    */
-  export
-  type Alignment = 'start' | 'center' | 'end' | 'justify';
+  export type Alignment = 'start' | 'center' | 'end' | 'justify';
 
   /**
    * An options object for initializing a split layout.
    */
-  export
-  interface IOptions {
+  export interface IOptions {
     /**
      * The renderer to use for the split layout.
      */
@@ -727,8 +749,7 @@ namespace SplitLayout {
   /**
    * A renderer for use with a split layout.
    */
-  export
-  interface IRenderer {
+  export interface IRenderer {
     /**
      * Create a new handle for use with a split layout.
      *
@@ -744,8 +765,7 @@ namespace SplitLayout {
    *
    * @returns The split layout stretch factor for the widget.
    */
-  export
-  function getStretch(widget: Widget): number {
+  export function getStretch(widget: Widget): number {
     return Private.stretchProperty.get(widget);
   }
 
@@ -756,12 +776,10 @@ namespace SplitLayout {
    *
    * @param value - The value for the stretch factor.
    */
-  export
-  function setStretch(widget: Widget, value: number): void {
+  export function setStretch(widget: Widget, value: number): void {
     Private.stretchProperty.set(widget, value);
   }
 }
-
 
 /**
  * The namespace for the module implementation details.
@@ -770,19 +788,17 @@ namespace Private {
   /**
    * The property descriptor for a widget stretch factor.
    */
-  export
-  const stretchProperty = new AttachedProperty<Widget, number>({
+  export const stretchProperty = new AttachedProperty<Widget, number>({
     name: 'stretch',
     create: () => 0,
     coerce: (owner, value) => Math.max(0, Math.floor(value)),
-    changed: onChildSizingChanged
+    changed: onChildSizingChanged,
   });
 
   /**
    * Create a new box sizer with the given size hint.
    */
-  export
-  function createSizer(size: number): BoxSizer {
+  export function createSizer(size: number): BoxSizer {
     let sizer = new BoxSizer();
     sizer.sizeHint = Math.floor(size);
     return sizer;
@@ -791,40 +807,31 @@ namespace Private {
   /**
    * Create a new split handle node using the given renderer.
    */
-  export
-  function createHandle(renderer: SplitLayout.IRenderer): HTMLDivElement {
+  export function createHandle(
+    renderer: SplitLayout.IRenderer
+  ): HTMLDivElement {
     let handle = renderer.createHandle();
     handle.style.position = 'absolute';
     return handle;
   }
 
   /**
-   * Clamp a spacing value to an integer >= 0.
-   */
-  export
-  function clampSpacing(value: number): number {
-    return Math.max(0, Math.floor(value));
-  }
-
-  /**
    * Compute the average size of an array of box sizers.
    */
-  export
-  function averageSize(sizers: BoxSizer[]): number {
+  export function averageSize(sizers: BoxSizer[]): number {
     return sizers.reduce((v, s) => v + s.size, 0) / sizers.length || 0;
   }
 
   /**
    * Normalize an array of values.
    */
-  export
-  function normalize(values: number[]): number[] {
+  export function normalize(values: number[]): number[] {
     let n = values.length;
     if (n === 0) {
       return [];
     }
     let sum = values.reduce((a, b) => a + Math.abs(b), 0);
-    return sum === 0 ? values.map(v => 1 / n) : values.map(v => v / sum);
+    return sum === 0 ? values.map((v) => 1 / n) : values.map((v) => v / sum);
   }
 
   /**

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -7,19 +7,19 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
-import { ArrayExt } from "@lumino/algorithm";
+import { ArrayExt } from '@lumino/algorithm';
 
-import { IDisposable } from "@lumino/disposable";
+import { IDisposable } from '@lumino/disposable';
 
-import { Drag } from "@lumino/dragdrop";
+import { Drag } from '@lumino/dragdrop';
 
-import { Message } from "@lumino/messaging";
+import { Message } from '@lumino/messaging';
 
-import { Panel } from "./panel";
+import { Panel } from './panel';
 
-import { SplitLayout } from "./splitlayout";
+import { SplitLayout } from './splitlayout';
 
-import { Widget } from "./widget";
+import { Widget } from './widget';
 
 /**
  * A panel which arranges its widgets into resizable sections.
@@ -35,9 +35,9 @@ export class SplitPanel extends Panel {
    */
   constructor(options: SplitPanel.IOptions = {}) {
     super({ layout: Private.createLayout(options) });
-    this.addClass("lm-SplitPanel");
+    this.addClass('lm-SplitPanel');
     /* <DEPRECATED> */
-    this.addClass("p-SplitPanel");
+    this.addClass('p-SplitPanel');
     /* </DEPRECATED> */
   }
 
@@ -158,19 +158,19 @@ export class SplitPanel extends Panel {
    */
   handleEvent(event: Event): void {
     switch (event.type) {
-      case "mousedown":
+      case 'mousedown':
         this._evtMouseDown(event as MouseEvent);
         break;
-      case "mousemove":
+      case 'mousemove':
         this._evtMouseMove(event as MouseEvent);
         break;
-      case "mouseup":
+      case 'mouseup':
         this._evtMouseUp(event as MouseEvent);
         break;
-      case "keydown":
+      case 'keydown':
         this._evtKeyDown(event as KeyboardEvent);
         break;
-      case "contextmenu":
+      case 'contextmenu':
         event.preventDefault();
         event.stopPropagation();
         break;
@@ -181,14 +181,14 @@ export class SplitPanel extends Panel {
    * A message handler invoked on a `'before-attach'` message.
    */
   protected onBeforeAttach(msg: Message): void {
-    this.node.addEventListener("mousedown", this);
+    this.node.addEventListener('mousedown', this);
   }
 
   /**
    * A message handler invoked on an `'after-detach'` message.
    */
   protected onAfterDetach(msg: Message): void {
-    this.node.removeEventListener("mousedown", this);
+    this.node.removeEventListener('mousedown', this);
     this._releaseMouse();
   }
 
@@ -196,9 +196,9 @@ export class SplitPanel extends Panel {
    * A message handler invoked on a `'child-added'` message.
    */
   protected onChildAdded(msg: Widget.ChildMessage): void {
-    msg.child.addClass("lm-SplitPanel-child");
+    msg.child.addClass('lm-SplitPanel-child');
     /* <DEPRECATED> */
-    msg.child.addClass("p-SplitPanel-child");
+    msg.child.addClass('p-SplitPanel-child');
     /* </DEPRECATED> */
     this._releaseMouse();
   }
@@ -207,9 +207,9 @@ export class SplitPanel extends Panel {
    * A message handler invoked on a `'child-removed'` message.
    */
   protected onChildRemoved(msg: Widget.ChildMessage): void {
-    msg.child.removeClass("lm-SplitPanel-child");
+    msg.child.removeClass('lm-SplitPanel-child');
     /* <DEPRECATED> */
-    msg.child.removeClass("p-SplitPanel-child");
+    msg.child.removeClass('p-SplitPanel-child');
     /* </DEPRECATED> */
     this._releaseMouse();
   }
@@ -255,16 +255,16 @@ export class SplitPanel extends Panel {
     event.stopPropagation();
 
     // Add the extra document listeners.
-    document.addEventListener("mouseup", this, true);
-    document.addEventListener("mousemove", this, true);
-    document.addEventListener("keydown", this, true);
-    document.addEventListener("contextmenu", this, true);
+    document.addEventListener('mouseup', this, true);
+    document.addEventListener('mousemove', this, true);
+    document.addEventListener('keydown', this, true);
+    document.addEventListener('contextmenu', this, true);
 
     // Compute the offset delta for the handle press.
     let delta: number;
     let handle = layout.handles[index];
     let rect = handle.getBoundingClientRect();
-    if (layout.orientation === "horizontal") {
+    if (layout.orientation === 'horizontal') {
       delta = event.clientX - rect.left;
     } else {
       delta = event.clientY - rect.top;
@@ -288,7 +288,7 @@ export class SplitPanel extends Panel {
     let pos: number;
     let layout = this.layout as SplitLayout;
     let rect = this.node.getBoundingClientRect();
-    if (layout.orientation === "horizontal") {
+    if (layout.orientation === 'horizontal') {
       pos = event.clientX - rect.left - this._pressData!.delta;
     } else {
       pos = event.clientY - rect.top - this._pressData!.delta;
@@ -329,10 +329,10 @@ export class SplitPanel extends Panel {
     this._pressData = null;
 
     // Remove the extra document listeners.
-    document.removeEventListener("mouseup", this, true);
-    document.removeEventListener("mousemove", this, true);
-    document.removeEventListener("keydown", this, true);
-    document.removeEventListener("contextmenu", this, true);
+    document.removeEventListener('mouseup', this, true);
+    document.removeEventListener('mousemove', this, true);
+    document.removeEventListener('keydown', this, true);
+    document.removeEventListener('contextmenu', this, true);
   }
 
   private _pressData: Private.IPressData | null = null;
@@ -409,10 +409,10 @@ export namespace SplitPanel {
      * @returns A new handle element for a split panel.
      */
     createHandle(): HTMLDivElement {
-      let handle = document.createElement("div");
-      handle.className = "lm-SplitPanel-handle";
+      let handle = document.createElement('div');
+      handle.className = 'lm-SplitPanel-handle';
       /* <DEPRECATED> */
-      handle.classList.add("p-SplitPanel-handle");
+      handle.classList.add('p-SplitPanel-handle');
       /* </DEPRECATED> */
       return handle;
     }

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -7,34 +7,19 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
-import {
-  ArrayExt
-} from '@lumino/algorithm';
+import { ArrayExt } from "@lumino/algorithm";
 
-import {
-  IDisposable
-} from '@lumino/disposable';
+import { IDisposable } from "@lumino/disposable";
 
-import {
-  Drag
-} from '@lumino/dragdrop';
+import { Drag } from "@lumino/dragdrop";
 
-import {
-  Message
-} from '@lumino/messaging';
+import { Message } from "@lumino/messaging";
 
-import {
-  Panel
-} from './panel';
+import { Panel } from "./panel";
 
-import {
-  SplitLayout
-} from './splitlayout';
+import { SplitLayout } from "./splitlayout";
 
-import {
-  Widget
-} from './widget';
-
+import { Widget } from "./widget";
 
 /**
  * A panel which arranges its widgets into resizable sections.
@@ -42,8 +27,7 @@ import {
  * #### Notes
  * This class provides a convenience wrapper around a [[SplitLayout]].
  */
-export
-class SplitPanel extends Panel {
+export class SplitPanel extends Panel {
   /**
    * Construct a new split panel.
    *
@@ -51,9 +35,9 @@ class SplitPanel extends Panel {
    */
   constructor(options: SplitPanel.IOptions = {}) {
     super({ layout: Private.createLayout(options) });
-    this.addClass('lm-SplitPanel');
+    this.addClass("lm-SplitPanel");
     /* <DEPRECATED> */
-    this.addClass('p-SplitPanel');
+    this.addClass("p-SplitPanel");
     /* </DEPRECATED> */
   }
 
@@ -174,22 +158,22 @@ class SplitPanel extends Panel {
    */
   handleEvent(event: Event): void {
     switch (event.type) {
-    case 'mousedown':
-      this._evtMouseDown(event as MouseEvent);
-      break;
-    case 'mousemove':
-      this._evtMouseMove(event as MouseEvent);
-      break;
-    case 'mouseup':
-      this._evtMouseUp(event as MouseEvent);
-      break;
-    case 'keydown':
-      this._evtKeyDown(event as KeyboardEvent);
-      break;
-    case 'contextmenu':
-      event.preventDefault();
-      event.stopPropagation();
-      break;
+      case "mousedown":
+        this._evtMouseDown(event as MouseEvent);
+        break;
+      case "mousemove":
+        this._evtMouseMove(event as MouseEvent);
+        break;
+      case "mouseup":
+        this._evtMouseUp(event as MouseEvent);
+        break;
+      case "keydown":
+        this._evtKeyDown(event as KeyboardEvent);
+        break;
+      case "contextmenu":
+        event.preventDefault();
+        event.stopPropagation();
+        break;
     }
   }
 
@@ -197,14 +181,14 @@ class SplitPanel extends Panel {
    * A message handler invoked on a `'before-attach'` message.
    */
   protected onBeforeAttach(msg: Message): void {
-    this.node.addEventListener('mousedown', this);
+    this.node.addEventListener("mousedown", this);
   }
 
   /**
    * A message handler invoked on an `'after-detach'` message.
    */
   protected onAfterDetach(msg: Message): void {
-    this.node.removeEventListener('mousedown', this);
+    this.node.removeEventListener("mousedown", this);
     this._releaseMouse();
   }
 
@@ -212,9 +196,9 @@ class SplitPanel extends Panel {
    * A message handler invoked on a `'child-added'` message.
    */
   protected onChildAdded(msg: Widget.ChildMessage): void {
-    msg.child.addClass('lm-SplitPanel-child');
+    msg.child.addClass("lm-SplitPanel-child");
     /* <DEPRECATED> */
-    msg.child.addClass('p-SplitPanel-child');
+    msg.child.addClass("p-SplitPanel-child");
     /* </DEPRECATED> */
     this._releaseMouse();
   }
@@ -223,9 +207,9 @@ class SplitPanel extends Panel {
    * A message handler invoked on a `'child-removed'` message.
    */
   protected onChildRemoved(msg: Widget.ChildMessage): void {
-    msg.child.removeClass('lm-SplitPanel-child');
+    msg.child.removeClass("lm-SplitPanel-child");
     /* <DEPRECATED> */
-    msg.child.removeClass('p-SplitPanel-child');
+    msg.child.removeClass("p-SplitPanel-child");
     /* </DEPRECATED> */
     this._releaseMouse();
   }
@@ -235,8 +219,10 @@ class SplitPanel extends Panel {
    */
   private _evtKeyDown(event: KeyboardEvent): void {
     // Stop input events during drag.
-    event.preventDefault();
-    event.stopPropagation();
+    if (this._pressData) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
 
     // Release the mouse if `Escape` is pressed.
     if (event.keyCode === 27) {
@@ -255,7 +241,7 @@ class SplitPanel extends Panel {
 
     // Find the handle which contains the mouse target, if any.
     let layout = this.layout as SplitLayout;
-    let index = ArrayExt.findFirstIndex(layout.handles, handle => {
+    let index = ArrayExt.findFirstIndex(layout.handles, (handle) => {
       return handle.contains(event.target as HTMLElement);
     });
 
@@ -269,16 +255,16 @@ class SplitPanel extends Panel {
     event.stopPropagation();
 
     // Add the extra document listeners.
-    document.addEventListener('mouseup', this, true);
-    document.addEventListener('mousemove', this, true);
-    document.addEventListener('keydown', this, true);
-    document.addEventListener('contextmenu', this, true);
+    document.addEventListener("mouseup", this, true);
+    document.addEventListener("mousemove", this, true);
+    document.addEventListener("keydown", this, true);
+    document.addEventListener("contextmenu", this, true);
 
     // Compute the offset delta for the handle press.
     let delta: number;
     let handle = layout.handles[index];
     let rect = handle.getBoundingClientRect();
-    if (layout.orientation === 'horizontal') {
+    if (layout.orientation === "horizontal") {
       delta = event.clientX - rect.left;
     } else {
       delta = event.clientY - rect.top;
@@ -302,7 +288,7 @@ class SplitPanel extends Panel {
     let pos: number;
     let layout = this.layout as SplitLayout;
     let rect = this.node.getBoundingClientRect();
-    if (layout.orientation === 'horizontal') {
+    if (layout.orientation === "horizontal") {
       pos = event.clientX - rect.left - this._pressData!.delta;
     } else {
       pos = event.clientY - rect.top - this._pressData!.delta;
@@ -343,44 +329,38 @@ class SplitPanel extends Panel {
     this._pressData = null;
 
     // Remove the extra document listeners.
-    document.removeEventListener('mouseup', this, true);
-    document.removeEventListener('mousemove', this, true);
-    document.removeEventListener('keydown', this, true);
-    document.removeEventListener('contextmenu', this, true);
+    document.removeEventListener("mouseup", this, true);
+    document.removeEventListener("mousemove", this, true);
+    document.removeEventListener("keydown", this, true);
+    document.removeEventListener("contextmenu", this, true);
   }
 
   private _pressData: Private.IPressData | null = null;
 }
 
-
 /**
  * The namespace for the `SplitPanel` class statics.
  */
-export
-namespace SplitPanel {
+export namespace SplitPanel {
   /**
    * A type alias for a split panel orientation.
    */
-  export
-  type Orientation = SplitLayout.Orientation;
+  export type Orientation = SplitLayout.Orientation;
 
   /**
    * A type alias for a split panel alignment.
    */
-  export
-  type Alignment = SplitLayout.Alignment;
+  export type Alignment = SplitLayout.Alignment;
 
   /**
    * A type alias for a split panel renderer.
    */
-  export
-  type IRenderer = SplitLayout.IRenderer;
+  export type IRenderer = SplitLayout.IRenderer;
 
   /**
    * An options object for initializing a split panel.
    */
-  export
-  interface IOptions {
+  export interface IOptions {
     /**
      * The renderer to use for the split panel.
      *
@@ -422,18 +402,17 @@ namespace SplitPanel {
   /**
    * The default implementation of `IRenderer`.
    */
-  export
-  class Renderer implements IRenderer {
+  export class Renderer implements IRenderer {
     /**
      * Create a new handle for use with a split panel.
      *
      * @returns A new handle element for a split panel.
      */
     createHandle(): HTMLDivElement {
-      let handle = document.createElement('div');
-      handle.className = 'lm-SplitPanel-handle';
+      let handle = document.createElement("div");
+      handle.className = "lm-SplitPanel-handle";
       /* <DEPRECATED> */
-      handle.classList.add('p-SplitPanel-handle');
+      handle.classList.add("p-SplitPanel-handle");
       /* </DEPRECATED> */
       return handle;
     }
@@ -442,8 +421,7 @@ namespace SplitPanel {
   /**
    * The default `Renderer` instance.
    */
-  export
-  const defaultRenderer = new Renderer();
+  export const defaultRenderer = new Renderer();
 
   /**
    * Get the split panel stretch factor for the given widget.
@@ -452,8 +430,7 @@ namespace SplitPanel {
    *
    * @returns The split panel stretch factor for the widget.
    */
-  export
-  function getStretch(widget: Widget): number {
+  export function getStretch(widget: Widget): number {
     return SplitLayout.getStretch(widget);
   }
 
@@ -464,12 +441,10 @@ namespace SplitPanel {
    *
    * @param value - The value for the stretch factor.
    */
-  export
-  function setStretch(widget: Widget, value: number): void {
+  export function setStretch(widget: Widget, value: number): void {
     SplitLayout.setStretch(widget, value);
   }
 }
-
 
 /**
  * The namespace for the module implementation details.
@@ -478,8 +453,7 @@ namespace Private {
   /**
    * An object which holds mouse press data.
    */
-  export
-  interface IPressData {
+  export interface IPressData {
     /**
      * The index of the pressed handle.
      */
@@ -499,13 +473,15 @@ namespace Private {
   /**
    * Create a split layout for the given panel options.
    */
-  export
-  function createLayout(options: SplitPanel.IOptions): SplitLayout {
-    return options.layout || new SplitLayout({
-      renderer: options.renderer || SplitPanel.defaultRenderer,
-      orientation: options.orientation,
-      alignment: options.alignment,
-      spacing: options.spacing
-    });
+  export function createLayout(options: SplitPanel.IOptions): SplitLayout {
+    return (
+      options.layout ||
+      new SplitLayout({
+        renderer: options.renderer || SplitPanel.defaultRenderer,
+        orientation: options.orientation,
+        alignment: options.alignment,
+        spacing: options.spacing,
+      })
+    );
   }
 }

--- a/packages/widgets/src/utils.ts
+++ b/packages/widgets/src/utils.ts
@@ -1,0 +1,10 @@
+export namespace Utils {
+  /**
+   * Clamp a dimension value to an integer >= 0.
+   */
+  export function clampDimension(value: number): number {
+    return Math.max(0, Math.floor(value));
+  }
+}
+
+export default Utils

--- a/packages/widgets/style/accordionpanel.css
+++ b/packages/widgets/style/accordionpanel.css
@@ -1,0 +1,6 @@
+.lm-AccordionPanel[data-orientation="horizontal"] > .lm-AccordionPanel-title {
+  /* Title is rotated for horizontal accordion panel using CSS */
+  display: block;
+  transform-origin: top left;
+  transform: rotate(-90deg) translate(-100%);
+}

--- a/packages/widgets/style/index.css
+++ b/packages/widgets/style/index.css
@@ -7,6 +7,7 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 @import './widget.css';
+@import './accordionpanel.css';
 @import './commandpalette.css';
 @import './dockpanel.css';
 @import './menu.css';

--- a/packages/widgets/tests/src/accordionlayout.spec.ts
+++ b/packages/widgets/tests/src/accordionlayout.spec.ts
@@ -1,0 +1,198 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { each, every } from '@lumino/algorithm';
+import { Message } from '@lumino/messaging';
+import { AccordionLayout, Title, Widget } from '@lumino/widgets';
+import { expect } from 'chai';
+
+const renderer: AccordionLayout.IRenderer = {
+  titleClassName: '.lm-AccordionTitle',
+  createHandle: () => document.createElement('div'),
+  createSectionTitle: (title: Title<Widget>) => document.createElement('h3'),
+};
+
+class LogAccordionLayout extends AccordionLayout {
+  methods: string[] = [];
+
+  protected init(): void {
+    super.init();
+    this.methods.push('init');
+  }
+
+  protected attachWidget(index: number, widget: Widget): void {
+    super.attachWidget(index, widget);
+    this.methods.push('attachWidget');
+  }
+
+  protected moveWidget(
+    fromIndex: number,
+    toIndex: number,
+    widget: Widget
+  ): void {
+    super.moveWidget(fromIndex, toIndex, widget);
+    this.methods.push('moveWidget');
+  }
+
+  protected detachWidget(index: number, widget: Widget): void {
+    super.detachWidget(index, widget);
+    this.methods.push('detachWidget');
+  }
+
+  protected onFitRequest(msg: Message): void {
+    super.onFitRequest(msg);
+    this.methods.push('onFitRequest');
+  }
+}
+
+describe('@lumino/widgets', () => {
+  describe('AccordionLayout', () => {
+    describe('#constructor()', () => {
+      it('should accept a renderer', () => {
+        const layout = new AccordionLayout({ renderer });
+        expect(layout).to.be.an.instanceof(AccordionLayout);
+      });
+
+      it('should be vertical by default', () => {
+        const layout = new AccordionLayout({ renderer });
+        expect(layout.orientation).to.equal('vertical');
+      });
+    });
+
+    describe('#titleSpace', () => {
+      it('should get the inter-element spacing for the split layout', () => {
+        const layout = new AccordionLayout({ renderer });
+        expect(layout.titleSpace).to.equal(22);
+      });
+
+      it('should set the inter-element spacing for the split layout', () => {
+        const layout = new AccordionLayout({ renderer });
+        layout.titleSpace = 10;
+        expect(layout.titleSpace).to.equal(10);
+      });
+
+      it('should post a fit request to the parent widget', (done) => {
+        let layout = new LogAccordionLayout({ renderer });
+        let parent = new Widget();
+        parent.layout = layout;
+        layout.titleSpace = 10;
+        requestAnimationFrame(() => {
+          expect(layout.methods).to.contain('onFitRequest');
+          done();
+        });
+      });
+
+      it('should be a no-op if the value does not change', (done) => {
+        let layout = new LogAccordionLayout({ renderer });
+        let parent = new Widget();
+        parent.layout = layout;
+        layout.titleSpace = 22;
+        requestAnimationFrame(() => {
+          expect(layout.methods).to.not.contain('onFitRequest');
+          done();
+        });
+      });
+    });
+
+    describe('#renderer', () => {
+      it('should get the renderer for the layout', () => {
+        const layout = new AccordionLayout({ renderer });
+        expect(layout.renderer).to.equal(renderer);
+      });
+    });
+
+    describe('#titles', () => {
+      it('should be a read-only sequence of the accordion titles in the layout', () => {
+        const layout = new AccordionLayout({ renderer });
+        let parent = new Widget();
+        parent.layout = layout;
+        const widgets = [new Widget(), new Widget(), new Widget()];
+        each(widgets, w => {
+          layout.addWidget(w);
+        });
+
+        expect(every(layout.titles, (h) => h instanceof HTMLElement));
+        expect(layout.titles).to.have.length(widgets.length);
+      });
+    });
+
+    describe('#attachWidget()', () => {
+      it('should insert a title node before the widget', () => {
+        let layout = new LogAccordionLayout({ renderer });
+        let parent = new Widget();
+        parent.layout = layout;
+        let widget = new Widget();
+
+        layout.addWidget(widget);
+
+        expect(layout.methods).to.contain('attachWidget');
+        expect(parent.node.contains(widget.node)).to.equal(true);
+        expect(layout.titles.length).to.equal(1);
+
+        const title = layout.titles[0];
+        expect(widget.node.previousElementSibling).to.equal(title);
+        expect(title.getAttribute('aria-label')).to.equal(
+          `${parent.title.label} Section`
+        );
+        expect(title.getAttribute('aria-expanded')).to.equal('true');
+        expect(title.classList.contains('lm-mod-expanded')).to.be.true;
+
+        expect(widget.node.getAttribute('role')).to.equal('region');
+        expect(widget.node.getAttribute('aria-labelledby')).to.equal(title.id);
+        parent.dispose();
+      });
+    });
+
+    describe('#moveWidget()', () => {
+      it("should move a title in the parent's DOM node", () => {
+        let layout = new LogAccordionLayout({ renderer });
+        let widgets = [new Widget(), new Widget(), new Widget()];
+        let parent = new Widget();
+        parent.layout = layout;
+        widgets.forEach((w) => {
+          layout.addWidget(w);
+        });
+        let widget = widgets[0];
+        let title = layout.titles[0];
+
+        layout.insertWidget(2, widget);
+
+        expect(layout.methods).to.contain('moveWidget');
+        expect(layout.titles[2]).to.equal(title);
+        parent.dispose();
+      });
+    });
+
+    describe('#detachWidget()', () => {
+      it("should detach a title from the parent's DOM node", () => {
+        let layout = new LogAccordionLayout({ renderer });
+        let widget = new Widget();
+        let parent = new Widget();
+        parent.layout = layout;
+        layout.addWidget(widget);
+        const title = layout.titles[0];
+
+        layout.removeWidget(widget);
+
+        expect(layout.methods).to.contain('detachWidget');
+        expect(parent.node.contains(title)).to.equal(false);
+        expect(layout.titles).to.have.length(0);
+        parent.dispose();
+      });
+    });
+
+    describe('#dispose', () => {
+      it('clear the titles list', () => {
+        const layout = new AccordionLayout({ renderer });
+        const widgets = [new Widget(), new Widget(), new Widget()];
+        widgets.forEach((w) => {
+          layout.addWidget(w);
+        });
+
+        layout.dispose();
+
+        expect(layout.titles).to.have.length(0);
+      });
+    });
+  });
+});

--- a/packages/widgets/tests/src/accordionpanel.spec.ts
+++ b/packages/widgets/tests/src/accordionpanel.spec.ts
@@ -1,0 +1,329 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { every } from '@lumino/algorithm';
+import { MessageLoop } from '@lumino/messaging';
+import {
+  AccordionLayout,
+  AccordionPanel,
+  Title,
+  Widget
+} from '@lumino/widgets';
+import { expect } from 'chai';
+import { simulate } from 'simulate-event';
+
+const renderer: AccordionPanel.IRenderer = {
+  titleClassName: '.lm-AccordionTitle',
+  createHandle: () => document.createElement('div'),
+  createSectionTitle: (title: Title<Widget>) => document.createElement('h3'),
+};
+
+class LogAccordionPanel extends AccordionPanel {
+  events: string[] = [];
+
+  handleEvent(event: Event): void {
+    super.handleEvent(event);
+    this.events.push(event.type);
+  }
+}
+
+describe('@lumino/widgets', () => {
+  describe('AccordionPanel', () => {
+    describe('#constructor()', () => {
+      it('should accept no arguments', () => {
+        let panel = new AccordionPanel();
+        expect(panel).to.be.an.instanceof(AccordionPanel);
+      });
+
+      it('should accept options', () => {
+        let panel = new AccordionPanel({
+          orientation: 'horizontal',
+          spacing: 5,
+          titleSpace: 42,
+          renderer,
+        });
+        expect(panel.orientation).to.equal('horizontal');
+        expect(panel.spacing).to.equal(5);
+        expect(panel.titleSpace).to.equal(42);
+        expect(panel.renderer).to.equal(renderer);
+      });
+
+      it('should accept a layout option', () => {
+        let layout = new AccordionLayout({ renderer });
+        let panel = new AccordionPanel({ layout });
+        expect(panel.layout).to.equal(layout);
+      });
+
+      it('should ignore other options if a layout is given', () => {
+        let ignored = Object.create(renderer);
+        let layout = new AccordionLayout({ renderer });
+        let panel = new AccordionPanel({
+          layout,
+          orientation: 'horizontal',
+          spacing: 5,
+          titleSpace: 42,
+          renderer: ignored,
+        });
+        expect(panel.layout).to.equal(layout);
+        expect(panel.orientation).to.equal('vertical');
+        expect(panel.spacing).to.equal(4);
+        expect(panel.titleSpace).to.equal(22);
+        expect(panel.renderer).to.equal(renderer);
+      });
+
+      it('should add the `lm-AccordionPanel` class', () => {
+        let panel = new AccordionPanel();
+        expect(panel.hasClass('lm-AccordionPanel')).to.equal(true);
+      });
+    });
+
+    describe('#dispose()', () => {
+      it('should dispose of the resources held by the panel', () => {
+        let panel = new LogAccordionPanel();
+        let layout = panel.layout as AccordionLayout;
+        let widgets = [new Widget(), new Widget(), new Widget()];
+        widgets.forEach((w) => {
+          panel.addWidget(w);
+        });
+        Widget.attach(panel, document.body);
+
+        panel.dispose();
+
+        expect(every(widgets, (w) => w.isDisposed));
+        expect(layout.titles).to.have.length(0);
+      });
+    });
+
+    describe('#titleSpace', () => {
+      it('should default to `22`', () => {
+        let panel = new AccordionPanel();
+        expect(panel.titleSpace).to.equal(22);
+      });
+
+      it('should set the titleSpace for the panel', () => {
+        let panel = new AccordionPanel();
+        panel.titleSpace = 10;
+        expect(panel.titleSpace).to.equal(10);
+      });
+    });
+
+    describe('#renderer', () => {
+      it('should get the renderer for the panel', () => {
+        let panel = new AccordionPanel({ renderer });
+        expect(panel.renderer).to.equal(renderer);
+      });
+    });
+
+    describe('#titles', () => {
+      it('should get the read-only sequence of the accordion titles in the panel', () => {
+        let panel = new AccordionPanel();
+        let widgets = [new Widget(), new Widget(), new Widget()];
+        widgets.forEach((w) => {
+          panel.addWidget(w);
+        });
+        expect(panel.titles.length).to.equal(widgets.length);
+      });
+    });
+
+    describe('#handleEvent()', () => {
+      let panel: LogAccordionPanel;
+      let layout: AccordionLayout;
+
+      beforeEach(() => {
+        panel = new LogAccordionPanel();
+        layout = panel.layout as AccordionLayout;
+        let widgets = [new Widget(), new Widget(), new Widget()];
+        widgets.forEach((w) => {
+          panel.addWidget(w);
+        });
+        panel.setRelativeSizes([10, 10, 10, 20]);
+        Widget.attach(panel, document.body);
+        MessageLoop.flush();
+      });
+
+      afterEach(() => {
+        panel.dispose();
+      });
+
+      context('click', () => {
+        it('should collapse an expanded widget', () => {
+          simulate(layout.titles[0], 'click');
+          expect(panel.events).to.contain('click');
+
+          expect(layout.titles[0].getAttribute('aria-expanded')).to.equal(
+            'false'
+          );
+          expect(layout.titles[0].classList.contains('lm-mod-expanded')).to.be.false;
+          expect(layout.widgets[0].isHidden).to.be.true;
+        });
+
+        it('should expand a collapsed widget', () => {
+          // Collapse
+          simulate(layout.titles[0], 'click');
+
+          simulate(layout.titles[0], 'click');
+
+          expect(layout.titles[0].getAttribute('aria-expanded')).to.equal(
+            'true'
+          );
+          expect(layout.titles[0].classList.contains('lm-mod-expanded')).to.be.true;
+          expect(layout.widgets[0].isHidden).to.be.false;
+        });
+      });
+
+      context('keydown', () => {
+        it('should redirect to toggle expansion state if Space is pressed', () => {
+          simulate(layout.titles[0], 'keydown', { key: 'Space' });
+          expect(panel.events).to.contain('keydown');
+
+          expect(layout.titles[0].getAttribute('aria-expanded')).to.equal(
+            'false'
+          );
+          expect(layout.titles[0].classList.contains('lm-mod-expanded')).to.be.false;
+          expect(layout.widgets[0].isHidden).to.be.true;
+
+          simulate(layout.titles[0], 'keydown', { key: 'Space' });
+          expect(panel.events).to.contain('keydown');
+
+          expect(layout.titles[0].getAttribute('aria-expanded')).to.equal(
+            'true'
+          );
+          expect(layout.titles[0].classList.contains('lm-mod-expanded')).to.be.true;
+          expect(layout.widgets[0].isHidden).to.be.false;
+        });
+
+        it('should redirect to toggle expansion state if Enter is pressed', () => {
+          simulate(layout.titles[0], 'keydown', { key: 'Enter' });
+          expect(panel.events).to.contain('keydown');
+
+          expect(layout.titles[0].getAttribute('aria-expanded')).to.equal(
+            'false'
+          );
+          expect(layout.titles[0].classList.contains('lm-mod-expanded')).to.be.false;
+          expect(layout.widgets[0].isHidden).to.be.true;
+
+          simulate(layout.titles[0], 'keydown', { key: 'Enter' });
+          expect(panel.events).to.contain('keydown');
+
+          expect(layout.titles[0].getAttribute('aria-expanded')).to.equal(
+            'true'
+          );
+          expect(layout.titles[0].classList.contains('lm-mod-expanded')).to.be.true;
+          expect(layout.widgets[0].isHidden).to.be.false;
+        });
+
+        it('should focus on the next widget if Arrow Down is pressed', () => {
+          layout.titles[1].focus();
+
+          simulate(layout.titles[1], 'keydown', { key: 'ArrowDown' });
+          expect(panel.events).to.contain('keydown');
+
+          expect(document.activeElement).to.be.equal(layout.titles[2]);
+        });
+
+        it('should focus on the previous widget if Arrow Up is pressed', () => {
+          layout.titles[1].focus();
+
+          simulate(layout.titles[1], 'keydown', { key: 'ArrowUp' });
+          expect(panel.events).to.contain('keydown');
+
+          expect(document.activeElement).to.be.equal(layout.titles[0]);
+        });
+
+        it('should focus on the first widget if Home is pressed', () => {
+          layout.titles[1].focus();
+
+          simulate(layout.titles[1], 'keydown', { key: 'Home' });
+          expect(panel.events).to.contain('keydown');
+
+          expect(document.activeElement).to.be.equal(layout.titles[0]);
+        });
+
+        it('should focus on the last widget if End is pressed', () => {
+          layout.titles[1].focus();
+
+          simulate(layout.titles[1], 'keydown', { key: 'End' });
+          expect(panel.events).to.contain('keydown');
+
+          expect(document.activeElement).to.be.equal(layout.titles[2]);
+        });
+      });
+    });
+
+    describe('#onBeforeAttach()', () => {
+      it('should attach a click listener to the node', () => {
+        let panel = new LogAccordionPanel();
+        Widget.attach(panel, document.body);
+        simulate(panel.node, 'click');
+        expect(panel.events).to.contain('click');
+        panel.dispose();
+      });
+
+      it('should attach a keydown listener to the node', () => {
+        let panel = new LogAccordionPanel();
+        Widget.attach(panel, document.body);
+        simulate(panel.node, 'keydown');
+        expect(panel.events).to.contain('keydown');
+        panel.dispose();
+      });
+    });
+
+    describe('#onAfterDetach()', () => {
+      it('should remove click listener', () => {
+        let panel = new LogAccordionPanel();
+        Widget.attach(panel, document.body);
+        simulate(panel.node, 'click');
+        expect(panel.events).to.contain('click');
+
+        Widget.detach(panel);
+
+        panel.events = [];
+        simulate(panel.node, 'click');
+        expect(panel.events).to.not.contain('click');
+      });
+
+      it('should remove keydown listener', () => {
+        let panel = new LogAccordionPanel();
+        Widget.attach(panel, document.body);
+        simulate(panel.node, 'keydown');
+        expect(panel.events).to.contain('keydown');
+
+        Widget.detach(panel);
+
+        panel.events = [];
+        simulate(panel.node, 'keydown');
+        expect(panel.events).to.not.contain('keydown');
+      });
+    });
+
+    describe('.Renderer()', () => {
+      describe('.defaultRenderer', () => {
+        it('should be an instance of `Renderer`', () => {
+          expect(AccordionPanel.defaultRenderer).to.be.an.instanceof(
+            AccordionPanel.Renderer
+          );
+        });
+      });
+
+      describe('#constructor', () => {
+        it('should create a section title', () => {
+          const renderer = new AccordionPanel.Renderer();
+
+          expect(
+            renderer.createSectionTitle(
+              new Title<Widget>({ owner: new Widget() })
+            )
+          ).to.be.instanceOf(HTMLElement);
+        });
+
+        it('should have a section title selector', () => {
+          const renderer = new AccordionPanel.Renderer();
+
+          expect(renderer.titleClassName).to.be.equal(
+            'lm-AccordionPanel-title'
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/widgets/tests/src/index.spec.ts
+++ b/packages/widgets/tests/src/index.spec.ts
@@ -11,6 +11,8 @@ import 'es6-promise/auto';  // polyfill Promise on IE
 
 import '@lumino/widgets/style/index.css';
 
+import './accordionlayout.spec';
+import './accordionpanel.spec';
 import './boxengine.spec';
 import './boxlayout.spec';
 import './boxpanel.spec';


### PR DESCRIPTION
This PR adds an accordion panel (including an example).

Features:
- Build on top of `SplitPanel` - multiple region of the accordion panel can be opened simulatenously and resized at will
- Keyboard navigation:
  - Tab to loop on sections and content of opened sections
  - Space and Enter opens/closes the section
  - Up / Down (for vertical) or Left / Right (for horizontal) Arrow to loop on section titles
  - Home / End to jump to first or last titles

Tasks:
- [x] Keyboard navigation
- [x] Handle all widgets collapsed
- [x] Handle horizontal layout
- [x] Handle alignment
- [x] Check that SplitPanel is still working as expected
- [x] Test
- [x] Documentation

![accordion_panel](https://user-images.githubusercontent.com/8435071/127496781-3382628b-abb1-416e-be22-550ffcddcfde.gif)
