### PR TITLE
Fix Accordion sizing issue

### DIFF
--- a/packages/widgets/src/accordionpanel.ts
+++ b/packages/widgets/src/accordionpanel.ts
@@ -136,10 +136,16 @@ export class AccordionPanel extends SplitPanel {
   }
 
   /**
+   * Compute the size of widgets in this panel on the title click event.
+   * On closing, the size of the widget is cached and we will try to expand
+   * the last opened widget.
+   * On opening, we will use the cached size if it is available to restore the
+   * widget.
+   * In both cases, if we can not compute the size of widgets, we will let
+   * `SplitLayout` decide.
    *
-   *
-
    * @param index - The index of widget to be opened of closed
+   *
    * @returns Relative size of widgets in this panel, if this size can
    * not be computed, return `undefined`
    */
@@ -168,7 +174,7 @@ export class AccordionPanel extends SplitPanel {
 
       const widgetToCollapse = newSize.map(sz => sz > 0).lastIndexOf(true);
       if (widgetToCollapse === -1) {
-        // All widget are closed, let the `SplitLayout` computes widget sizes.
+        // All widget are closed, let the `SplitLayout` compute widget sizes.
         return undefined;
       }
 
@@ -178,7 +184,7 @@ export class AccordionPanel extends SplitPanel {
       // Show the widget
       const previousSize = this._widgetSizesCache.get(widget);
       if (!previousSize) {
-        // Previous size is unavailable, let the `SplitLayout` computes widget sizes.
+        // Previous size is unavailable, let the `SplitLayout` compute widget sizes.
         return undefined;
       }
       newSize[index] += previousSize;

--- a/packages/widgets/src/accordionpanel.ts
+++ b/packages/widgets/src/accordionpanel.ts
@@ -176,7 +176,11 @@ export class AccordionPanel extends SplitPanel {
         widgetSizes[widgetToCollapse] + currentSize + delta;
     } else {
       // Show the widget
-      const previousSize = this._widgetSizesCache.get(widget)!;
+      const previousSize = this._widgetSizesCache.get(widget);
+      if (!previousSize) {
+        // Previous size is unavailable, let the `SplitLayout` computes widget sizes.
+        return undefined;
+      }
       newSize[index] += previousSize;
 
       const widgetToCollapse = newSize
@@ -286,7 +290,7 @@ export class AccordionPanel extends SplitPanel {
     }
   }
 
-  private _widgetSizesCache: Map<Widget, number> = new Map();
+  private _widgetSizesCache: WeakMap<Widget, number> = new WeakMap();
 }
 
 /**

--- a/packages/widgets/src/splitlayout.ts
+++ b/packages/widgets/src/splitlayout.ts
@@ -158,6 +158,17 @@ export class SplitLayout extends PanelLayout {
   }
 
   /**
+   * Get the absolute sizes of the widgets in the layout.
+   *
+   * @returns A new array of the absolute sizes of the widgets.
+   *
+   * This method **does not** measure the DOM nodes.
+   */
+  absoluteSizes(): number[] {
+    return this._sizers.map(sizer => sizer.size);
+  }
+
+  /**
    * Get the relative sizes of the widgets in the layout.
    *
    * @returns A new array of the relative sizes of the widgets.
@@ -176,13 +187,15 @@ export class SplitLayout extends PanelLayout {
    * Set the relative sizes for the widgets in the layout.
    *
    * @param sizes - The relative sizes for the widgets in the panel.
+   * @param update - Update the layout after setting relative sizes.
+   * Default is True.
    *
    * #### Notes
    * Extra values are ignored, too few will yield an undefined layout.
    *
    * The actual geometry of the DOM nodes is updated asynchronously.
    */
-  setRelativeSizes(sizes: number[]): void {
+  setRelativeSizes(sizes: number[], update = true): void {
     // Copy the sizes and pad with zeros as needed.
     let n = this._sizers.length;
     let temp = sizes.slice(0, n);
@@ -204,7 +217,7 @@ export class SplitLayout extends PanelLayout {
     this._hasNormedSizes = true;
 
     // Trigger an update of the parent widget.
-    if (this.parent) {
+    if (update && this.parent) {
       this.parent.update();
     }
   }

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -151,8 +151,8 @@ export class SplitPanel extends Panel {
    *
    * The actual geometry of the DOM nodes is updated asynchronously.
    */
-  setRelativeSizes(sizes: number[]): void {
-    (this.layout as SplitLayout).setRelativeSizes(sizes);
+  setRelativeSizes(sizes: number[], update = true): void {
+    (this.layout as SplitLayout).setRelativeSizes(sizes, update);
   }
 
   /**

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -145,6 +145,8 @@ export class SplitPanel extends Panel {
    * Set the relative sizes for the widgets in the panel.
    *
    * @param sizes - The relative sizes for the widgets in the panel.
+   * @param update - Update the layout after setting relative sizes.
+   * Default is True.
    *
    * #### Notes
    * Extra values are ignored, too few will yield an undefined layout.

--- a/packages/widgets/tests/src/accordionpanel.spec.ts
+++ b/packages/widgets/tests/src/accordionpanel.spec.ts
@@ -343,5 +343,44 @@ describe('@lumino/widgets', () => {
         });
       });
     });
+
+    describe('#_computeWidgetSize()', () => {
+      const DELTA = 1e-6;
+      let panel: AccordionPanel;
+      beforeEach(() => {
+        panel = new AccordionPanel({ renderer, titleSpace: 0, spacing: 0 });
+        panel.node.style.height = '500px';
+        Widget.attach(panel, document.body);
+      });
+      it('should not compute the size of panel with only one widget', () => {
+        panel.addWidget(new Widget());
+        MessageLoop.flush();
+        const value = panel['_computeWidgetSize'](0);
+        expect(value).to.be.equal(undefined);
+      });
+      it('should compute the size of panel with two opened widgets', () => {
+        const widgets = [new Widget(), new Widget()];
+        widgets.forEach(w => panel.addWidget(w));
+        MessageLoop.flush();
+        const value0 = panel['_computeWidgetSize'](0);
+        expect(value0.length).to.be.equal(2);
+        expect(value0[0]).to.be.closeTo(0, DELTA);
+        expect(value0[1]).to.be.closeTo(1, DELTA);
+        const value1 = panel['_computeWidgetSize'](1);
+        expect(value1[0]).to.be.closeTo(1, DELTA);
+        expect(value1[1]).to.be.closeTo(0, DELTA);
+      });
+      it('should compute the size of panel with three widgets', () => {
+        const widgets = [new Widget(), new Widget(), new Widget()];
+        widgets.forEach(w => panel.addWidget(w));
+        MessageLoop.flush();
+
+        const value = panel['_computeWidgetSize'](0);
+        expect(value.length).to.be.equal(3);
+        expect(value[0]).to.be.closeTo(0, DELTA);
+        expect(value[1]).to.be.closeTo(0.333333, DELTA);
+        expect(value[2]).to.be.closeTo(0.666666, DELTA);
+      });
+    });
   });
 });


### PR DESCRIPTION
## References
This PR fixes the sizing issue of the Accordion widget when a child is opened/closed multiple times.

## Code changes
- Add private method `_computeWidgetSize` to `AccordionPanel`  to cache and compute the size of widgets on title click event.
- Add boolean parameter `update`  to `SplitPanel.setRelativeSizes` to allow updating relative size without sending update message to the panel.


## User-facing changes
- Child widgets keep their sizes after being closed/opened.
- The resize behavior is changed, when a widget is opened or closed, the Accordion panel will try to resize only the last opened widget if possible.

### Old behavior

![old](https://user-images.githubusercontent.com/4451292/171374487-4f5d3607-56ab-4483-978b-9793ba407edb.gif)

### New behavior

![new](https://user-images.githubusercontent.com/4451292/171374518-7fdd4e94-83d2-4171-aedb-e3dc76a95402.gif)

## Backwards-incompatible changes

N/A
