### PR TITLE
Add static examples in docs

### DIFF
--- a/.github/jupyterlab-probot.yml
+++ b/.github/jupyterlab-probot.yml
@@ -1,2 +1,0 @@
-binderUrlSuffix: "?urlpath=lab/tree/examples"
-addBinderLink: true

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ docs/source/changelog.md
 # generated api files
 docs/api
 
+# generated example files
+docs/source/examples
+
 # jetbrains ide stuff
 *.iml
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ review/api/temp
 docs/source/changelog.md
 
 # generated api files
-docs/api
+docs/source/api
 
 # generated example files
 docs/source/examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,14 @@ There are also tests in some of the examples. These can be run as:
 ```bash
 yarn test:examples
 ```
+
+## Static Examples
+
+There are static examples built into the documentation.  Having them in docs allows us to test examples
+in the ReadTheDocs build for a PR.
+
+To add an example to the static examples:
+
+- Add appropriate link in: `docs/source/examples.rst`
+- Add the example name to the `EXAMPLES` in `docs/source/conf.py`
+- Add `ignore-links` config in `package.json`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,6 +30,7 @@ from subprocess import check_call
 
 
 HERE = osp.abspath(osp.dirname(__file__))
+EXAMPLES = ["accordionpanel", "datagrid", "dockpanel"]
 
 # -- General configuration ------------------------------------------------
 
@@ -103,7 +104,7 @@ def build_api_docs(out_dir):
     docs = osp.join(HERE, os.pardir)
     root = osp.join(docs, os.pardir)
     docs_api = osp.join(docs, "api")
-    api_index = osp.join(docs_api, "index.html")
+    api_index = osp.join(docs_api, "algorithm", "index.html")
 
     if osp.exists(api_index):
         # avoid rebuilding docs because it takes forever
@@ -126,6 +127,36 @@ def build_api_docs(out_dir):
     dest = osp.join(dest_dir, 'index.html')
     shutil.copy(osp.join(HERE, 'api_index.html'), dest)
 
+
+# build js examples and stage them to the build directory
+def build_examples(out_dir):
+    """build js example docs"""
+    docs = osp.join(HERE, os.pardir)
+    root = osp.join(docs, os.pardir)
+
+    examples_dir = osp.join(root, "examples")
+    api_index = osp.join(examples_dir, f"example-{EXAMPLES[0]}", "index.html")
+
+    if osp.exists(api_index):
+        # avoid rebuilding examples because it takes forever
+        # `make clean` to force a rebuild
+        print(f"already have examples")
+    else:
+        print("Building lumino examples docs")
+        npm = [shutil.which('npm')]
+        check_call(npm + ['install', '-g', 'yarn'], cwd=root)
+        yarn = [shutil.which('yarn')]
+        check_call(yarn, cwd=root)
+        check_call(yarn + ["build"], cwd=root)
+        check_call(yarn + ["build:examples"], cwd=root)
+
+    for example in EXAMPLES:
+        source = osp.join(root, "examples", f"example-{example}")
+        dest_dir = osp.join(out_dir, "examples", example)
+        print(f"Copying {source} -> {dest_dir}")
+        if osp.exists(dest_dir):
+            shutil.rmtree(dest_dir)
+        shutil.copytree(source, dest_dir)
 
 # -- Options for HTML output ----------------------------------------------
 
@@ -260,3 +291,4 @@ def setup(app):
     shutil.copy(osp.join(HERE, '..', '..', 'CHANGELOG.md'), dest)
     app.add_css_file('css/custom.css')  # may also be an URL
     build_api_docs(app.outdir)
+    build_examples(app.outdir)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,7 +103,7 @@ def build_api_docs(out_dir):
     """build js api docs"""
     docs = osp.join(HERE, os.pardir)
     root = osp.join(docs, os.pardir)
-    docs_api = osp.join(docs, "api")
+    docs_api = osp.join(docs, "source", "api")
     api_index = osp.join(docs_api, "algorithm", "index.html")
 
     if osp.exists(api_index):
