### PR TITLE
Automated Changelog Entry for 2022.5.11 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2022.5.11
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/v2022.1.13...9c2948ed094b089f1c948300dfdf1f85fff4b83c))
+
+### Enhancements made
+
+- Add handle moved signal to split panel [#301](https://github.com/jupyterlab/lumino/pull/301) ([@afshin](https://github.com/afshin))
+
+### Maintenance and upkeep improvements
+
+- Bump async from 2.6.3 to 2.6.4 [#302](https://github.com/jupyterlab/lumino/pull/302) ([@dependabot](https://github.com/dependabot))
+- Bump minimist from 1.2.5 to 1.2.6 [#296](https://github.com/jupyterlab/lumino/pull/296) ([@dependabot](https://github.com/dependabot))
+- Bump karma from 6.3.14 to 6.3.16 [#295](https://github.com/jupyterlab/lumino/pull/295) ([@dependabot](https://github.com/dependabot))
+- Bump follow-redirects from 1.14.7 to 1.14.8 [#294](https://github.com/jupyterlab/lumino/pull/294) ([@dependabot](https://github.com/dependabot))
+- Bump node-fetch from 2.6.1 to 2.6.7 [#293](https://github.com/jupyterlab/lumino/pull/293) ([@dependabot](https://github.com/dependabot))
+- Bump karma from 6.3.4 to 6.3.14 [#292](https://github.com/jupyterlab/lumino/pull/292) ([@dependabot](https://github.com/dependabot))
+- Bump trim-off-newlines from 1.0.1 to 1.0.3 [#288](https://github.com/jupyterlab/lumino/pull/288) ([@dependabot](https://github.com/dependabot))
+- Bump log4js from 6.3.0 to 6.4.0 [#287](https://github.com/jupyterlab/lumino/pull/287) ([@dependabot](https://github.com/dependabot))
+- Bump shelljs from 0.8.4 to 0.8.5 [#286](https://github.com/jupyterlab/lumino/pull/286) ([@dependabot](https://github.com/dependabot))
+- Bump engine.io from 4.1.1 to 4.1.2 [#284](https://github.com/jupyterlab/lumino/pull/284) ([@dependabot](https://github.com/dependabot))
+- Bump follow-redirects from 1.14.1 to 1.14.7 [#282](https://github.com/jupyterlab/lumino/pull/282) ([@dependabot](https://github.com/dependabot))
+
+### Documentation improvements
+
+- chore:  Add Web Component external example to README.md [#299](https://github.com/jupyterlab/lumino/pull/299) ([@GordonSmith](https://github.com/GordonSmith))
+- Improve DockLayout code documentation [#285](https://github.com/jupyterlab/lumino/pull/285) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-01-13&to=2022-05-12&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-01-13..2022-05-12&type=Issues) | [@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aajbozarth+updated%3A2022-01-13..2022-05-12&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2022-01-13..2022-05-12&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2022-01-13..2022-05-12&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-01-13..2022-05-12&type=Issues) | [@GordonSmith](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3AGordonSmith+updated%3A2022-01-13..2022-05-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2022.1.13
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.28.0...f7d36a8bac6c44ee9928ea918d3473e297853658))
@@ -15,8 +50,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-01-10&to=2022-01-13&type=c))
 
 [@GordonSmith](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3AGordonSmith+updated%3A2022-01-10..2022-01-13&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2022.1.10
 


### PR DESCRIPTION
Automated Changelog Entry for 2022.5.11 on main
```
npm workspace versions:
@lumino/example-accordionpanel: 0.8.0
@lumino/example-datagrid: 0.32.0
@lumino/example-datastore: 0.21.0
@lumino/example-dockpanel: 0.21.0
@lumino/example-dockpanel-amd: 0.4.0
@lumino/example-dockpanel-iife: 0.4.0
@lumino/algorithm: 1.9.1
@lumino/application: 1.29.0
@lumino/collections: 1.9.1
@lumino/commands: 1.20.0
@lumino/coreutils: 1.12.0
@lumino/datagrid: 0.36.0
@lumino/datastore: 0.18.0
@lumino/default-theme: 0.22.0
@lumino/disposable: 1.10.1
@lumino/domutils: 1.8.1
@lumino/dragdrop: 1.14.0
@lumino/keyboard: 1.8.1
@lumino/messaging: 1.10.1
@lumino/polling: 1.10.0
@lumino/properties: 1.8.1
@lumino/signaling: 1.10.1
@lumino/virtualdom: 1.14.1
@lumino/widgets: 1.32.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | main  |
| Version Spec | 2022.5.11 |
| Since | v2022.1.13 |