### PR TITLE
Automated Changelog Entry for 2021.10.25 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@
 
 ### Enhancements made
 
-- Add arrow glyphs #151 [#252](https://github.com/jupyterlab/lumino/pull/252) ([@PlatinumCD](https://github.com/PlatinumCD))
-- Added PointerEvents to splitpanel [#251](https://github.com/jupyterlab/lumino/pull/251) ([@martaszmit](https://github.com/martaszmit))
+- Add arrow glyph handling to command registry [#252](https://github.com/jupyterlab/lumino/pull/252) ([@PlatinumCD](https://github.com/PlatinumCD))
+- Added `PointerEvents` handling to `SplitPanel` [#251](https://github.com/jupyterlab/lumino/pull/251) ([@martaszmit](https://github.com/martaszmit))
 - Ignore `keydown` events for modifier keys when accumulating key sequence [#245](https://github.com/jupyterlab/lumino/pull/245) ([@ph-ph](https://github.com/ph-ph))
 
 ### Bugs fixed
 
-- Update title in AccordionPanel [#249](https://github.com/jupyterlab/lumino/pull/249) ([@hbcarlos](https://github.com/hbcarlos))
+- Update title appropriately in `AccordionPanel` [#249](https://github.com/jupyterlab/lumino/pull/249) ([@hbcarlos](https://github.com/hbcarlos))
 
 ### Maintenance and upkeep improvements
 


### PR DESCRIPTION
Automated Changelog Entry for 2021.10.25 on master
```
npm workspace versions:
@lumino/example-datastore: 0.18.0
@lumino/example-accordionpanel: 0.5.0
@lumino/example-dockpanel-amd: 0.4.0
@lumino/example-dockpanel: 0.18.0
@lumino/example-dockpanel-iife: 0.4.0
@lumino/example-datagrid: 0.29.0
@lumino/default-theme: 0.20.0
@lumino/virtualdom: 1.14.0
@lumino/coreutils: 1.11.0
@lumino/domutils: 1.8.0
@lumino/widgets: 1.29.0
@lumino/commands: 1.18.0
@lumino/polling: 1.9.0
@lumino/datagrid: 0.33.0
@lumino/collections: 1.9.0
@lumino/algorithm: 1.9.0
@lumino/application: 1.26.0
@lumino/messaging: 1.10.0
@lumino/dragdrop: 1.13.0
@lumino/signaling: 1.10.0
@lumino/disposable: 1.10.0
@lumino/properties: 1.8.0
@lumino/datastore: 0.17.0
@lumino/keyboard: 1.8.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | master  |
| Version Spec | 2021.10.25 |
| Since | @lumino/algorithm@1.8.0 |