@@ -118,31 +118,20 @@ def build_api_docs(out_dir):
         check_call(yarn, cwd=root)
         check_call(yarn + ["docs"], cwd=root)
 
-    dest_dir = osp.join(out_dir, "api")
-    print(f"Copying {docs_api} -> {dest_dir}")
-    if osp.exists(dest_dir):
-        shutil.rmtree(dest_dir)
-    shutil.copytree(docs_api, dest_dir)
-
-    dest = osp.join(dest_dir, 'index.html')
-    shutil.copy(osp.join(HERE, 'api_index.html'), dest)
-
-
 # build js examples and stage them to the build directory
 def build_examples(out_dir):
     """build js example docs"""
     docs = osp.join(HERE, os.pardir)
     root = osp.join(docs, os.pardir)
 
-    examples_dir = osp.join(root, "examples")
-    example_index = osp.join(examples_dir, f"example-{EXAMPLES[0]}", "index.html")
+    example_index = osp.join(docs, "examples", EXAMPLES[0], "index.html")
 
     if osp.exists(example_index):
         # avoid rebuilding examples because it takes forever
         # `make clean` to force a rebuild
         print(f"already have examples")
     else:
-        print("Building lumino examples docs")
+        print("Building lumino examples")
         npm = [shutil.which('npm')]
         check_call(npm + ['install', '-g', 'yarn'], cwd=root)
         yarn = [shutil.which('yarn')]
@@ -150,13 +139,14 @@ def build_examples(out_dir):
         check_call(yarn + ["build"], cwd=root)
         check_call(yarn + ["build:examples"], cwd=root)
 
-    for example in EXAMPLES:
-        source = osp.join(root, "examples", f"example-{example}")
-        dest_dir = osp.join(out_dir, "examples", example)
-        print(f"Copying {source} -> {dest_dir}")
-        if osp.exists(dest_dir):
-            shutil.rmtree(dest_dir)
-        shutil.copytree(source, dest_dir)
+        # Move the examples locally so they can be picked up by html_static_path
+        for example in EXAMPLES:
+            source = osp.join(root, "examples", f"example-{example}")
+            dest_dir = osp.join(docs, "source", "examples", example)
+            print(f"Copying {source} -> {dest_dir}")
+            if osp.exists(dest_dir):
+                shutil.rmtree(dest_dir)
+            shutil.copytree(source, dest_dir)
 
 # -- Options for HTML output ----------------------------------------------
 
@@ -176,9 +166,8 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# We add the build directories of the examples
-html_static_path = ['_static'] + ['/'.join(['examples', e, 'build']) for e in EXAMPLES]
-print(html_static_path)
+html_static_path = ['_static']
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #
@@ -237,7 +226,6 @@ latex_documents = [
      'Project Jupyter', 'manual'),
 ]
 
-
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
@@ -246,7 +234,6 @@ man_pages = [
     (master_doc, 'lumino', 'Lumino Documentation',
      [author], 1)
 ]
