### PR TITLE
Automated Changelog Entry for 2022.6.7 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2022.6.7
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.29.0...30a88f463778ad44ebbe8034622db3a76fbdc540))
+
+### Bugs fixed
+
+- Fix Accordion sizing issue [#304](https://github.com/jupyterlab/lumino/pull/304) ([@trungleduc](https://github.com/trungleduc))
+
+### Maintenance and upkeep improvements
+
+- Enable bot PRs to auto-label [#306](https://github.com/jupyterlab/lumino/pull/306) ([@blink1073](https://github.com/blink1073))
+- Bump semver-regex from 3.1.3 to 3.1.4 [#305](https://github.com/jupyterlab/lumino/pull/305) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-05-12&to=2022-06-07&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2022-05-12..2022-06-07&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2022-05-12..2022-06-07&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Atrungleduc+updated%3A2022-05-12..2022-06-07&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2022-05-12..2022-06-07&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2022.5.12
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/v2022.1.13...9c2948ed094b089f1c948300dfdf1f85fff4b83c))
@@ -34,8 +55,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-01-13&to=2022-05-12&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-01-13..2022-05-12&type=Issues) | [@ajbozarth](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aajbozarth+updated%3A2022-01-13..2022-05-12&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2022-01-13..2022-05-12&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2022-01-13..2022-05-12&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-01-13..2022-05-12&type=Issues) | [@GordonSmith](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3AGordonSmith+updated%3A2022-01-13..2022-05-12&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2022.1.13
 


### PR DESCRIPTION
Automated Changelog Entry for 2022.6.7 on main
```
npm workspace versions:
@lumino/example-accordionpanel: 0.8.1
@lumino/example-datagrid: 0.32.1
@lumino/example-datastore: 0.21.1
@lumino/example-dockpanel: 0.21.1
@lumino/example-dockpanel-amd: 0.4.0
@lumino/example-dockpanel-iife: 0.4.0
@lumino/algorithm: 1.9.1
@lumino/application: 1.29.1
@lumino/collections: 1.9.1
@lumino/commands: 1.20.0
@lumino/coreutils: 1.12.0
@lumino/datagrid: 0.36.1
@lumino/datastore: 0.18.0
@lumino/default-theme: 0.22.1
@lumino/disposable: 1.10.1
@lumino/domutils: 1.8.1
@lumino/dragdrop: 1.14.0
@lumino/keyboard: 1.8.1
@lumino/messaging: 1.10.1
@lumino/polling: 1.10.0
@lumino/properties: 1.8.1
@lumino/signaling: 1.10.1
@lumino/virtualdom: 1.14.1
@lumino/widgets: 1.32.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | main  |
| Version Spec | 2022.6.7 |
| Since | @lumino/application@1.29.0 |