### PR TITLE
Add arrow glyphs #151

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1063,6 +1063,26 @@ export namespace CommandRegistry {
     shift: boolean;
 
     /**
+     * Whether `'ArrowLeft'` appears in the keystroke.
+     */
+    arrowLeft: boolean;
+
+    /**
+     * Whether `'ArrowUp'` appears in the keystroke.
+     */
+    arrowUp: boolean;
+
+    /**
+     * Whether `'ArrowRight'` appears in the keystroke.
+     */
+    arrowRight: boolean;
+
+    /**
+     * Whether `'ArrowDown'` appears in the keystroke.
+     */
+    arrowDown: boolean;
+
+    /**
      * The primary key for the keystroke.
      */
     key: string;
@@ -1096,6 +1116,10 @@ export namespace CommandRegistry {
     let cmd = false;
     let ctrl = false;
     let shift = false;
+    let arrowLeft = false;
+    let arrowUp = false;
+    let arrowRight = false;
+    let arrowDown = false;
     for (let token of keystroke.split(/\s+/)) {
       if (token === 'Accel') {
         if (Platform.IS_MAC) {
@@ -1111,11 +1135,29 @@ export namespace CommandRegistry {
         ctrl = true;
       } else if (token === 'Shift') {
         shift = true;
+      } else if (token === 'ArrowLeft') {
+        arrowLeft = true;
+      } else if (token === 'ArrowUp') {
+        arrowUp = true;
+      } else if (token === 'ArrowRight') {
+        arrowRight = true;
+      } else if (token === 'ArrowDown') {
+        arrowDown = true;
       } else if (token.length > 0) {
         key = token;
       }
     }
-    return { cmd, ctrl, alt, shift, key };
+    return {
+      cmd,
+      ctrl,
+      alt,
+      shift,
+      key,
+      arrowLeft,
+      arrowUp,
+      arrowRight,
+      arrowDown
+    };
   }
 
   /**
@@ -1186,6 +1228,18 @@ export namespace CommandRegistry {
       }
       if (parts.cmd) {
         mods += '\u2318 ';
+      }
+      if (parts.arrowLeft) {
+        mods += '\u2190 ';
+      }
+      if (parts.arrowUp) {
+        mods += '\u2191 ';
+      }
+      if (parts.arrowRight) {
+        mods += '\u2192 ';
+      }
+      if (parts.arrowDown) {
+        mods += '\u2193 ';
       }
     } else {
       if (parts.ctrl) {


### PR DESCRIPTION
Hi! This is my first time opening a pull request for Lumino. I'm currently writing a Jupyterlab Extension for the company I work at and I'm loving the Jupyterlab ecosystem.

I think the majority of my changes are self explanatory. Here are a few thoughts:
- The arrow order, left up right down, follows the order of unicode symbols.
- I transformed line 1118 into multiple lines because it was growing long.
- I considered changing the 'else if' chain into a switch statement but I did not follow through.