### PR TITLE
Automated Changelog Entry for 2021.9.30 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2021.9.30
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/algorithm@1.7.0...e6612f622c827b2e85cffb1858fcc3bf1b09be76))
+
+### Enhancements made
+
+- Basic Touch Events [#123](https://github.com/jupyterlab/lumino/pull/123) ([@bign8](https://github.com/bign8))
+
+### Maintenance and upkeep improvements
+
+- Optimise grid rendering [#239](https://github.com/jupyterlab/lumino/pull/239) ([@ibdafna](https://github.com/ibdafna))
+
+### Documentation improvements
+
+- Add static examples in docs [#241](https://github.com/jupyterlab/lumino/pull/241) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2021-09-22&to=2021-09-30&type=c))
+
+[@bign8](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Abign8+updated%3A2021-09-22..2021-09-30&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2021-09-22..2021-09-30&type=Issues) | [@ibdafna](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aibdafna+updated%3A2021-09-22..2021-09-30&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ajupyterlab-probot+updated%3A2021-09-22..2021-09-30&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2021.9.22
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/signaling@1.7.2...520444449e74a37a82c34fdf51c70c60059733b3))
@@ -30,8 +54,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2021-08-23&to=2021-09-22&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2021-08-23..2021-09-22&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2021-08-23..2021-09-22&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2021-08-23..2021-09-22&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2021-08-23..2021-09-22&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ajtpio+updated%3A2021-08-23..2021-09-22&type=Issues) | [@jupyterlab-probot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ajupyterlab-probot+updated%3A2021-08-23..2021-09-22&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2021.8.23
 


### PR DESCRIPTION
Automated Changelog Entry for 2021.9.30 on master
npm workspace versions:
@lumino/example-datastore: 0.17.0
@lumino/example-accordionpanel: 0.4.0
@lumino/example-dockpanel-iife: 0.3.0
@lumino/example-dockpanel: 0.17.0
@lumino/example-datagrid: 0.28.0
@lumino/example-dockpanel-amd: 0.3.0
@lumino/keyboard: 1.7.0
@lumino/widgets: 1.28.0
@lumino/polling: 1.8.0
@lumino/properties: 1.7.0
@lumino/commands: 1.17.0
@lumino/domutils: 1.7.0
@lumino/signaling: 1.9.0
@lumino/datastore: 0.16.0
@lumino/disposable: 1.9.0
@lumino/collections: 1.8.0
@lumino/datagrid: 0.32.0
@lumino/algorithm: 1.8.0
@lumino/default-theme: 0.19.0
@lumino/coreutils: 1.10.0
@lumino/dragdrop: 1.12.0
@lumino/virtualdom: 1.13.0
@lumino/application: 1.25.0
@lumino/messaging: 1.9.0

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | master  |
| Version Spec | 2021.9.30 |
| Since | @lumino/algorithm@1.7.0 |