### PR TITLE
Add handle moved signal to split panel

### DIFF
--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -351,7 +351,7 @@ export class SplitPanel extends Panel {
     this._pressData = null;
 
     // Emit the handle moved signal.
-    this._handleMoved.emit(undefined);
+    this._handleMoved.emit();
 
     // Remove the extra document listeners.
     document.removeEventListener('mouseup', this, true);

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -119,7 +119,6 @@ export class SplitPanel extends Panel {
     return this._handleMoved;
   }
 
-
   /**
    * A read-only array of the split handles in the panel.
    */
@@ -351,6 +350,9 @@ export class SplitPanel extends Panel {
     this._pressData.override.dispose();
     this._pressData = null;
 
+    // Emit the handle moved signal.
+    this._handleMoved.emit(undefined);
+
     // Remove the extra document listeners.
     document.removeEventListener('mouseup', this, true);
     document.removeEventListener('mousemove', this, true);
@@ -358,9 +360,6 @@ export class SplitPanel extends Panel {
     document.removeEventListener('pointerup', this, true);
     document.removeEventListener('pointermove', this, true);
     document.removeEventListener('contextmenu', this, true);
-
-    // Emit the handle moved signal.
-    this._handleMoved.emit(undefined);
   }
 
   private _handleMoved = new Signal<any, void>(this);

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -15,6 +15,8 @@ import { Drag } from '@lumino/dragdrop';
 
 import { Message } from '@lumino/messaging';
 
+import { ISignal, Signal } from '@lumino/signaling';
+
 import { Panel } from './panel';
 
 import { SplitLayout } from './splitlayout';
@@ -109,6 +111,14 @@ export class SplitPanel extends Panel {
   get renderer(): SplitPanel.IRenderer {
     return (this.layout as SplitLayout).renderer;
   }
+
+  /**
+   * A signal emitted when a split handle has moved.
+   */
+  get handleMoved(): ISignal<this, void> {
+    return this._handleMoved;
+  }
+
 
   /**
    * A read-only array of the split handles in the panel.
@@ -348,8 +358,12 @@ export class SplitPanel extends Panel {
     document.removeEventListener('pointerup', this, true);
     document.removeEventListener('pointermove', this, true);
     document.removeEventListener('contextmenu', this, true);
+
+    // Emit the handle moved signal.
+    this._handleMoved.emit(undefined);
   }
 
+  private _handleMoved = new Signal<any, void>(this);
   private _pressData: Private.IPressData | null = null;
 }
 

--- a/packages/widgets/tests/src/splitpanel.spec.ts
+++ b/packages/widgets/tests/src/splitpanel.spec.ts
@@ -21,6 +21,17 @@ const renderer: SplitPanel.IRenderer = {
   createHandle: () => document.createElement('div')
 };
 
+function dragHandle(panel: LogSplitPanel): void {
+  MessageLoop.sendMessage(panel, Widget.Msg.UpdateRequest);
+  let handle = panel.handles[0];
+  let rect = handle.getBoundingClientRect();
+  let args = { clientX: rect.left + 1, clientY: rect.top + 1 };
+  simulate(handle, 'mousedown', args);
+  args = { clientX: rect.left + 10, clientY: rect.top + 1 };
+  simulate(document.body, 'mousemove', args);
+  simulate(document.body, 'mouseup');
+}
+
 class LogSplitPanel extends SplitPanel {
   events: string[] = [];
 
@@ -127,6 +138,26 @@ describe('@lumino/widgets', () => {
       it('should get the renderer for the panel', () => {
         let panel = new SplitPanel({ renderer });
         expect(panel.renderer).to.equal(renderer);
+      });
+    });
+
+    describe('#handleMoved', () => {
+      it('should be emitted when a handle is moved by the user', done => {
+        let panel = new LogSplitPanel();
+        let widgets = [new Widget(), new Widget()];
+        panel.orientation = 'horizontal';
+        each(widgets, w => {
+          w.node.style.minHeight = '40px';
+          w.node.style.minWidth = '40px';
+          panel.addWidget(w);
+        });
+        panel.setRelativeSizes([40, 80]);
+        Widget.attach(panel, document.body);
+        panel.handleMoved.connect((sender, _) => {
+          expect(sender).to.equal(panel);
+          done();
+        });
+        dragHandle(panel);
       });
     });
 

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -76,7 +76,7 @@ function startDrag(
   // Force an update.
   MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
   simulateOnNode(tab, 'mousedown');
-  let called = true;
+  let called = false;
   bar.tabDetachRequested.connect((sender, args) => {
     called = true;
   });


### PR DESCRIPTION
The `handleMoved` signal is useful for capturing state changes in the layout of a `SplitPanel` and saving it (e.g. for layout restoration). This PR allows for removing the following code in JupyterLab:
```typescript
import { ISignal, Signal } from '@lumino/signaling';
import { SplitPanel as SPanel } from '@lumino/widgets';

/**
 * A deprecated split panel that will be removed when the phosphor split panel
 * supports a handle moved signal. See https://github.com/phosphorjs/phosphor/issues/297.
 */
export class SplitPanel extends SPanel {
  /**
   * Emits when the split handle has moved.
   */
  readonly handleMoved: ISignal<any, void> = new Signal<any, void>(this);

  handleEvent(event: Event): void {
    super.handleEvent(event);

    if (event.type === 'mouseup') {
      (this.handleMoved as Signal<any, void>).emit(undefined);
    }
  }
}
```
https://github.com/jupyterlab/jupyterlab/blob/dbdefed9db9332381fe4104bdf53ec314451951f/packages/settingeditor/src/splitpanel.ts