-
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -258,8 +245,6 @@ texinfo_documents = [
      author, 'Lumino', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
 
 # -- Options for Epub output ----------------------------------------------
 
@@ -280,8 +265,6 @@ epub_copyright = copyright
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
-
-
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,13 +118,20 @@ def build_api_docs(out_dir):
         check_call(yarn, cwd=root)
         check_call(yarn + ["docs"], cwd=root)
 
+    dest_dir = osp.join(out_dir, "api")
+    print(f"Copying {docs_api} -> {dest_dir}")
+    if osp.exists(dest_dir):
+        shutil.rmtree(dest_dir)
+    shutil.copytree(docs_api, dest_dir)
+    shutil.copy(osp.join(HERE, 'api_index.html'), osp.join(dest_dir, 'index.html'))
+
 # build js examples and stage them to the build directory
 def build_examples(out_dir):
     """build js example docs"""
     docs = osp.join(HERE, os.pardir)
     root = osp.join(docs, os.pardir)
-
-    example_index = osp.join(docs, "examples", EXAMPLES[0], "index.html")
+    examples_dir = osp.join(docs, "source", "examples")
+    example_index = osp.join(examples_dir, EXAMPLES[0], "index.html")
 
     if osp.exists(example_index):
         # avoid rebuilding examples because it takes forever
@@ -139,7 +146,7 @@ def build_examples(out_dir):
         check_call(yarn + ["build"], cwd=root)
         check_call(yarn + ["build:examples"], cwd=root)
 
-        # Move the examples locally so they can be picked up by html_static_path
+        # Copy the examples into source so the JS files get picked up
         for example in EXAMPLES:
             source = osp.join(root, "examples", f"example-{example}")
             dest_dir = osp.join(docs, "source", "examples", example)
@@ -147,6 +154,12 @@ def build_examples(out_dir):
             if osp.exists(dest_dir):
                 shutil.rmtree(dest_dir)
             shutil.copytree(source, dest_dir)
+
+    dest_dir = osp.join(out_dir, "examples")
+    print(f"Copying {examples_dir} -> {dest_dir}")
+    if osp.exists(dest_dir):
+        shutil.rmtree(dest_dir)
+    shutil.copytree(examples_dir, dest_dir)
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -176,8 +176,9 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static', 'examples']
-
+# We add the build directories of the examples
+html_static_path = ['_static'] + ['/'.join(['examples', e, 'build']) for e in EXAMPLES]
+print(html_static_path)
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,9 +91,6 @@ language = None
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = []
 
-# List of paths that contain custom static files (such as style sheets or script files)
-html_static_path = ['./examples']
-
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
@@ -179,7 +176,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ['_static', 'examples']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,6 +91,9 @@ language = None
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = []
 
+# List of paths that contain custom static files (such as style sheets or script files)
+html_static_path = ['./examples']
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
@@ -135,9 +138,9 @@ def build_examples(out_dir):
     root = osp.join(docs, os.pardir)
 
     examples_dir = osp.join(root, "examples")
-    api_index = osp.join(examples_dir, f"example-{EXAMPLES[0]}", "index.html")
+    example_index = osp.join(examples_dir, f"example-{EXAMPLES[0]}", "index.html")
 
-    if osp.exists(api_index):
+    if osp.exists(example_index):
         # avoid rebuilding examples because it takes forever
         # `make clean` to force a rebuild
         print(f"already have examples")

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,0 +1,12 @@
+
+
+Examples
+========
+
+Rendered static examples
+
+`Accordion Panel <examples/accordionpanel/index.html>`_
+
+`DataGrid <examples/datagrid/index.html>`_
+
+`DockPanel <examples/dockpanel/index.html>`_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Lumino's documentation!
-==================================
+Lumino
+======
 
 .. toctree::
    :maxdepth: 1
@@ -12,6 +12,7 @@ Welcome to Lumino's documentation!
 
    changelog
    api
+   examples
 
 Indices and tables
 ==================

--- a/examples/example-accordionpanel/index.html
+++ b/examples/example-accordionpanel/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
   <script type="text/javascript" src="build/bundle.example.js"></script>
 </head>
 <body>

--- a/examples/example-dockpanel/index.html
+++ b/examples/example-dockpanel/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
   <script type="text/javascript" src="build/bundle.example.js"></script>
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -58,7 +58,10 @@
     ],
     "options": {
       "ignore-links": [
-        "./api/index.html"
+        "./api/index.html",
+        "examples/accordionpanel/index.html",
+        "examples/datagrid/index.html",
+        "examples/dockpanel/index.html"
       ]
     },
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean:examples": "lerna run clean --scope \"@lumino/example-*\"",
     "clean:src": "lerna run clean --scope \"@lumino/!(test-|example-)*\"",
     "clean:tests": "lerna run clean:tests",
