### PR TITLE
Automated Changelog Entry for 2021.12.13 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2021.12.13
 
-([Full Changelog](https://github.com/jupyterlab/lumino/compare/v2021.11.4...v2
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/v2021.11.4...44b44a408e0849857cc7a7e639b5b0be00ae61ec)
 
 - Enforce labels on PRs by @blink1073 in https://github.com/jupyterlab/lumino/pull/267
 - Fix transposed display names for arrow keys by @thomasjm in https://github.com/jupyterlab/lumino/pull/268

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2021.12.13
+
+No merged PRs
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2021.11.4
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/algorithm@1.9.0...6720e2482ac4cd7d7ee7918ecb33cb6a16642d99))
@@ -23,8 +29,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2021-10-25&to=2021-11-04&type=c))
 
 [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2021-10-25..2021-11-04&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ajasongrout+updated%3A2021-10-25..2021-11-04&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2021.10.25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ## 2021.12.13
 
-No merged PRs
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/v2021.11.4...v2
+
+- Enforce labels on PRs by @blink1073 in https://github.com/jupyterlab/lumino/pull/267
+- Fix transposed display names for arrow keys by @thomasjm in https://github.com/jupyterlab/lumino/pull/268
 
 <!-- <END NEW CHANGELOG ENTRY> -->
 


### PR DESCRIPTION
Automated Changelog Entry for 2021.12.13 on main
```
npm workspace versions:
@lumino/example-accordionpanel: 0.6.1
@lumino/example-datagrid: 0.30.1
@lumino/example-datastore: 0.19.1
@lumino/example-dockpanel: 0.19.1
@lumino/example-dockpanel-amd: 0.4.0
@lumino/example-dockpanel-iife: 0.4.0
@lumino/algorithm: 1.9.1
@lumino/application: 1.27.1
@lumino/collections: 1.9.1
@lumino/commands: 1.19.1
@lumino/coreutils: 1.11.1
@lumino/datagrid: 0.34.1
@lumino/datastore: 0.17.1
@lumino/default-theme: 0.20.2
@lumino/disposable: 1.10.1
@lumino/domutils: 1.8.1
@lumino/dragdrop: 1.13.1
@lumino/keyboard: 1.8.1
@lumino/messaging: 1.10.1
@lumino/polling: 1.9.1
@lumino/properties: 1.8.1
@lumino/signaling: 1.10.1
@lumino/virtualdom: 1.14.1
@lumino/widgets: 1.30.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | main  |
| Version Spec | 2021.12.13 |
| Since | @lumino/algorithm@1.9.1 |