### PR TITLE
Update NPM package author to Project Jupyter

### DIFF
--- a/packages/algorithm/package.json
+++ b/packages/algorithm/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.node.js",
   "browser": "dist/index.js",
   "jsdelivr": "dist/index.min.js",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -11,12 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -7,13 +7,7 @@
     "url": "https://github.com/jupyterlab/lumino/issues"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "files": [
     "dist/*",
     "src/*",

--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/domutils/package.json
+++ b/packages/domutils/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/polling/package.json
+++ b/packages/polling/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "A. T. Darian <git@darian.email>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Ian Rose <ian.r.rose@gmail.com>",
-    "Jason Grout <jgrout6@bloomberg.net>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/signaling/package.json
+++ b/packages/signaling/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -11,13 +11,7 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "license": "BSD-3-Clause",
-  "author": "S. Chris Colbert <sccolbert@gmail.com>",
-  "contributors": [
-    "A. T. Darian <git@darian.email>",
-    "Dave Willmer <dave.willmer@gmail.com>",
-    "S. Chris Colbert <sccolbert@gmail.com>",
-    "Steven Silvester <steven.silvester@gmail.com>"
-  ],
+  "author": "Project Jupyter",
   "main": "dist/index.js",
   "jsdelivr": "dist/index.min.js",
   "unpkg": "dist/index.min.js",


### PR DESCRIPTION
This PR updates all of the `author` fields in the `package.json` files for each published Lumino package to be set to `Project Jupyter`.