### PR TITLE
New renderer: HyperlinkRenderer

### DIFF
--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -11,7 +11,7 @@ import 'es6-promise/auto';  // polyfill Promise on IE
 
 import {
   BasicKeyHandler, BasicMouseHandler, BasicSelectionModel, CellRenderer, CellGroup,
-  DataGrid, DataModel, JSONModel, TextRenderer, MutableDataModel, CellEditor, ICellEditor
+  DataGrid, DataModel, JSONModel, TextRenderer, HyperlinkRenderer, MutableDataModel, CellEditor, ICellEditor
 } from '@lumino/datagrid';
 
 import {
@@ -582,6 +582,24 @@ function main(): void {
   const columnIdentifier = {'name': 'Corp. Data'};
   grid6.editorController!.setEditor(columnIdentifier, (config: CellEditor.CellConfig): ICellEditor => {
     return new JSONCellEditor();
+  });
+
+  const hyperlinkRenderer = new HyperlinkRenderer({
+    url: (config: CellRenderer.CellConfig) => {
+      return config.value[0];
+    },
+    urlName: (config: CellRenderer.CellConfig) => {
+      return config.value[1];
+    }
+  });
+
+  grid6.cellRenderers.update({
+    'body': (config: CellRenderer.CellConfig) => {
+      if (config.metadata.name === "link") {
+        return hyperlinkRenderer
+      }
+      return undefined;
+    }
   });
 
   let grid7 = new DataGrid();
@@ -1329,6 +1347,7 @@ namespace Data {
     "data": [
       {
         "index": 0,
+        "link": ["https://www.chevrolet.com/", "Chevrolet"],
         "Name": "Chevrolet",
         "Contact": "info@chevrolet.com",
         "Origin": "USA",
@@ -1342,6 +1361,7 @@ namespace Data {
       },
       {
         "index": 1,
+        "link": ["https://www.bmw.com/", "BMW"],
         "Name": "BMW",
         "Contact": "info@bmw.com",
         "Origin": "Germany",
@@ -1355,6 +1375,7 @@ namespace Data {
       },
       {
         "index": 2,
+        "link": ["https://www.mercedes-benz.com/", "Mercedes"],
         "Name": "Mercedes",
         "Contact": "info@mbusa.com",
         "Origin": "Germany",
@@ -1368,6 +1389,7 @@ namespace Data {
       },
       {
         "index": 3,
+        "link": ["https://www.honda.com/", "Honda"],
         "Name": "Honda",
         "Contact": "info@honda.com",
         "Origin": "Japan",
@@ -1381,6 +1403,7 @@ namespace Data {
       },
       {
         "index": 4,
+        "link": ["https://www.toyota.com/", "Toyota"],
         "Name": "Toyota",
         "Contact": "info@toyota.com",
         "Origin": "Japan",
@@ -1394,6 +1417,7 @@ namespace Data {
       },
       {
         "index": 5,
+        "link": ["https://www.renaultgroup.com/", "Renault"],
         "Name": "Renault",
         "Contact": "info@renault.com",
         "Origin": "France",
@@ -1414,6 +1438,10 @@ namespace Data {
         {
           "name": "index",
           "type": "integer"
+        },
+        {
+          "name": "link",
+          "type": "object"
         },
         {
           "name": "Name",

--- a/packages/datagrid/src/basicmousehandler.ts
+++ b/packages/datagrid/src/basicmousehandler.ts
@@ -196,6 +196,9 @@ class BasicMouseHandler implements DataGrid.IMouseHandler {
         // Open the hyperlink only if user hit Ctrl+Click.
         if (accel) {
           window.open(url);
+          // Reset cursor default after clicking
+          const cursor = this.cursorForHandle('none');
+          grid.viewport.node.style.cursor = cursor;
           // Not applying selections if navigating away.
           return;
         }

--- a/packages/datagrid/src/hyperlinkrenderer.ts
+++ b/packages/datagrid/src/hyperlinkrenderer.ts
@@ -8,8 +8,16 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import {
-    CellRenderer, TextRenderer, GraphicsContext
-} from '.';
+    CellRenderer
+} from './cellrenderer';
+
+import {
+    GraphicsContext
+} from './graphicscontext';
+
+import {
+    TextRenderer
+} from './textrenderer';
 
 
 
@@ -28,8 +36,14 @@ export
         options.textColor = options.textColor || 'navy';
         options.font = options.font || 'bold 12px sans-serif';
         super(options);
+        this.url = options.url;
         this.urlName = options.urlName;
     }
+
+    /**
+     * The URL address.
+     */
+    readonly url: CellRenderer.ConfigOption<string> | undefined;
 
     /**
      * The friendly link name.
@@ -96,7 +110,7 @@ export
             return;
         }
 
-        let format = this.format;
+        const format = this.format;
         let text;
 
         // If we have a friendly URL name, use that.
@@ -325,6 +339,10 @@ namespace HyperlinkRenderer {
      */
     export
         interface IOptions extends TextRenderer.IOptions {
+        /**
+         * The URL address
+         */
+        url?: CellRenderer.ConfigOption<string> | undefined;
         /**
          * The friendly link name.
          *

--- a/packages/datagrid/src/hyperlinkrenderer.ts
+++ b/packages/datagrid/src/hyperlinkrenderer.ts
@@ -51,39 +51,6 @@ export
     readonly urlName: CellRenderer.ConfigOption<string> | undefined;
 
     /**
-     * Paint the content for a cell.
-     *
-     * @param gc - The graphics context to use for drawing.
-     *
-     * @param config - The configuration data for the cell.
-     */
-    paint(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
-        this.drawBackground(gc, config);
-        this.drawText(gc, config);
-    }
-
-    /**
-     * Draw the background for the cell.
-     *
-     * @param gc - The graphics context to use for drawing.
-     *
-     * @param config - The configuration data for the cell.
-     */
-    drawBackground(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
-        // Resolve the background color for the cell.
-        let color = CellRenderer.resolveOption(this.backgroundColor, config);
-
-        // Bail if there is no background color to draw.
-        if (!color) {
-            return;
-        }
-
-        // Fill the cell with the background color.
-        gc.fillStyle = color;
-        gc.fillRect(config.x, config.y, config.width, config.height);
-    }
-
-    /**
      * Draw the text for the cell.
      *
      * @param gc - The graphics context to use for drawing.

--- a/packages/datagrid/src/hyperlinkrenderer.ts
+++ b/packages/datagrid/src/hyperlinkrenderer.ts
@@ -1,0 +1,335 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2019, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+import {
+    CellRenderer, TextRenderer, GraphicsContext
+} from '.';
+
+
+
+/**
+ * A cell renderer which renders data values as text.
+ */
+export
+    class HyperlinkRenderer extends TextRenderer {
+    /**
+     * Construct a new text renderer.
+     *
+     * @param options - The options for initializing the renderer.
+     */
+    constructor(options: HyperlinkRenderer.IOptions = {}) {
+        // Set default parameters before passing over the super.
+        options.textColor = options.textColor || 'navy';
+        options.font = options.font || 'bold 12px sans-serif';
+        super(options);
+        this.urlName = options.urlName;
+    }
+
+    /**
+     * The friendly link name.
+     */
+    readonly urlName: CellRenderer.ConfigOption<string> | undefined;
+
+    /**
+     * Paint the content for a cell.
+     *
+     * @param gc - The graphics context to use for drawing.
+     *
+     * @param config - The configuration data for the cell.
+     */
+    paint(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
+        this.drawBackground(gc, config);
+        this.drawText(gc, config);
+    }
+
+    /**
+     * Draw the background for the cell.
+     *
+     * @param gc - The graphics context to use for drawing.
+     *
+     * @param config - The configuration data for the cell.
+     */
+    drawBackground(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
+        // Resolve the background color for the cell.
+        let color = CellRenderer.resolveOption(this.backgroundColor, config);
+
+        // Bail if there is no background color to draw.
+        if (!color) {
+            return;
+        }
+
+        // Fill the cell with the background color.
+        gc.fillStyle = color;
+        gc.fillRect(config.x, config.y, config.width, config.height);
+    }
+
+    /**
+     * Draw the text for the cell.
+     *
+     * @param gc - The graphics context to use for drawing.
+     *
+     * @param config - The configuration data for the cell.
+     */
+    drawText(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
+        // Resolve the font for the cell.
+        let font = CellRenderer.resolveOption(this.font, config);
+
+        // Bail if there is no font to draw.
+        if (!font) {
+            return;
+        }
+
+        // Resolve for the friendly URL name.
+        let urlName = CellRenderer.resolveOption(this.urlName, config);
+
+        // Resolve the text color for the cell.
+        let color = CellRenderer.resolveOption(this.textColor, config);
+
+        // Bail if there is no text color to draw.
+        if (!color) {
+            return;
+        }
+
+        let format = this.format;
+        let text;
+
+        // If we have a friendly URL name, use that.
+        if (urlName) {
+            text = format({
+                ...config,
+                value: urlName
+            } as CellRenderer.CellConfig);
+        } else {
+            // Otherwise use the raw value attribute.
+            text = format(config);
+        }
+
+        // Bail if there is no text to draw.
+        if (!text) {
+            return;
+        }
+
+        // Resolve the vertical and horizontal alignment.
+        let vAlign = CellRenderer.resolveOption(this.verticalAlignment, config);
+        let hAlign = CellRenderer.resolveOption(this.horizontalAlignment, config);
+
+        // Resolve the elision direction
+        let elideDirection = CellRenderer.resolveOption(this.elideDirection, config);
+
+        // Resolve the text wrapping flag
+        let wrapText = CellRenderer.resolveOption(this.wrapText, config);
+
+        // Compute the padded text box height for the specified alignment.
+        let boxHeight = config.height - (vAlign === 'center' ? 1 : 2);
+
+        // Bail if the text box has no effective size.
+        if (boxHeight <= 0) {
+            return;
+        }
+
+        // Compute the text height for the gc font.
+        let textHeight = HyperlinkRenderer.measureFontHeight(font);
+
+        // Set up the text position variables.
+        let textX: number;
+        let textY: number;
+        let boxWidth: number;
+
+        // Compute the Y position for the text.
+        switch (vAlign) {
+            case 'top':
+                textY = config.y + 2 + textHeight;
+                break;
+            case 'center':
+                textY = config.y + config.height / 2 + textHeight / 2;
+                break;
+            case 'bottom':
+                textY = config.y + config.height - 2;
+                break;
+            default:
+                throw 'unreachable';
+        }
+
+        // Compute the X position for the text.
+        switch (hAlign) {
+            case 'left':
+                textX = config.x + 8;
+                boxWidth = config.width - 14;
+                break;
+            case 'center':
+                textX = config.x + config.width / 2;
+                boxWidth = config.width;
+                break;
+            case 'right':
+                textX = config.x + config.width - 8;
+                boxWidth = config.width - 14;
+                break;
+            default:
+                throw 'unreachable';
+        }
+
+        // Clip the cell if the text is taller than the text box height.
+        if (textHeight > boxHeight) {
+            gc.beginPath();
+            gc.rect(config.x, config.y, config.width, config.height - 1);
+            gc.clip();
+        }
+
+        // Set the gc state.
+        gc.font = font;
+        gc.fillStyle = color;
+        gc.textAlign = hAlign;
+        gc.textBaseline = 'bottom';
+
+        // The current text width in pixels.
+        let textWidth = gc.measureText(text).width;
+
+        // Apply text wrapping if enabled.
+        if (wrapText && textWidth > boxWidth) {
+            // Make sure box clipping happens.
+            gc.beginPath();
+            gc.rect(config.x, config.y, config.width, config.height - 1);
+            gc.clip();
+
+            // Split column name to words based on
+            // whitespace preceding a word boundary.
+            // "Hello  world" --> ["Hello  ", "world"]
+            const wordsInColumn = text.split(/\s(?=\b)/);
+
+            // Y-coordinate offset for any additional lines
+            let curY = textY;
+            let textInCurrentLine = wordsInColumn.shift()!
+
+            // Single word. Applying text wrap on word by splitting
+            // it into characters and fitting the maximum number of
+            // characters possible per line (box width).
+            if (wordsInColumn.length === 0) {
+                let curLineTextWidth = gc.measureText(textInCurrentLine).width;
+                while (curLineTextWidth > boxWidth && textInCurrentLine !== "") {
+                    // Iterating from the end of the string until we find a
+                    // substring (0,i) which has a width less than the box width.
+                    for (let i = textInCurrentLine.length; i > 0; i--) {
+                        const curSubString = textInCurrentLine.substring(0, i);
+                        const curSubStringWidth = gc.measureText(curSubString).width;
+                        if (curSubStringWidth < boxWidth || curSubString.length === 1) {
+                            // Found a substring which has a width less than the current
+                            // box width. Rendering that substring on the current line
+                            // and setting the remainder of the parent string as the next
+                            // string to iterate on for the next line.
+                            const nextLineText = textInCurrentLine.substring(i, textInCurrentLine.length);
+                            textInCurrentLine = nextLineText;
+                            curLineTextWidth = gc.measureText(textInCurrentLine).width;
+                            gc.fillText(curSubString, textX, curY);
+                            curY += textHeight;
+                            // No need to continue iterating after we identified
+                            // an index to break the string on.
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Multiple words in column header. Fitting maximum
+            // number of words possible per line (box width).
+            else {
+                while (wordsInColumn.length !== 0) {
+                    // Processing the next word in the queue.
+                    const curWord = wordsInColumn.shift();
+                    // Joining that word with the existing text for
+                    // the current line.
+                    const incrementedText = [textInCurrentLine, curWord].join(" ");
+                    const incrementedTextWidth = gc.measureText(incrementedText).width;
+                    if (incrementedTextWidth > boxWidth) {
+                        // If the newly combined text has a width larger than
+                        // the box width, we render the line before the current
+                        // word was added. We set the current word as the next
+                        // line.
+                        gc.fillText(textInCurrentLine, textX, curY);
+                        curY += textHeight;
+                        textInCurrentLine = curWord!;
+                    }
+                    else {
+                        // The combined text hasd a width less than the box width. We
+                        // set the the current line text to be the new combined text.
+                        textInCurrentLine = incrementedText;
+                    }
+                }
+            }
+            gc.fillText(textInCurrentLine!, textX, curY);
+            // Terminating the call here as we don't want
+            // to apply text eliding when wrapping is active.
+            return;
+        }
+
+        // Elide text that is too long
+        let elide = '\u2026';
+
+        // Compute elided text
+        if (elideDirection === 'right') {
+            while ((textWidth > boxWidth) && (text.length > 1)) {
+                if (text.length > 4 && textWidth >= 2 * boxWidth) {
+                    // If text width is substantially bigger, take half the string
+                    text = text.substring(0, (text.length / 2) + 1) + elide;
+                } else {
+                    // Otherwise incrementally remove the last character
+                    text = text.substring(0, text.length - 2) + elide;
+                }
+                textWidth = gc.measureText(text).width;
+            }
+        } else {
+            while ((textWidth > boxWidth) && (text.length > 1)) {
+                if (text.length > 4 && textWidth >= 2 * boxWidth) {
+                    // If text width is substantially bigger, take half the string
+                    text = elide + text.substring((text.length / 2));
+                } else {
+                    // Otherwise incrementally remove the last character
+                    text = elide + text.substring(2);
+                }
+                textWidth = gc.measureText(text).width;
+            }
+        }
+
+        // Draw the text for the cell.
+        gc.fillText(text, textX, textY);
+    }
+}
+
+export
+namespace HyperlinkRenderer {
+    /**
+     * A type alias for the supported vertical alignment modes.
+     */
+    export
+        type VerticalAlignment = 'top' | 'center' | 'bottom';
+
+    /**
+     * A type alias for the supported horizontal alignment modes.
+     */
+    export
+        type HorizontalAlignment = 'left' | 'center' | 'right';
+
+    /**
+     * A type alias for the supported ellipsis sides.
+     */
+    export
+        type ElideDirection = 'left' | 'right';
+
+    /**
+     * An options object for initializing a text renderer.
+     */
+    export
+        interface IOptions extends TextRenderer.IOptions {
+        /**
+         * The friendly link name.
+         *
+         * The default is the URL itself.
+         */
+        urlName?: CellRenderer.ConfigOption<string> | undefined;
+    }
+}

--- a/packages/datagrid/src/index.ts
+++ b/packages/datagrid/src/index.ts
@@ -21,4 +21,5 @@ export * from './renderermap';
 export * from './selectionmodel';
 export * from './sectionlist';
 export * from './textrenderer';
+export * from './hyperlinkrenderer';
 export * from './cellgroup';


### PR DESCRIPTION
This PR adds support for `HyperlinkRenderer` : a custom renderer based on `TextRenderer`, which adds logic for displaying and opening hyperlinks.

As it extends `TextRenderer`, parameters such as `font`, `color` and `background` can all be customised as expected. `HyperlinkRenderer` adds two additional parameters on top - `url` and `urlName`. Both take functions which control the logic of how to arrive at the actual `href` value for the URL, as well as any friendly name for displaying the hyperlink in the grid. In addition, the default text color and font weight for links rendered in `HyperlinkRenderer` are navy blue and **bold**.

Columns rendered with `HyperlinkRenderer` will have a pointer hover cursor to indicate they're links. To open a link, the _Ctrl_ key must be pressed before clicking. Not pressing the key will result in the existing selection behaviour.

![lumino_hyperlink](https://user-images.githubusercontent.com/24281433/128968426-281342c9-5ff4-4c6a-bb9d-8498e62fc991.gif)
