### PR TITLE
Make keyboard layouts in charge of modifier keys and formatting of keys

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1063,26 +1063,6 @@ export namespace CommandRegistry {
     shift: boolean;
 
     /**
-     * Whether `'ArrowLeft'` appears in the keystroke.
-     */
-    arrowLeft: boolean;
-
-    /**
-     * Whether `'ArrowUp'` appears in the keystroke.
-     */
-    arrowUp: boolean;
-
-    /**
-     * Whether `'ArrowRight'` appears in the keystroke.
-     */
-    arrowRight: boolean;
-
-    /**
-     * Whether `'ArrowDown'` appears in the keystroke.
-     */
-    arrowDown: boolean;
-
-    /**
      * The primary key for the keystroke.
      */
     key: string;
@@ -1116,10 +1096,6 @@ export namespace CommandRegistry {
     let cmd = false;
     let ctrl = false;
     let shift = false;
-    let arrowLeft = false;
-    let arrowUp = false;
-    let arrowRight = false;
-    let arrowDown = false;
     for (let token of keystroke.split(/\s+/)) {
       if (token === 'Accel') {
         if (Platform.IS_MAC) {
@@ -1135,29 +1111,11 @@ export namespace CommandRegistry {
         ctrl = true;
       } else if (token === 'Shift') {
         shift = true;
-      } else if (token === 'ArrowLeft') {
-        arrowLeft = true;
-      } else if (token === 'ArrowUp') {
-        arrowUp = true;
-      } else if (token === 'ArrowRight') {
-        arrowRight = true;
-      } else if (token === 'ArrowDown') {
-        arrowDown = true;
       } else if (token.length > 0) {
         key = token;
       }
     }
-    return {
-      cmd,
-      ctrl,
-      alt,
-      shift,
-      key,
-      arrowLeft,
-      arrowUp,
-      arrowRight,
-      arrowDown
-    };
+    return { cmd, ctrl, alt, shift, key };
   }
 
   /**
@@ -1228,18 +1186,6 @@ export namespace CommandRegistry {
       }
       if (parts.cmd) {
         mods += '\u2318 ';
-      }
-      if (parts.arrowLeft) {
-        mods += '\u2190 ';
-      }
-      if (parts.arrowUp) {
-        mods += '\u2191 ';
-      }
-      if (parts.arrowRight) {
-        mods += '\u2192 ';
-      }
-      if (parts.arrowDown) {
-        mods += '\u2193 ';
       }
     } else {
       if (parts.ctrl) {

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1172,33 +1172,25 @@ export namespace CommandRegistry {
    * Format a keystroke for display on the local system.
    */
   export function formatKeystroke(keystroke: string): string {
-    let mods = '';
     let parts = parseKeystroke(keystroke);
-    if (Platform.IS_MAC) {
-      if (parts.ctrl) {
-        mods += '\u2303 ';
-      }
-      if (parts.alt) {
-        mods += '\u2325 ';
-      }
-      if (parts.shift) {
-        mods += '\u21E7 ';
-      }
-      if (parts.cmd) {
-        mods += '\u2318 ';
-      }
-    } else {
-      if (parts.ctrl) {
-        mods += 'Ctrl+';
-      }
-      if (parts.alt) {
-        mods += 'Alt+';
-      }
-      if (parts.shift) {
-        mods += 'Shift+';
-      }
+    let layout = getKeyboardLayout();
+    let label = [];
+    let separator = Platform.IS_MAC ? '+' : ' ';
+    if (parts.ctrl) {
+      label.push('Ctrl');
     }
-    return mods + parts.key;
+    if (parts.alt) {
+      label.push('Alt');
+    }
+    if (parts.shift) {
+      label.push('Shift');
+    }
+    if (Platform.IS_MAC && parts.cmd) {
+      // Keyboard layouts label Command as Meta
+      label.push('Meta');
+    }
+    label.push(parts.key);
+    return label.map(layout.formatKey).join(separator);
   }
 
   /**
@@ -1228,20 +1220,19 @@ export namespace CommandRegistry {
     if (!key || layout.isModifierKey(key)) {
       return '';
     }
-    let mods = '';
-    if (event.ctrlKey) {
-      mods += 'Ctrl ';
+    // Loop through modifier keys in order to test them
+    let mods = [];
+    for (let mod in layout.modifierKeys()) {
+      // Special treatment for Meta (Cmd on macOS) for backwards compatibility
+      if (mod === 'Meta') {
+        if (Platform.IS_MAC && event.getModifierState(mod)) {
+          mods.push('Cmd');
+        }
+      } else if (event.getModifierState(mod)) {
+        mods.push(mod);
+      }
     }
-    if (event.altKey) {
-      mods += 'Alt ';
-    }
-    if (event.shiftKey) {
-      mods += 'Shift ';
-    }
-    if (event.metaKey && Platform.IS_MAC) {
-      mods += 'Cmd ';
-    }
-    return mods + key;
+    return mods.join(" ") + " " + key;
   }
 }
 

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1177,7 +1177,8 @@ export namespace CommandRegistry {
     let label = [];
     let separator = Platform.IS_MAC ? '+' : ' ';
     if (parts.ctrl) {
-      label.push('Ctrl');
+      // Keyboard layouts label Ctrl as Control
+      label.push('Control');
     }
     if (parts.alt) {
       label.push('Alt');
@@ -1229,7 +1230,12 @@ export namespace CommandRegistry {
           mods.push('Cmd');
         }
       } else if (event.getModifierState(mod)) {
-        mods.push(mod);
+        if (mod === 'Control') {
+          // For backwards compatibility, we use Ctrl for the Control modifier
+          mods.push('Ctrl');
+        } else {
+          mods.push(mod);
+        }
       }
     }
     return mods.join(" ") + " " + key;

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1228,6 +1228,11 @@ export namespace CommandRegistry {
         if (Platform.IS_MAC && event.getModifierState(mod)) {
           mods.push('Cmd');
         }
+      } else if (mod === 'Ctrl') {
+        // For backwards compatibility, our keyboard layout still uses Ctrl.
+        if (event.getModifierState('Control')) {
+          mods.push('Ctrl');
+        }
       } else if (event.getModifierState(mod)) {
         mods.push(mod);
       }

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1177,8 +1177,7 @@ export namespace CommandRegistry {
     let label = [];
     let separator = Platform.IS_MAC ? '+' : ' ';
     if (parts.ctrl) {
-      // Keyboard layouts label Ctrl as Control
-      label.push('Control');
+      label.push('Ctrl');
     }
     if (parts.alt) {
       label.push('Alt');
@@ -1230,12 +1229,7 @@ export namespace CommandRegistry {
           mods.push('Cmd');
         }
       } else if (event.getModifierState(mod)) {
-        if (mod === 'Control') {
-          // For backwards compatibility, we use Ctrl for the Control modifier
-          mods.push('Ctrl');
-        } else {
-          mods.push(mod);
-        }
+        mods.push(mod);
       }
     }
     return mods.join(" ") + " " + key;

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1572,6 +1572,7 @@ namespace Private {
     clone.shiftKey = event.shiftKey || false;
     clone.metaKey = event.metaKey || false;
     clone.view = event.view || window;
+    clone.getModifierState = (key: string) => event.getModifierState(key);
     return clone as KeyboardEvent;
   }
 }

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -43,6 +43,9 @@
     "test:ie": "cd tests && karma start --browsers=IE",
     "watch": "tsc --build --watch"
   },
+  "dependencies": {
+    "@lumino/domutils": "^1.8.0"
+  },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.6.0",
     "@types/chai": "^3.4.35",

--- a/packages/keyboard/src/index.ts
+++ b/packages/keyboard/src/index.ts
@@ -8,6 +8,8 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
+import { Platform } from '@lumino/domutils';
+
 /**
  * An object which represents an abstract keyboard layout.
  */
@@ -64,6 +66,15 @@ export interface IKeyboardLayout {
    *   does not represent a valid primary key.
    */
   keyForKeydownEvent(event: KeyboardEvent): string;
+
+  /**
+   * Get the formatted string for displaying a key in the user interface.
+   *
+   * @param key - The user provided key.
+   *
+   * @returns A unicode string representing the key in the interface.
+   */
+  formatKey(key: string): string;
 }
 
 /**
@@ -115,12 +126,14 @@ export class KeycodeLayout implements IKeyboardLayout {
   constructor(
     name: string,
     codes: KeycodeLayout.CodeMap,
-    modifierKeys: string[] = []
+    modifierKeys: string[] = [],
+    format: KeycodeLayout.KeyFormat = x => x
   ) {
     this.name = name;
     this._codes = codes;
     this._keys = KeycodeLayout.extractKeys(codes);
     this._modifierKeys = KeycodeLayout.convertToKeySet(modifierKeys);
+    this._format = format;
   }
 
   /**
@@ -171,9 +184,21 @@ export class KeycodeLayout implements IKeyboardLayout {
     return this._codes[event.keyCode] || '';
   }
 
+  /**
+   * Get the formatted string for displaying a key in the user interface.
+   *
+   * @param key - The user provided key.
+   *
+   * @returns A unicode string representing the key in the interface.
+   */
+  formatKey(key: string): string {
+    return this._format(key);
+  }
+
   private _keys: KeycodeLayout.KeySet;
   private _codes: KeycodeLayout.CodeMap;
   private _modifierKeys: KeycodeLayout.KeySet;
+  private _format: KeycodeLayout.KeyFormat;
 }
 
 /**
@@ -189,6 +214,11 @@ export namespace KeycodeLayout {
    * A type alias for a key set.
    */
   export type KeySet = { readonly [key: string]: boolean };
+
+  /**
+   * A type alias for a key format function.
+   */
+  export type KeyFormat = (key: string) => string;
 
   /**
    * Extract the set of keys from a code map.
@@ -218,6 +248,57 @@ export namespace KeycodeLayout {
       keySet[keys[i]] = true;
     }
     return keySet;
+  }
+}
+
+export const MAC_DISPLAY: { [key: string]: string } = {
+  Backspace: '⌫',
+  Tab: '⇥',
+  Enter: '↩',
+  Shift: '⇧',
+  Ctrl: '⌃',
+  Alt: '⌥',
+  Escape: '⎋',
+  PageUp: '⇞',
+  PageDown: '⇟',
+  End: '↘',
+  Home: '↖',
+  ArrowLeft: '←',
+  ArrowUp: '↑',
+  ArrowRight: '→',
+  ArrowDown: '↓',
+  Delete: '⌦',
+  Meta: '⌘'
+};
+
+export const WIN_DISPLAY: { [key: string]: string } = {
+  // 'Backspace': '⌫',
+  // 'Tab': '⇥',
+  // 'Enter': 'Return',
+  // 'Shift': '⇧',
+  // 'Ctrl': 'Ctrl',
+  // 'Alt': '⌥',
+  // 'Pause': '',
+  Escape: 'Esc',
+  // 'Space': '␣',
+  PageUp: 'Page Up',
+  PageDown: 'Page Down',
+  // 'End': '↘',
+  // 'Home': '↖',
+  ArrowLeft: 'Left',
+  ArrowUp: 'Right',
+  ArrowRight: 'Up',
+  ArrowDown: 'Down',
+  // 'Insert': '',
+  Delete: 'Del'
+  // 'Meta': ''
+};
+
+export function formatKey(key: string): string {
+  if (Platform.IS_MAC) {
+    return MAC_DISPLAY.hasOwnProperty(key) ? MAC_DISPLAY[key] : key;
+  } else {
+    return WIN_DISPLAY.hasOwnProperty(key) ? WIN_DISPLAY[key] : key;
   }
 }
 
@@ -345,7 +426,8 @@ export const EN_US: IKeyboardLayout = new KeycodeLayout(
     222: "'",
     224: 'Meta' // firefox
   },
-  ['Shift', 'Ctrl', 'Alt', 'Meta'] // modifier keys
+  ['Shift', 'Ctrl', 'Alt', 'Meta'], // modifier keys,
+  formatKey
 );
 
 /**

--- a/packages/keyboard/src/index.ts
+++ b/packages/keyboard/src/index.ts
@@ -349,7 +349,7 @@ export const EN_US: IKeyboardLayout = new KeycodeLayout(
     9: 'Tab',
     13: 'Enter',
     16: 'Shift',
-    17: 'Control',
+    17: 'Ctrl',
     18: 'Alt',
     19: 'Pause',
     27: 'Escape',
@@ -446,7 +446,7 @@ export const EN_US: IKeyboardLayout = new KeycodeLayout(
     224: 'Meta' // firefox
   },
   // The modifier is labeled "Control", but the key value is "Ctrl"?
-  ['Control', 'Alt', 'Shift', 'Meta'], // modifier keys in display order
+  ['Ctrl', 'Alt', 'Shift', 'Meta'], // modifier keys in display order
   formatKey
 );
 

--- a/packages/keyboard/src/index.ts
+++ b/packages/keyboard/src/index.ts
@@ -349,7 +349,7 @@ export const EN_US: IKeyboardLayout = new KeycodeLayout(
     9: 'Tab',
     13: 'Enter',
     16: 'Shift',
-    17: 'Ctrl',
+    17: 'Control',
     18: 'Alt',
     19: 'Pause',
     27: 'Escape',
@@ -446,7 +446,7 @@ export const EN_US: IKeyboardLayout = new KeycodeLayout(
     224: 'Meta' // firefox
   },
   // The modifier is labeled "Control", but the key value is "Ctrl"?
-  ['Ctrl', 'Alt', 'Shift', 'Meta'], // modifier keys in display order
+  ['Control', 'Alt', 'Shift', 'Meta'], // modifier keys in display order
   formatKey
 );
 

--- a/packages/keyboard/tsconfig.json
+++ b/packages/keyboard/tsconfig.json
@@ -13,7 +13,7 @@
     "moduleResolution": "node",
     "target": "ES5",
     "outDir": "lib",
-    "lib": ["ES5", "DOM", "ES2015.Iterable"],
+    "lib": ["ES5", "DOM", "ES2015.Collection", "ES2015.Iterable"],
     "importHelpers": true,
     "types": [],
     "rootDir": "src"


### PR DESCRIPTION
Currently, the commands package is in charge of formatting a keyboard shortcut for display and hard-coding the modifiers for a keyboard shortcut. However, this means that the modifiers and how keyboard keys are displayed are both hard-coded in the command package rather than being specified in the keyboard layout, which is closer to the keyboard capabilities.

I think ideally, the keyboard layout should be responsible for encoding the capabilities of the keyboard, including what the modifier keys are and how keys are displayed. This PR explores how this might work.

A couple of notes and unfinished business:

1. The  parsed modifiers in a user-specified keyboard shortcut are still hard-coded in the commands package to be from the set Ctrl, Alt, Shift, and Cmd. To go further, we should make that modifier checking more generic, relying on the modifiers the keyboard layout says it has.
2. There was a choice about whether the keyboard layout should use "Control" or "Ctrl" for the control modifier. In the end, I opted to keep things backwards compatible with Ctrl, though this PR also contains a reverted commit changing the layout to use Control and adjusting the user-specified shortcut when needed.

It may be that when we are ready to support keyboard layouts with other modifiers, it is appropriate to switch from using `.keyCode` to `.key`, which may make this PR obsolete.