### PR TITLE
Automated Changelog Entry for 2022.1.13 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs fixed
 
-- fix(DockLayout):  Invalid use of "this" in private namespace [#281](https://github.com/jupyterlab/lumino/pull/281) ([@GordonSmith](https://github.com/GordonSmith))
+- fix(DockLayout): Invalid use of "this" in private namespace [#281](https://github.com/jupyterlab/lumino/pull/281) ([@GordonSmith](https://github.com/GordonSmith))
 
 ### Contributors to this release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2022.1.13
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.28.0...f7d36a8bac6c44ee9928ea918d3473e297853658))
+
+### Bugs fixed
+
+- fix(DockLayout):  Invalid use of "this" in private namespace [#281](https://github.com/jupyterlab/lumino/pull/281) ([@GordonSmith](https://github.com/GordonSmith))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-01-10&to=2022-01-13&type=c))
+
+[@GordonSmith](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3AGordonSmith+updated%3A2022-01-10..2022-01-13&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2022.1.10
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.27.1...68ba69cdf8233576f103f24caf8e3a47ca6c69f6))
@@ -26,8 +42,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2021-12-13&to=2022-01-10&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2021-12-13..2022-01-10&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2021-12-13..2022-01-10&type=Issues) | [@GordonSmith](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3AGordonSmith+updated%3A2021-12-13..2022-01-10&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ahbcarlos+updated%3A2021-12-13..2022-01-10&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Akrassowski+updated%3A2021-12-13..2022-01-10&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2021.12.13
 


### PR DESCRIPTION
Automated Changelog Entry for 2022.1.13 on main
```
npm workspace versions:
@lumino/example-accordionpanel: 0.7.1
@lumino/example-datagrid: 0.31.1
@lumino/example-datastore: 0.20.1
@lumino/example-dockpanel: 0.20.1
@lumino/example-dockpanel-amd: 0.4.0
@lumino/example-dockpanel-iife: 0.4.0
@lumino/algorithm: 1.9.1
@lumino/application: 1.28.1
@lumino/collections: 1.9.1
@lumino/commands: 1.20.0
@lumino/coreutils: 1.12.0
@lumino/datagrid: 0.35.1
@lumino/datastore: 0.18.0
@lumino/default-theme: 0.21.1
@lumino/disposable: 1.10.1
@lumino/domutils: 1.8.1
@lumino/dragdrop: 1.14.0
@lumino/keyboard: 1.8.1
@lumino/messaging: 1.10.1
@lumino/polling: 1.10.0
@lumino/properties: 1.8.1
@lumino/signaling: 1.10.1
@lumino/virtualdom: 1.14.1
@lumino/widgets: 1.31.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | main  |
| Version Spec | 2022.1.13 |
| Since | @lumino/application@1.28.0 |