### PR TITLE
feature: Add commandWillExecute signal to CommandRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-- Add `commentWillExecute` signal to `CommandRegistry`.
-
 ## 2022.1.13
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.28.0...f7d36a8bac6c44ee9928ea918d3473e297853658))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+- Add `commentWillExecute` signal to `CommandRegistry`.
+
 ## 2022.1.13
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.28.0...f7d36a8bac6c44ee9928ea918d3473e297853658))

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -54,9 +54,9 @@ export class CommandRegistry {
    */
   get commandWillExecute(): ISignal<
     this,
-    CommandRegistry.ICommandExecutedArgs
+    CommandRegistry.ICommandWillExecuteArgs
   > {
-    return this._commandExecuted;
+    return this._commandWillExecute;
   }
 
   /**

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -80,8 +80,23 @@ describe('@lumino/commands', () => {
       });
     });
 
+    describe('#commandWillExecute', () => {
+      it('should be emitted before a command is executed', () => {
+        let called = false;
+        registry.addCommand('test', NULL_COMMAND);
+        registry.commandWillExecute.connect((reg, args) => {
+          expect(reg).to.equal(registry);
+          expect(args.id).to.equal('test');
+          expect(args.args).to.deep.equal({});
+          called = true;
+        });
+        registry.execute('test');
+        expect(called).to.equal(true);
+      });
+    });
+
     describe('#commandExecuted', () => {
-      it('should be emitted when a command is executed', () => {
+      it('should be emitted after a command is executed', () => {
         let called = false;
         registry.addCommand('test', NULL_COMMAND);
         registry.commandExecuted.connect((reg, args) => {


### PR DESCRIPTION
This signal would be useful to me.

Note: it looks like I need to update `review/api/commands.api.md` but I couldn't figure out how to do it.