### PR TITLE
Prevent opening an empty menu

### DIFF
--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -280,10 +280,15 @@ function main(): void {
   menu3.title.label = 'View';
   menu3.title.mnemonic = 0;
 
+  let emptyMenu = new Menu({ commands });
+  emptyMenu.title.label = 'Empty Menu';
+  emptyMenu.title.mnemonic = 0;
+
   let bar = new MenuBar();
   bar.addMenu(menu1);
   bar.addMenu(menu2);
   bar.addMenu(menu3);
+  bar.addMenu(emptyMenu);
   bar.id = 'menuBar';
 
   let palette = new CommandPalette({ commands });

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -607,7 +607,9 @@ export class MenuBar extends Widget {
     let { left, bottom } = (itemNode as HTMLElement).getBoundingClientRect();
 
     // Open the new menu at the computed location.
-    newMenu.open(left, bottom, this._forceItemsPosition);
+    if (newMenu.items.length > 0) {
+      newMenu.open(left, bottom, this._forceItemsPosition);
+    }
   }
 
   /**

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -405,6 +405,9 @@ export class MenuBar extends Widget {
     for (let i = 0, n = menus.length; i < n; ++i) {
       let title = menus[i].title;
       let active = i === activeIndex;
+      if (active && menus[i].items.length == 0) {
+        active = false;
+      }
       content[i] = renderer.renderItem({
         title,
         active,

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -288,6 +288,16 @@ describe('@lumino/widgets', () => {
         expect(menu.isAttached).to.equal(false);
         bar.dispose();
       });
+
+      it('should be a no-op if the active menu is empty', () => {
+        let bar = new MenuBar();
+        let menu = new Menu({ commands });
+        bar.addMenu(menu);
+        bar.activeMenu = menu;
+        bar.openActiveMenu();
+        expect(menu.isAttached).to.equal(false);
+        bar.dispose();
+      });
     });
 
     describe('#addMenu()', () => {


### PR DESCRIPTION
Solves https://github.com/jupyterlab/jupyterlab/pull/11650

As commented in https://github.com/jupyterlab/jupyterlab/pull/11650#discussion_r766563571, there is a minor glitch on the menu when it is empty.
This PR prevents the menu bar from adding a menu to the DOM if the menu is empty.