### PR TITLE
Automated Changelog Entry for 2021.8.12 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2021.8.12
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.23.0...5bd6fe37c0351e48c7e72a9ccb01927a30473020))
+
+### Enhancements made
+
+- New renderer: HyperlinkRenderer [#218](https://github.com/jupyterlab/lumino/pull/218) ([@ibdafna](https://github.com/ibdafna))
+
+### Maintenance and upkeep improvements
+
+- Update dependencies [#217](https://github.com/jupyterlab/lumino/pull/217) ([@afshin](https://github.com/afshin))
+- Fix handling of pip cache in CI [#216](https://github.com/jupyterlab/lumino/pull/216) ([@blink1073](https://github.com/blink1073))
+
+### Other merged PRs
+
+- Bump tar from 4.4.13 to 4.4.15 [#215](https://github.com/jupyterlab/lumino/pull/215) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2021-08-03&to=2021-08-12&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2021-08-03..2021-08-12&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2021-08-03..2021-08-12&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2021-08-03..2021-08-12&type=Issues) | [@ibdafna](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aibdafna+updated%3A2021-08-03..2021-08-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2021.8.3
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.22.0...d54b9ebc5bc28fa3676c9482da3db5656840934b))
@@ -23,8 +48,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2021-07-23&to=2021-08-03&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2021-07-23..2021-08-03&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2021-07-23..2021-08-03&type=Issues) | [@marthacryan](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Amarthacryan+updated%3A2021-07-23..2021-08-03&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2021.7.23
 


### PR DESCRIPTION
Automated Changelog Entry for 2021.8.12 on master
Python version: 2021.8.12
npm version: lumino-top-level: 2021.8.3
npm workspace versions:
@lumino/example-datagrid: 0.25.0
@lumino/example-dockpanel-iife: 0.1.0
@lumino/example-accordionpanel: 0.2.0
@lumino/example-datastore: 0.15.0
@lumino/example-dockpanel: 0.15.0
@lumino/example-dockpanel-amd: 0.1.0
@lumino/polling: 1.6.0
@lumino/keyboard: 1.5.0
@lumino/messaging: 1.7.0
@lumino/signaling: 1.7.0
@lumino/algorithm: 1.6.0
@lumino/dragdrop: 1.10.0
@lumino/collections: 1.6.0
@lumino/default-theme: 0.17.0
@lumino/commands: 1.15.0
@lumino/virtualdom: 1.11.0
@lumino/coreutils: 1.8.0
@lumino/domutils: 1.5.0
@lumino/application: 1.23.0
@lumino/datagrid: 0.28.0
@lumino/widgets: 1.26.0
@lumino/disposable: 1.7.0
@lumino/datastore: 0.14.0
@lumino/properties: 1.5.0

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | master  |
| Version Spec | 2021.8.12 |
