### PR TITLE
Fix transposed display names for arrow keys

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1462,8 +1462,8 @@ namespace Private {
     PageUp: 'Page Up',
     PageDown: 'Page Down',
     ArrowLeft: 'Left',
-    ArrowUp: 'Right',
-    ArrowRight: 'Up',
+    ArrowUp: 'Up',
+    ArrowRight: 'Right',
     ArrowDown: 'Down',
     Delete: 'Del'
   };


### PR DESCRIPTION
Introduced in #258, CC @jasongrout 