### PR TITLE
Automated Changelog Entry for 2021.7.23 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2021.7.23
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/example-datagrid@0.23.0...eee4eb491d5df940bead38b9dff7cba0a94ec482))
+
+### Enhancements made
+
+- Added option to force items' position [#208](https://github.com/jupyterlab/lumino/pull/208) ([@hbcarlos](https://github.com/hbcarlos))
+- Add option to not group context menu item by target [#206](https://github.com/jupyterlab/lumino/pull/206) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Fixes for Check Release [#210](https://github.com/jupyterlab/lumino/pull/210) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2021-07-21&to=2021-07-23&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2021-07-21..2021-07-23&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2021-07-21..2021-07-23&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ahbcarlos+updated%3A2021-07-21..2021-07-23&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2021-07-21..2021-07-23&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2017.7.22
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/example-datagrid@0.23.0...04b0cf32e49d1371f1c68228850a3941e5b0c6a2))
@@ -16,8 +39,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2021-07-21&to=2021-07-22&type=c))
 
 [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2021-07-21..2021-07-22&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ahbcarlos+updated%3A2021-07-21..2021-07-22&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2021-07-21..2021-07-22&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2021.7.21
 


### PR DESCRIPTION
Automated Changelog Entry for 2021.7.23 on master
Python version: 2021.7.23
npm version: lumino-top-level: 2021.7.21
npm workspace versions:
@lumino/example-datastore: 0.14.0
@lumino/example-datagrid: 0.24.0
@lumino/example-dockpanel-iife: 0.1.0
@lumino/example-dockpanel-amd: 0.1.0
@lumino/example-dockpanel: 0.14.0
@lumino/commands: 1.15.0
@lumino/messaging: 1.7.0
@lumino/domutils: 1.5.0
@lumino/disposable: 1.7.0
@lumino/coreutils: 1.8.0
@lumino/polling: 1.6.0
@lumino/widgets: 1.25.0
@lumino/properties: 1.5.0
@lumino/virtualdom: 1.11.0
@lumino/datagrid: 0.27.0
@lumino/keyboard: 1.5.0
@lumino/default-theme: 0.16.0
@lumino/collections: 1.6.0
@lumino/application: 1.22.0
@lumino/dragdrop: 1.10.0
@lumino/signaling: 1.7.0
@lumino/datastore: 0.14.0
@lumino/algorithm: 1.6.0

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | master  |
| Version Spec | 2021.7.23 |
