### PR TITLE
Ignore `keydown` events for modifier keys when accumulating key sequence

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -497,7 +497,7 @@ export class CommandRegistry {
    */
   processKeydownEvent(event: KeyboardEvent): void {
     // Bail immediately if playing back keystrokes.
-    if (this._replaying) {
+    if (this._replaying || CommandRegistry.isIgnoredKeyPressed(event)) {
       return;
     }
 
@@ -1202,6 +1202,19 @@ export namespace CommandRegistry {
   }
 
   /**
+   * Check if `'keydown'` event is caused by pressing a key that should be ignored.
+   *
+   * @param event - The event object for a `'keydown'` event.
+   *
+   * @returns `true` if ignored key was pressed, `false` otherwise.
+   */
+  export function isIgnoredKeyPressed(event: KeyboardEvent): boolean {
+    let layout = getKeyboardLayout();
+    let key = layout.keyForKeydownEvent(event);
+    return layout.isIgnoredKey(key);
+  }
+
+  /**
    * Create a normalized keystroke for a `'keydown'` event.
    *
    * @param event - The event object for a `'keydown'` event.
@@ -1210,8 +1223,9 @@ export namespace CommandRegistry {
    *   does not represent a valid keystroke for the given layout.
    */
   export function keystrokeForKeydownEvent(event: KeyboardEvent): string {
-    let key = getKeyboardLayout().keyForKeydownEvent(event);
-    if (!key) {
+    let layout = getKeyboardLayout();
+    let key = layout.keyForKeydownEvent(event);
+    if (!key || layout.isIgnoredKey(key)) {
       return '';
     }
     let mods = '';

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -1007,6 +1007,55 @@ describe('@lumino/commands', () => {
         expect(called).to.equal(false);
         document.body.removeEventListener('keydown', keydown);
       });
+
+      it('should ignore modifier keys pressed in the middle of key sequence', () => {
+        let count = 0;
+        registry.addCommand('test', {
+          execute: () => {
+            count++;
+          }
+        });
+        registry.addKeyBinding({
+          keys: ['Ctrl K', 'Ctrl L'],
+          selector: `#${elem.id}`,
+          command: 'test'
+        });
+        let eventK = generate('keydown', { keyCode: 75, ctrlKey: true });
+        let eventCtrl = generate('keydown', { keyCode: 17, ctrlKey: true });
+        let eventL = generate('keydown', { keyCode: 76, ctrlKey: true });
+        elem.dispatchEvent(eventK);
+        expect(count).to.equal(0);
+        elem.dispatchEvent(eventCtrl); // user presses Ctrl again - this should not break the sequence
+        expect(count).to.equal(0);
+        elem.dispatchEvent(eventL);
+        expect(count).to.equal(1);
+      });
+
+      it('should process key sequences that use different modifier keys', () => {
+        let count = 0;
+        registry.addCommand('test', {
+          execute: () => {
+            count++;
+          }
+        });
+        registry.addKeyBinding({
+          keys: ['Shift K', 'Ctrl L'],
+          selector: `#${elem.id}`,
+          command: 'test'
+        });
+        let eventShift = generate('keydown', { keyCode: 16, shiftlKey: true });
+        let eventK = generate('keydown', { keyCode: 75, shiftKey: true });
+        let eventCtrl = generate('keydown', { keyCode: 17, ctrlKey: true });
+        let eventL = generate('keydown', { keyCode: 76, ctrlKey: true });
+        elem.dispatchEvent(eventShift);
+        expect(count).to.equal(0);
+        elem.dispatchEvent(eventK);
+        expect(count).to.equal(0);
+        elem.dispatchEvent(eventCtrl);
+        expect(count).to.equal(0);
+        elem.dispatchEvent(eventL);
+        expect(count).to.equal(1);
+      });
     });
 
     describe('.parseKeystroke()', () => {
@@ -1080,6 +1129,14 @@ describe('@lumino/commands', () => {
 
       it('should fail on an invalid shortcut', () => {
         let event = generate('keydown', { keyCode: -1 });
+        let keystroke = CommandRegistry.keystrokeForKeydownEvent(
+          event as KeyboardEvent
+        );
+        expect(keystroke).to.equal('');
+      });
+
+      it('should return nothing for keys that are marked as ignored in keyboard layout', () => {
+        let event = generate('keydown', { keyCode: 17, ctrlKey: true });
         let keystroke = CommandRegistry.keystrokeForKeydownEvent(
           event as KeyboardEvent
         );

--- a/packages/keyboard/tests/src/index.spec.ts
+++ b/packages/keyboard/tests/src/index.spec.ts
@@ -65,6 +65,24 @@ describe('@lumino/keyboard', () => {
         expect(layout.isValidKey('F')).to.equal(true);
         expect(layout.isValidKey('A')).to.equal(false);
       });
+
+      it('should treat ignored keys as valid', () => {
+        let layout = new KeycodeLayout('foo', { 100: 'F', 101: 'A' }, ['A']);
+        expect(layout.isValidKey('A')).to.equal(true);
+      });
+    });
+
+    describe('#isIgnoredKey()', () => {
+      it('should test whether the key is ignored for the layout', () => {
+        let layout = new KeycodeLayout('foo', { 100: 'F', 101: 'A' }, ['A']);
+        expect(layout.isIgnoredKey('F')).to.equal(false);
+        expect(layout.isIgnoredKey('A')).to.equal(true);
+      });
+
+      it('should return false for keys that are not in the layout', () => {
+        let layout = new KeycodeLayout('foo', { 100: 'F', 101: 'A' }, ['A']);
+        expect(layout.isIgnoredKey('B')).to.equal(false);
+      });
     });
 
     describe('#keyForKeydownEvent()', () => {
@@ -90,6 +108,14 @@ describe('@lumino/keyboard', () => {
         expect(KeycodeLayout.extractKeys(keys)).to.deep.equal(goal);
       });
     });
+
+    describe('.convertToKeySet()', () => {
+      it('should convert key array to key set', () => {
+        let keys: string[] = ['F', 'G', 'H'];
+        let goal: KeycodeLayout.KeySet = { F: true, G: true, H: true };
+        expect(KeycodeLayout.convertToKeySet(keys)).to.deep.equal(goal);
+      });
+    });
   });
 
   describe('EN_US', () => {
@@ -102,6 +128,20 @@ describe('@lumino/keyboard', () => {
       expect(EN_US.isValidKey('Z')).to.equal(true);
       expect(EN_US.isValidKey('0')).to.equal(true);
       expect(EN_US.isValidKey('a')).to.equal(false);
+    });
+
+    it('should have modifier keys', () => {
+      expect(EN_US.isValidKey('Shift')).to.equal(true);
+      expect(EN_US.isValidKey('Ctrl')).to.equal(true);
+      expect(EN_US.isValidKey('Alt')).to.equal(true);
+      expect(EN_US.isValidKey('Meta')).to.equal(true);
+    });
+
+    it('should mark modifier keys as ignored', () => {
+      expect(EN_US.isIgnoredKey('Shift')).to.equal(true);
+      expect(EN_US.isIgnoredKey('Ctrl')).to.equal(true);
+      expect(EN_US.isIgnoredKey('Alt')).to.equal(true);
+      expect(EN_US.isIgnoredKey('Meta')).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
This change addresses JupyterLab issue: https://github.com/jupyterlab/jupyterlab/issues/7702 .

It follows the strategy proposed by @jasongrout in the issue comments:
- adds `isIgnoredKey` method to keyboard layout interface
- adds modifier keys to en-us layout, but marks them as ignored
- skips processing of 'keydown' event for ignored keys.

I can see several reasons for why the change might be concerning:
- default keyboard layout now has new valid keys, which may break some downstream dependency
- we rely on `keyCode` to detect modifier keys, which is probably not the best way in the long run
- skipping processing of ignored keys actually changes the order in which keydown events are processed. E.g. if user presses "Shift", "Shift C", "Ctrl", "Ctrl P", and there's no "Shift C Ctrl P" shortcut, the events will be processed in the order "Shift", "Ctrl" (ignored events that we let propagate), "Shift C", "Ctrl P" (replayed events). _Probably_ ok for modifier keys, but may cause weird behavior if we start ignoring non-modifier keys in the future.

Let me know if you think there's a better way.

## How it was tested
- Added new specs for `commands` and `keyboard` packages
- Locally modified `dockpanel` example to have shortcuts like "Shift C Ctrl P", verified that the shortcuts worked as expected. 