### PR TITLE
Add auto-resize function for column widths

### DIFF
--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3773,6 +3773,53 @@ class DataGrid extends Widget {
   }
 
   /**
+   * Resizes row header columns so their text fits
+   * without clipping or wrapping.
+   * @param dataModel 
+   */
+   private _fitRowColumnHeaders(dataModel: DataModel): void {
+    /*
+      if we're working with nested row headers,
+      retrieve the nested levels and iterate on them.
+    */
+    const rowColumnCount = dataModel.columnCount('row-header');
+    for (let i = 0; i < rowColumnCount; i++) {
+      const numCols = dataModel.rowCount('column-header');
+      console.log(numCols);
+      /*
+        Calculate the maximum text width vertically, across
+        all nested columns under a given row index.
+      */
+      let maxWidth = 0;
+      for (let j = 0; j < numCols; j++) {
+        const cellValue = dataModel.data('corner-header', j, i);
+
+        // Basic CellConfig object to get the renderer for that cell.
+        let config = {
+          x: 0, y: 0, width: 0, height: 0,
+          region: 'column-header' as DataModel.CellRegion, row: 0, column: i,
+          value: (null as any), metadata: DataModel.emptyMetadata
+        };
+
+        // Get the renderer for the given cell.
+        const renderer = this.cellRenderers.get(config) as TextRenderer;
+
+        // Use the canvas context to measure the cell's text width
+        const gc = this.canvasGC;
+        gc.font = CellRenderer.resolveOption(renderer.font, config);
+        const textWidth = gc.measureText(cellValue).width;
+        maxWidth = Math.max(maxWidth, textWidth);
+      }
+
+      /*
+        Send a resize message with new width for the given column.
+        Using a padding of 15 pixels to leave some room.
+      */
+      this.resizeColumn('row-header', i, maxWidth + 15);
+    }
+  }
+
+  /**
    * Paint the overlay content for the entire grid.
    *
    * This is the primary overlay paint entry point. The individual

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -1482,6 +1482,22 @@ class DataGrid extends Widget {
   }
 
   /**
+   * Auto sizes column widths based on their text content.
+   * @param area 
+   */
+   fitColumnNames(area: DataGrid.ColumnFitType = 'all'): void {
+    // Attempt resizing only if a data model is present.
+    if (this.dataModel) {
+      if (area === 'body' || area === 'all') {
+        this._fitBodyColumnHeaders(this.dataModel);
+      }
+      if (area === 'row-header' || area === 'all') {
+        this._fitRowColumnHeaders(this.dataModel);
+      }
+    }
+  }
+
+  /**
    * Map a client position to local viewport coordinates.
    *
    * @param clientX - The client X position of the mouse.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -1536,11 +1536,11 @@ class DataGrid extends Widget {
           } else {
             /*
               Otherwise the entire body column count can be resized.
-              Resize all body columns and subtract from remaining
-              column resize allowance.
+              Resize based on the smallest number between remaining
+              resize allowance and body column count.
             */
-            this._fitBodyColumnHeaders(this.dataModel, bodyColumnCount);
-            colsRemaining = colsRemaining - bodyColumnCount;
+            this._fitBodyColumnHeaders(this.dataModel,
+              Math.min(colsRemaining, bodyColumnCount));
           }
         } else {
           // No column resize cap passed - resizing all columns.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -64,6 +64,10 @@ import {
   JSONExt
 } from '@lumino/coreutils';
 
+import { 
+  TextRenderer 
+} from './textrenderer';
+
 /**
  * A widget which implements a high-performance tabular data grid.
  *

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -5694,6 +5694,12 @@ namespace DataGrid {
   type HeaderVisibility = 'all' | 'row' | 'column' | 'none';
 
   /**
+   * A type alias for the supported column auto resize modes.
+   */
+  export
+  type ColumnFitType = 'all' | 'row-header' | 'body';
+
+  /**
    * A type alias for the arguments to a copy format function.
    */
   export

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3801,7 +3801,6 @@ class DataGrid extends Widget {
     const rowColumnCount = dataModel.columnCount('row-header');
     for (let i = 0; i < rowColumnCount; i++) {
       const numCols = dataModel.rowCount('column-header');
-      console.log(numCols);
       /*
         Calculate the maximum text width vertically, across
         all nested columns under a given row index.


### PR DESCRIPTION
This PR adds a function which resizes column widths for `body` and `row` column headers (index and non-index columns) based on the text width of their column names. This allows users to not have to worry about manually resizing the grid columns upon instantiation or pre-determine column widths before instantiation. The API is quite simple takes two optional arguments: 

```typescript
DataGrid.fitColumnNames(area: DataGrid.ColumnFitType = 'all', numCols?: number): void;

type ColumnFitType = 'all' | 'row-header' | 'body';
```

`numCols` allow for capping of the number of columns to be resized.

![lumino_autofit](https://user-images.githubusercontent.com/24281433/129821908-ccda69e3-7b39-4b57-9d4c-a3649ed2e422.gif)

