### PR TITLE
[memory-leak] Title.changed not cleared when owner is disposed

### DIFF
--- a/packages/widgets/src/title.ts
+++ b/packages/widgets/src/title.ts
@@ -7,6 +7,8 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
+import { IDisposable } from '@lumino/disposable';
+
 import { ISignal, Signal } from '@lumino/signaling';
 
 import { VirtualElement } from '@lumino/virtualdom';
@@ -18,8 +20,10 @@ import { VirtualElement } from '@lumino/virtualdom';
  * A title object is intended to hold the data necessary to display a
  * header for a particular object. A common example is the `TabPanel`,
  * which uses the widget title to populate the tab for a child widget.
+ *
+ * It is the responsibility of the owner to call the title disposal.
  */
-export class Title<T> {
+export class Title<T> implements IDisposable {
   /**
    * Construct a new title.
    *
@@ -343,6 +347,28 @@ export class Title<T> {
     this._changed.emit(undefined);
   }
 
+  /**
+   * Test whether the title has been disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Dispose of the resources held by the title.
+   *
+   * #### Notes
+   * It is the responsibility of the owner to call the title disposal.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+
+    Signal.clearData(this);
+  }
+
   private _label = '';
   private _caption = '';
   private _mnemonic = -1;
@@ -359,6 +385,7 @@ export class Title<T> {
   private _closable = false;
   private _dataset: Title.Dataset;
   private _changed = new Signal<this, void>(this);
+  private _isDisposed = false;
 }
 
 /**

--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -80,6 +80,9 @@ export class Widget implements IMessageHandler, IObservableDisposable {
       this._layout = null;
     }
 
+    // Dispose the title
+    this.title.dispose();
+
     // Clear the extra data associated with the widget.
     Signal.clearData(this);
     MessageLoop.clearData(this);

--- a/packages/widgets/tests/src/title.spec.ts
+++ b/packages/widgets/tests/src/title.spec.ts
@@ -11,7 +11,9 @@ import { expect } from 'chai';
 
 import { Title } from '@lumino/widgets';
 
-const owner = { name: 'Bob' };
+const owner = {
+  name: 'Bob'
+};
 
 describe('@lumino/widgets', () => {
   describe('Title', () => {
@@ -33,6 +35,19 @@ describe('@lumino/widgets', () => {
         });
         title.label = 'baz';
         expect(called).to.equal(true);
+      });
+
+      it('should clear signal if it is disposed', () => {
+        let called = false;
+        let title = new Title({ owner });
+        title.changed.connect((sender, arg) => {
+          called = true;
+        });
+
+        title.dispose();
+
+        title.label = 'baz';
+        expect(called).to.equal(false);
       });
     });
 

--- a/packages/widgets/tests/src/title.spec.ts
+++ b/packages/widgets/tests/src/title.spec.ts
@@ -37,7 +37,7 @@ describe('@lumino/widgets', () => {
         expect(called).to.equal(true);
       });
 
-      it('should clear signal if it is disposed', () => {
+      it('should be cleared if it is disposed', () => {
         let called = false;
         let title = new Title({ owner });
         title.changed.connect((sender, arg) => {

--- a/packages/widgets/tests/src/widget.spec.ts
+++ b/packages/widgets/tests/src/widget.spec.ts
@@ -168,6 +168,13 @@ describe('@lumino/widgets', () => {
         widget.dispose();
         expect(layout.isDisposed).to.equal(true);
       });
+
+      it('should dispose of the widget title', () => {
+        const widget = new Widget();
+        const title = widget.title;
+        widget.dispose();
+        expect(title.isDisposed).to.equal(true);
+      });
     });
 
     describe('#disposed', () => {


### PR DESCRIPTION
### Reference

When working on adding memory leak test on JupyterLab in that [PR](https://github.com/jupyterlab/benchmarks/pull/100), it was highlighted that the signal connection to `Title.changed` where not cleared when the owner is disposed. This induces a memory leak due to connection stored in `Signal`.

---

In the open/close notebook scenario, the Launcher is removed from the memory leak by commenting the `title.changed` connection in [packages/running-extension/src/opentabs.ts](https://github.com/jupyterlab/jupyterlab/blob/master/packages/running-extension/src/opentabs.ts#L35).

### Code changes

- `Title` implements `IDisposable` and its the responsability of its owner to call `Title.dispose` (as it was added for `Widget` in this PR).
