### PR TITLE
Add `collapse` and `expand` methods to `AccordionPanel`

### DIFF
--- a/packages/widgets/src/accordionpanel.ts
+++ b/packages/widgets/src/accordionpanel.ts
@@ -69,12 +69,15 @@ export class AccordionPanel extends SplitPanel {
   /**
    * Collapse the widget at position `index`.
    *
+   * #### Notes
+   * If no widget is found for `index`, this will bail.
+   *
    * @param index Widget index
    */
   collapse(index: number): void {
     const widget = (this.layout as AccordionLayout).widgets[index];
 
-    if (!widget.isHidden) {
+    if (widget && !widget.isHidden) {
       this._toggleExpansion(index);
     }
   }
@@ -82,12 +85,15 @@ export class AccordionPanel extends SplitPanel {
   /**
    * Expand the widget at position `index`.
    *
+   * #### Notes
+   * If no widget is found for `index`, this will bail.
+   *
    * @param index Widget index
    */
   expand(index: number): void {
     const widget = (this.layout as AccordionLayout).widgets[index];
 
-    if (widget.isHidden) {
+    if (widget && widget.isHidden) {
       this._toggleExpansion(index);
     }
   }

--- a/packages/widgets/src/accordionpanel.ts
+++ b/packages/widgets/src/accordionpanel.ts
@@ -67,6 +67,32 @@ export class AccordionPanel extends SplitPanel {
   }
 
   /**
+   * Collapse the widget at position `index`.
+   *
+   * @param index Widget index
+   */
+  collapse(index: number): void {
+    const widget = (this.layout as AccordionLayout).widgets[index];
+
+    if (!widget.isHidden) {
+      this._toggleExpansion(index);
+    }
+  }
+
+  /**
+   * Expand the widget at position `index`.
+   *
+   * @param index Widget index
+   */
+  expand(index: number): void {
+    const widget = (this.layout as AccordionLayout).widgets[index];
+
+    if (widget.isHidden) {
+      this._toggleExpansion(index);
+    }
+  }
+
+  /**
    * Insert a widget at the specified index.
    *
    * @param index - The index at which to insert the widget.
@@ -221,23 +247,7 @@ export class AccordionPanel extends SplitPanel {
       if (index >= 0) {
         event.preventDefault();
         event.stopPropagation();
-        const title = this.titles[index];
-        const widget = (this.layout as AccordionLayout).widgets[index];
-
-        const newSize = this._computeWidgetSize(index);
-        if (newSize) {
-          this.setRelativeSizes(newSize, false);
-        }
-
-        if (widget.isHidden) {
-          title.classList.add('lm-mod-expanded');
-          title.setAttribute('aria-expanded', 'true');
-          widget.show();
-        } else {
-          title.classList.remove('lm-mod-expanded');
-          title.setAttribute('aria-expanded', 'false');
-          widget.hide();
-        }
+        this._toggleExpansion(index);
       }
     }
   }
@@ -293,6 +303,26 @@ export class AccordionPanel extends SplitPanel {
       if (handled) {
         event.preventDefault();
       }
+    }
+  }
+
+  private _toggleExpansion(index: number) {
+    const title = this.titles[index];
+    const widget = (this.layout as AccordionLayout).widgets[index];
+
+    const newSize = this._computeWidgetSize(index);
+    if (newSize) {
+      this.setRelativeSizes(newSize, false);
+    }
+
+    if (widget.isHidden) {
+      title.classList.add('lm-mod-expanded');
+      title.setAttribute('aria-expanded', 'true');
+      widget.show();
+    } else {
+      title.classList.remove('lm-mod-expanded');
+      title.setAttribute('aria-expanded', 'false');
+      widget.hide();
     }
   }
 

--- a/packages/widgets/tests/src/accordionpanel.spec.ts
+++ b/packages/widgets/tests/src/accordionpanel.spec.ts
@@ -137,6 +137,69 @@ describe('@lumino/widgets', () => {
       });
     });
 
+    describe('#collapse()', () => {
+      let panel: AccordionPanel;
+      let layout: AccordionLayout;
+
+      beforeEach(() => {
+        panel = new AccordionPanel();
+        layout = panel.layout as AccordionLayout;
+        let widgets = [new Widget(), new Widget(), new Widget()];
+        widgets.forEach(w => {
+          panel.addWidget(w);
+        });
+        panel.setRelativeSizes([10, 10, 10, 20]);
+        Widget.attach(panel, document.body);
+        MessageLoop.flush();
+      });
+
+      afterEach(() => {
+        panel.dispose();
+      });
+
+      it('should collapse an expanded widget', () => {
+        panel.collapse(1);
+
+        expect(layout.titles[1].getAttribute('aria-expanded')).to.equal(
+          'false'
+        );
+        expect(layout.titles[1].classList.contains('lm-mod-expanded')).to.be
+          .false;
+        expect(layout.widgets[1].isHidden).to.be.true;
+      });
+    });
+
+    describe('#expand()', () => {
+      let panel: AccordionPanel;
+      let layout: AccordionLayout;
+
+      beforeEach(() => {
+        panel = new AccordionPanel();
+        layout = panel.layout as AccordionLayout;
+        let widgets = [new Widget(), new Widget(), new Widget()];
+        widgets.forEach(w => {
+          panel.addWidget(w);
+        });
+        panel.setRelativeSizes([10, 10, 10, 20]);
+        Widget.attach(panel, document.body);
+        MessageLoop.flush();
+      });
+
+      afterEach(() => {
+        panel.dispose();
+      });
+
+      it('should expand a collapsed widget', () => {
+        panel.collapse(1);
+        panel.expand(1);
+
+        expect(layout.titles[0].getAttribute('aria-expanded')).to.equal('true');
+        expect(layout.titles[0].classList.contains('lm-mod-expanded')).to.be
+          .true;
+        expect(layout.widgets[0].isHidden).to.be.false;
+      });
+    });
+
     describe('#handleEvent()', () => {
       let panel: LogAccordionPanel;
       let layout: AccordionLayout;


### PR DESCRIPTION
## Reference

Required for https://github.com/jupyterlab/jupyterlab/pull/12866

## Code Changes

Add API to programmatically expand or collapse a `AccordionPanel` widget. Before only user by clicking on the title could do that.

It is required for the extensions manager so we can show or hide the warning about installing third-party extensions depending on a settings parameter.