### PR TITLE
Fix handling of pip cache in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,15 +96,23 @@ jobs:
           python-version: 3.9
           architecture: "x64"
 
+      # Cache pip
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+
       - name: Get pip cache dir
         id: pip-cache
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
+
       - name: Cache pip
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
+          key: ${{ runner.os }}-pip-${{ steps.get-date.outputs.date }}
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-pip-


### PR DESCRIPTION
Since there is no python package for lumino, use a cache key that is today's date.