-    "docs": "rimraf docs/api && lerna run build:src --concurrency 1 && lerna run docs",
+    "docs": "rimraf docs/source/api && lerna run build:src --concurrency 1 && lerna run docs",
     "eslint": "eslint --ext .js,.jsx,.ts,.tsx --cache --fix .",
     "eslint:check": "eslint --ext .js,.jsx,.ts,.tsx --cache .",
     "get:dependency": "get-dependency",

--- a/packages/algorithm/tdoptions.json
+++ b/packages/algorithm/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/algorithm",
+  "out": "../../docs/source/api/algorithm",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/application/tdoptions.json
+++ b/packages/application/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/application",
+  "out": "../../docs/source/api/application",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["../packages/*"]

--- a/packages/collections/tdoptions.json
+++ b/packages/collections/tdoptions.json
@@ -3,7 +3,7 @@
   "mode": "file",
   "target": "es5",
   "module": "es5",
-  "out": "../../docs/api/collections",
+  "out": "../../docs/source/api/collections",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/commands/tdoptions.json
+++ b/packages/commands/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/commands",
+  "out": "../../docs/source/api/commands",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/coreutils/tdoptions.json
+++ b/packages/coreutils/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/coreutils",
+  "out": "../../docs/source/api/coreutils",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/datagrid/tdoptions.json
+++ b/packages/datagrid/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/datagrid",
+  "out": "../../docs/source/api/datagrid",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/datastore/tdoptions.json
+++ b/packages/datastore/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/datastore",
+  "out": "../../docs/source/api/datastore",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/disposable/tdoptions.json
+++ b/packages/disposable/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/disposable",
+  "out": "../../docs/source/api/disposable",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/domutils/tdoptions.json
+++ b/packages/domutils/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/domutils",
+  "out": "../../docs/source/api/domutils",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/dragdrop/tdoptions.json
+++ b/packages/dragdrop/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/dragdrop",
+  "out": "../../docs/source/api/dragdrop",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/keyboard/tdoptions.json
+++ b/packages/keyboard/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/keyboard",
+  "out": "../../docs/source/api/keyboard",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/messaging/tdoptions.json
+++ b/packages/messaging/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/messaging",
+  "out": "../../docs/source/api/messaging",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/polling/tdoptions.json
+++ b/packages/polling/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/polling",
+  "out": "../../docs/source/api/polling",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/properties/tdoptions.json
+++ b/packages/properties/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/properties",
+  "out": "../../docs/source/api/properties",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/signaling/tdoptions.json
+++ b/packages/signaling/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/signaling",
+  "out": "../../docs/source/api/signaling",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/virtualdom/tdoptions.json
+++ b/packages/virtualdom/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/virtualdom",
+  "out": "../../docs/source/api/virtualdom",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/packages/widgets/tdoptions.json
+++ b/packages/widgets/tdoptions.json
@@ -9,7 +9,7 @@
     "lib.es2015.promise.d.ts",
     "lib.dom.d.ts"
   ],
-  "out": "../../docs/api/widgets",
+  "out": "../../docs/source/api/widgets",
   "baseUrl": ".",
   "paths": {
     "@lumino/*": ["node_modules/@lumino/*"]

--- a/typedoc.js
+++ b/typedoc.js
@@ -21,8 +21,8 @@ module.exports = {
   entryPoints,
   exclude,
   name: '@lumino',
-  out: 'docs/api',
-  // json: 'docs/api.json',
+  out: 'docs/source/api',
+  // json: 'docs/source/api.json',
   readme: 'README.md',
   theme: 'typedoc-theme',
   tsconfig: 'tsconfigdoc.json'


### PR DESCRIPTION
- Add rendered static examples in docs
- Remove the binder link since we could not reliably view the examples in the binder due to iframe limitations

![image](https://user-images.githubusercontent.com/2096628/135352424-af930a06-b9c9-4ee4-8080-2dbb56c28733.png)

