### PR TITLE
Investigate using `Node.contains` to avoid layout reflow

### DIFF
--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -1349,7 +1349,10 @@ namespace Private {
 
       // Handle the simplest case of in-place text update first.
       if (oldVNode.type === 'text' && newVNode.type === 'text') {
-        currElem!.textContent = newVNode.content;
+        // Only update the textContent if it changed
+        if (currElem!.textContent !== newVNode.content) {
+          currElem!.textContent = newVNode.content;
+        }
         currElem = currElem!.nextSibling;
         continue;
       }

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -703,9 +703,15 @@ export class Menu extends Widget {
    * This listener is attached to the menu node.
    */
   private _evtMouseMove(event: MouseEvent): void {
+    const target = event.target;
+    // Bail early if mouse not above any element.
+    if (!(target instanceof Element)) {
+      return;
+    }
+
     // Hit test the item nodes for the item under the mouse.
     let index = ArrayExt.findFirstIndex(this.contentNode.children, node => {
-      return ElementExt.hitTest(node, event.clientX, event.clientY);
+      return node.contains(target);
     });
 
     // Bail early if the mouse is already over the active index.
@@ -774,8 +780,10 @@ export class Menu extends Widget {
     }
 
     // If the mouse is over the child menu, cancel the close timer.
-    let { clientX, clientY } = event;
-    if (ElementExt.hitTest(this._childMenu.node, clientX, clientY)) {
+    if (
+      event.target instanceof Element &&
+      this._childMenu.node.contains(event.target)
+    ) {
       this._cancelCloseTimer();
       return;
     }
@@ -801,7 +809,7 @@ export class Menu extends Widget {
     // is not on a menu, the entire hierarchy is closed and the event
     // is allowed to propagate. This allows other code to act on the
     // event, such as focusing the clicked element.
-    if (Private.hitTestMenus(this, event.clientX, event.clientY)) {
+    if (Private.hitTestMenus(this, event)) {
       event.preventDefault();
       event.stopPropagation();
     } else {
@@ -1475,9 +1483,14 @@ namespace Private {
   /**
    * Hit test a menu hierarchy starting at the given root.
    */
-  export function hitTestMenus(menu: Menu, x: number, y: number): boolean {
+  export function hitTestMenus(menu: Menu, event: MouseEvent): boolean {
+    const target = event.target;
+    // Bail early if mouse not above any element.
+    if (!(target instanceof Element)) {
+      return false;
+    }
     for (let temp: Menu | null = menu; temp; temp = temp.childMenu) {
-      if (ElementExt.hitTest(temp.node, x, y)) {
+      if (temp.node.contains(target)) {
         return true;
       }
     }

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -9,8 +9,6 @@
 |----------------------------------------------------------------------------*/
 import { ArrayExt } from '@lumino/algorithm';
 
-import { ElementExt } from '@lumino/domutils';
-
 import { getKeyboardLayout } from '@lumino/keyboard';
 
 import { Message, MessageLoop } from '@lumino/messaging';
@@ -487,9 +485,15 @@ export class MenuBar extends Widget {
    * Handle the `'mousedown'` event for the menu bar.
    */
   private _evtMouseDown(event: MouseEvent): void {
+    const target = event.target;
+    // Bail early if mouse press was not above any element.
+    if (!(target instanceof Element)) {
+      return;
+    }
+
     // Bail if the mouse press was not on the menu bar. This can occur
     // when the document listener is installed for an active menu bar.
-    if (!ElementExt.hitTest(this.node, event.clientX, event.clientY)) {
+    if (!this.node.contains(target)) {
       return;
     }
 
@@ -501,7 +505,7 @@ export class MenuBar extends Widget {
 
     // Check if the mouse is over one of the menu items.
     let index = ArrayExt.findFirstIndex(this.contentNode.children, node => {
-      return ElementExt.hitTest(node, event.clientX, event.clientY);
+      return node.contains(target);
     });
 
     // If the press was not on an item, close the child menu.
@@ -529,9 +533,15 @@ export class MenuBar extends Widget {
    * Handle the `'mousemove'` event for the menu bar.
    */
   private _evtMouseMove(event: MouseEvent): void {
+    const target = event.target;
+    // Bail early if mouse not above any element.
+    if (!(target instanceof Element)) {
+      return;
+    }
+
     // Check if the mouse is over one of the menu items.
     let index = ArrayExt.findFirstIndex(this.contentNode.children, node => {
-      return ElementExt.hitTest(node, event.clientX, event.clientY);
+      return node.contains(target);
     });
 
     // Bail early if the active index will not change.


### PR DESCRIPTION
This is an attempt to see if `Node.contains` solves https://github.com/jupyterlab/jupyterlab/issues/9757 as suggested in https://github.com/jupyterlab/jupyterlab/issues/9757#issuecomment-997357312:

Results are inconclusive.

While it avoids reflows due to moving mouse over menu items, If my understanding is correct, those are only problematic if you move mouse over items while the DOM is evolving (e.g. math is slowly rendering, after scrolling, etc) - otherwise reflow only happens once and consecutive transitions between menu items are smooth. Based on my local profiling it looks like we get mere 2% speed up for the tested notebook (below).

Remaining issues:
- opening submenus (and menus in general) also causes calls `getBoundingClientRect` (calculating position of the menu); I don't see an easy way around this yet, but this is relatively harmless - each takes about 50ms:
    ![Screenshot from 2021-12-19 21-58-26](https://user-images.githubusercontent.com/5832902/146692239-d50c6ee1-5aa9-4d7e-91d0-eb298e75dba0.png)
- moving mouse over the menu bar sets the `focus()` which also triggers reflow and this one is very noticeable:
    ![Screenshot from 2021-12-19 21-57-23](https://user-images.githubusercontent.com/5832902/146692262-759fc5ef-5b00-4a79-ac7f-a1a90d60a2fc.png)
- even if we remove `focus()` call the following `update()` call triggers reflow with identical effect (there is some 

I recall that when I profiled a very different environment of mine I saw lumino's `ElementExt.hitTest` as a substantial contributor to the issue, but it does not seem obvious anymore to me (but I have not tested in that environment, so maybe it is only a bottleneck for certain setups?).

### Testing procedure

Test notebook: https://github.com/UCB-stat-159-s21/site/blob/main/Notes/tests.ipynb

I opened the test notebook from https://github.com/jupyterlab/jupyterlab/issues/9757.

```
wget https://raw.githubusercontent.com/UCB-stat-159-s21/site/main/Notes/tests.ipynb
```

I scrolled to the end and waited until math is rendered fully. I then checked how many elements are in the DOM:

```js
document.querySelectorAll('*').length
35909
```

(should be the same order of magnitude, might vary slightly depending on open sidebars/menu/files items, etc)

Some more notes:
- [x] `currElem!.textContent = newVNode.content;` needs to have a check because virtual dom updates the actual DOM even if text has not changed and it is recorded by Chromium; it is not clear if it has a significant performance impact but we can likely cut some milliseconds here
- It looks like its the `requestAnimationFrame` in messaging's `schedule()` which causes the "Recalculate Styles" task; there is a bug report for Chromium which might be related [RequestAnimationFrame will trigger recalculate style even nothing changes](https://bugs.chromium.org/p/chromium/issues/detail?id=1252311#c6):
   ![Screenshot from 2021-12-20 19-07-57](https://user-images.githubusercontent.com/5832902/146819600-c8ff66e6-7a1e-4328-b6e4-bea4f3a5ae4f.png)
- in said animation frame the classes of icons are updated which takes more time than it should considering that there are absolutely no icons in the menu I am testing (only empty placeholder icons nodes for each item):
    ![Screenshot from 2021-12-20 19-09-19](https://user-images.githubusercontent.com/5832902/146819811-44f1f845-775a-4142-807e-eba343cffdf9.png)


Edit: also note `elementFromPoint` could be used with `contains`.