### PR TITLE
Update `dragdrop` to use `PointerEvent` and `DragEvent`

### DIFF
--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -124,6 +124,14 @@ Helper functions for `DisposableSet` and `ObservableDisposableSet` have been udp
 | ✅  | `function` | `DisposableSet.from(...)`           | Accept `Iterable<IDisposable>` |
 | ✅  | `function` | `ObservableDisposableSet.from(...)` | Accept `Iterable<IDisposable>` |
 
+### `@lumino/dragdrop`
+
+|     | `export`    | name               | note                                    |
+| --- | ----------- | ------------------ | --------------------------------------- |
+| ❌  | `type`      | `DropAction`       | Moved to `Drag.DropAction`              |
+| ❌  | `type`      | `SupportedActions` | Moved to `Drag.SupportedActions`        |
+| ☑️  | `interface` | `IDragEvent`       | `@deprecated`, use `Drag.Event` instead |
+
 ### `@lumino/widgets`
 
 `Layout` and its sub-classes now use native iterators, e.g. `implements Iterable<Widget>`.

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -155,7 +155,12 @@ export class Drag implements IDisposable {
 
     // If there is a current target, dispatch a drag leave event.
     if (this._currentTarget) {
-      let event = Private.createMouseEvent('pointerup', -1, -1);
+      let event = new PointerEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+        clientX: -1,
+        clientY: -1
+      });
       Private.dispatchDragLeave(this, this._currentTarget, null, event);
     }
 
@@ -244,7 +249,12 @@ export class Drag implements IDisposable {
     });
 
     // Trigger a fake move event to kick off the drag operation.
-    let event = Private.createMouseEvent('pointermove', clientX, clientY);
+    let event = new PointerEvent('pointermove', {
+      bubbles: true,
+      cancelable: true,
+      clientX,
+      clientY
+    });
     document.dispatchEvent(event);
 
     // Return the pending promise for the drag operation.
@@ -755,43 +765,6 @@ namespace Private {
     supported: SupportedActions
   ): DropAction {
     return actionTable[action] & supportedTable[supported] ? action : 'none';
-  }
-
-  /**
-   * Create a left mouse event at the given position.
-   *
-   * @param type - The event type for the mouse event.
-   *
-   * @param clientX - The client X position.
-   *
-   * @param clientY - The client Y position.
-   *
-   * @returns A newly created and initialized mouse event.
-   */
-  export function createMouseEvent(
-    type: string,
-    clientX: number,
-    clientY: number
-  ): MouseEvent {
-    let event = document.createEvent('MouseEvent');
-    event.initMouseEvent(
-      type,
-      true,
-      true,
-      window,
-      0,
-      0,
-      0,
-      clientX,
-      clientY,
-      false,
-      false,
-      false,
-      false,
-      0,
-      null
-    );
-    return event;
   }
 
   /**

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -657,7 +657,7 @@ export namespace Drag {
         altKey: event.altKey,
         button: event.button,
         clientX: event.clientX,
-        clientY: event.clientX,
+        clientY: event.clientY,
         ctrlKey: event.ctrlKey,
         detail: 0,
         metaKey: event.metaKey,

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -12,81 +12,12 @@ import { MimeData } from '@lumino/coreutils';
 import { DisposableDelegate, IDisposable } from '@lumino/disposable';
 
 /**
- * A type alias which defines the possible independent drop actions.
- */
-export type DropAction = 'none' | 'copy' | 'link' | 'move';
-
-/**
- * A type alias which defines the possible supported drop actions.
- */
-export type SupportedActions =
-  | DropAction
-  | 'copy-link'
-  | 'copy-move'
-  | 'link-move'
-  | 'all';
-
-/**
- * A custom event type used for drag-drop operations.
+ * @deprecated
  *
  * #### Notes
- * In order to receive `'lm-dragover'`, `'lm-dragleave'`, or `'lm-drop'`
- * events, a drop target must cancel the `'lm-dragenter'` event by
- * calling the event's `preventDefault()` method.
+ * This interface is deprecated. Use Drag.Event instead.
  */
-export interface IDragEvent extends PointerEvent {
-  /**
-   * The drop action supported or taken by the drop target.
-   *
-   * #### Notes
-   * At the start of each event, this value will be `'none'`. During a
-   * `'lm-dragover'` event, the drop target must set this value to one
-   * of the supported actions, or the drop event will not occur.
-   *
-   * When handling the drop event, the drop target should set this
-   * to the action which was *actually* taken. This value will be
-   * reported back to the drag initiator.
-   */
-  dropAction: DropAction;
-
-  /**
-   * The drop action proposed by the drag initiator.
-   *
-   * #### Notes
-   * This is the action which is *preferred* by the drag initiator. The
-   * drop target is not required to perform this action, but should if
-   * it all possible.
-   */
-  readonly proposedAction: DropAction;
-
-  /**
-   * The drop actions supported by the drag initiator.
-   *
-   * #### Notes
-   * If the `dropAction` is not set to one of the supported actions
-   * during the `'lm-dragover'` event, the drop event will not occur.
-   */
-  readonly supportedActions: SupportedActions;
-
-  /**
-   * The mime data associated with the event.
-   *
-   * #### Notes
-   * This is mime data provided by the drag initiator. Drop targets
-   * should use this data to determine if they can handle the drop.
-   */
-  readonly mimeData: MimeData;
-
-  /**
-   * The source object of the drag, as provided by the drag initiator.
-   *
-   * #### Notes
-   * For advanced applications, the drag initiator may wish to expose
-   * a source object to the drop targets. That will be provided here
-   * if given by the drag initiator, otherwise it will be `null`.
-   */
-  readonly source: any;
-}
+export interface IDragEvent extends Drag.Event {}
 
 /**
  * An object which manages a drag-drop operation.
@@ -186,12 +117,12 @@ export class Drag implements IDisposable {
   /**
    * The proposed drop action for the drag object.
    */
-  readonly proposedAction: DropAction;
+  readonly proposedAction: Drag.DropAction;
 
   /**
    * The supported drop actions for the drag object.
    */
-  readonly supportedActions: SupportedActions;
+  readonly supportedActions: Drag.SupportedActions;
 
   /**
    * Get the drag source for the drag object.
@@ -226,10 +157,10 @@ export class Drag implements IDisposable {
    *
    * This method assumes the left mouse button is already held down.
    */
-  start(clientX: number, clientY: number): Promise<DropAction> {
-    // If the drag object is already disposed, resolve to `None`.
+  start(clientX: number, clientY: number): Promise<Drag.DropAction> {
+    // If the drag object is already disposed, resolve to `none`.
     if (this._disposed) {
-      return Promise.resolve('none' as DropAction);
+      return Promise.resolve('none');
     }
 
     // If the drag has already been started, return the promise.
@@ -244,7 +175,7 @@ export class Drag implements IDisposable {
     this._attachDragImage(clientX, clientY);
 
     // Create the promise which will be resolved on completion.
-    this._promise = new Promise<DropAction>((resolve, reject) => {
+    this._promise = new Promise<Drag.DropAction>(resolve => {
       this._resolve = resolve;
     });
 
@@ -512,7 +443,7 @@ export class Drag implements IDisposable {
   /**
    * Set the internal drop action state and update the drag cursor.
    */
-  private _setDropAction(action: DropAction): void {
+  private _setDropAction(action: Drag.DropAction): void {
     action = Private.validateAction(action, this.supportedActions);
     if (this._override && this._dropAction === action) {
       return;
@@ -540,7 +471,7 @@ export class Drag implements IDisposable {
   /**
    * Finalize the drag operation and resolve the drag promise.
    */
-  private _finalize(action: DropAction): void {
+  private _finalize(action: Drag.DropAction): void {
     // Store the resolve function as a temp variable.
     let resolve = this._resolve;
 
@@ -612,19 +543,34 @@ export class Drag implements IDisposable {
   };
 
   private _disposed = false;
-  private _dropAction: DropAction = 'none';
+  private _dropAction: Drag.DropAction = 'none';
   private _override: IDisposable | null = null;
   private _currentTarget: Element | null = null;
   private _currentElement: Element | null = null;
-  private _promise: Promise<DropAction> | null = null;
+  private _promise: Promise<Drag.DropAction> | null = null;
   private _scrollTarget: Private.IScrollTarget | null = null;
-  private _resolve: ((value: DropAction) => void) | null = null;
+  private _resolve: ((value: Drag.DropAction) => void) | null = null;
 }
 
 /**
  * The namespace for the `Drag` class statics.
  */
 export namespace Drag {
+  /**
+   * A type alias which defines the possible independent drop actions.
+   */
+  export type DropAction = 'none' | 'copy' | 'link' | 'move';
+
+  /**
+   * A type alias which defines the possible supported drop actions.
+   */
+  export type SupportedActions =
+    | DropAction
+    | 'copy-link'
+    | 'copy-move'
+    | 'link-move'
+    | 'all';
+
   /**
    * An options object for initializing a `Drag` object.
    */
@@ -696,6 +642,124 @@ export namespace Drag {
   }
 
   /**
+   * A custom event used for drag-drop operations.
+   *
+   * #### Notes
+   * In order to receive `'lm-dragover'`, `'lm-dragleave'`, or `'lm-drop'`
+   * events, a drop target must cancel the `'lm-dragenter'` event by
+   * calling the event's `preventDefault()` method.
+   */
+  export class Event extends DragEvent {
+    constructor(event: PointerEvent, options: Event.IOptions) {
+      super(options.type, {
+        bubbles: true,
+        cancelable: true,
+        altKey: event.altKey,
+        button: event.button,
+        clientX: event.clientX,
+        clientY: event.clientX,
+        ctrlKey: event.ctrlKey,
+        detail: 0,
+        metaKey: event.metaKey,
+        relatedTarget: options.related,
+        screenX: event.screenX,
+        screenY: event.screenY,
+        shiftKey: event.shiftKey,
+        view: window
+      });
+
+      const { drag } = options;
+      this.dropAction = 'none';
+      this.mimeData = drag.mimeData;
+      this.proposedAction = drag.proposedAction;
+      this.supportedActions = drag.supportedActions;
+      this.source = drag.source;
+    }
+
+    /**
+     * The drop action supported or taken by the drop target.
+     *
+     * #### Notes
+     * At the start of each event, this value will be `'none'`. During a
+     * `'lm-dragover'` event, the drop target must set this value to one
+     * of the supported actions, or the drop event will not occur.
+     *
+     * When handling the drop event, the drop target should set this
+     * to the action which was *actually* taken. This value will be
+     * reported back to the drag initiator.
+     */
+    dropAction: DropAction;
+
+    /**
+     * The drop action proposed by the drag initiator.
+     *
+     * #### Notes
+     * This is the action which is *preferred* by the drag initiator. The
+     * drop target is not required to perform this action, but should if
+     * it all possible.
+     */
+    readonly proposedAction: DropAction;
+
+    /**
+     * The drop actions supported by the drag initiator.
+     *
+     * #### Notes
+     * If the `dropAction` is not set to one of the supported actions
+     * during the `'lm-dragover'` event, the drop event will not occur.
+     */
+    readonly supportedActions: SupportedActions;
+
+    /**
+     * The mime data associated with the event.
+     *
+     * #### Notes
+     * This is mime data provided by the drag initiator. Drop targets
+     * should use this data to determine if they can handle the drop.
+     */
+    readonly mimeData: MimeData;
+
+    /**
+     * The source object of the drag, as provided by the drag initiator.
+     *
+     * #### Notes
+     * For advanced applications, the drag initiator may wish to expose
+     * a source object to the drop targets. That will be provided here
+     * if given by the drag initiator, otherwise it will be `null`.
+     */
+    readonly source: any;
+  }
+
+  /**
+   * The namespace for the `Event` class statics.
+   */
+  export namespace Event {
+    /**
+     * An options object for initializing a `Drag` object.
+     */
+    export interface IOptions {
+      /**
+       * The drag object to use for seeding the drag data.
+       */
+      drag: Drag;
+
+      /**
+       * The related target for the event, or `null`.
+       */
+      related: Element | null;
+
+      /**
+       * The drag event type.
+       */
+      type:
+        | 'lm-dragenter'
+        | 'lm-dragexit'
+        | 'lm-dragleave'
+        | 'lm-dragover'
+        | 'lm-drop';
+    }
+  }
+
+  /**
    * Override the cursor icon for the entire document.
    *
    * @param cursor - The string representing the cursor style.
@@ -761,9 +825,9 @@ namespace Private {
    * Returns the given action or `'none'` if the action is unsupported.
    */
   export function validateAction(
-    action: DropAction,
-    supported: SupportedActions
-  ): DropAction {
+    action: Drag.DropAction,
+    supported: Drag.SupportedActions
+  ): Drag.DropAction {
     return actionTable[action] & supportedTable[supported] ? action : 'none';
   }
 
@@ -930,7 +994,11 @@ namespace Private {
     }
 
     // Dispatch a drag enter event to the current element.
-    let dragEvent = createDragEvent('lm-dragenter', drag, event, currTarget);
+    let dragEvent = new Drag.Event(event, {
+      drag,
+      related: currTarget,
+      type: 'lm-dragenter'
+    });
     let canceled = !currElem.dispatchEvent(dragEvent);
 
     // If the event was canceled, use the current element as the new target.
@@ -949,7 +1017,11 @@ namespace Private {
     }
 
     // Dispatch a drag enter event on the document body.
-    dragEvent = createDragEvent('lm-dragenter', drag, event, currTarget);
+    dragEvent = new Drag.Event(event, {
+      drag,
+      related: currTarget,
+      type: 'lm-dragenter'
+    });
     body.dispatchEvent(dragEvent);
 
     // Ignore the event cancellation, and use the body as the new target.
@@ -985,7 +1057,11 @@ namespace Private {
     }
 
     // Dispatch the drag exit event to the previous target.
-    let dragEvent = createDragEvent('lm-dragexit', drag, event, currTarget);
+    let dragEvent = new Drag.Event(event, {
+      drag,
+      related: currTarget,
+      type: 'lm-dragexit'
+    });
     prevTarget.dispatchEvent(dragEvent);
   }
 
@@ -1018,7 +1094,11 @@ namespace Private {
     }
 
     // Dispatch the drag leave event to the previous target.
-    let dragEvent = createDragEvent('lm-dragleave', drag, event, currTarget);
+    let dragEvent = new Drag.Event(event, {
+      drag,
+      related: currTarget,
+      type: 'lm-dragleave'
+    });
     prevTarget.dispatchEvent(dragEvent);
   }
 
@@ -1042,14 +1122,18 @@ namespace Private {
     drag: Drag,
     currTarget: Element | null,
     event: PointerEvent
-  ): DropAction {
+  ): Drag.DropAction {
     // If there is no current target, the drop action is none.
     if (!currTarget) {
       return 'none';
     }
 
     // Dispatch the drag over event to the current target.
-    let dragEvent = createDragEvent('lm-dragover', drag, event, null);
+    let dragEvent = new Drag.Event(event, {
+      drag,
+      related: null,
+      type: 'lm-dragover'
+    });
     let canceled = !currTarget.dispatchEvent(dragEvent);
 
     // If the event was canceled, return the drop action result.
@@ -1081,14 +1165,18 @@ namespace Private {
     drag: Drag,
     currTarget: Element | null,
     event: PointerEvent
-  ): DropAction {
+  ): Drag.DropAction {
     // If there is no current target, the drop action is none.
     if (!currTarget) {
       return 'none';
     }
 
     // Dispatch the drop event to the current target.
-    let dragEvent = createDragEvent('lm-drop', drag, event, null);
+    let dragEvent = new Drag.Event(event, {
+      drag,
+      related: null,
+      type: 'lm-drop'
+    });
     let canceled = !currTarget.dispatchEvent(dragEvent);
 
     // If the event was canceled, return the drop action result.
@@ -1123,57 +1211,4 @@ namespace Private {
     'link-move': actionTable['link'] | actionTable['move'],
     all: actionTable['copy'] | actionTable['link'] | actionTable['move']
   };
-
-  /**
-   * Create a new initialized `IDragEvent` from the given data.
-   *
-   * @param type - The event type for the drag event.
-   *
-   * @param drag - The drag object to use for seeding the drag data.
-   *
-   * @param event - The mouse event to use for seeding the mouse data.
-   *
-   * @param related - The related target for the event, or `null`.
-   *
-   * @returns A new object which implements `IDragEvent`.
-   */
-  function createDragEvent(
-    type: string,
-    drag: Drag,
-    event: PointerEvent,
-    related: Element | null
-  ): IDragEvent {
-    // Create a new mouse event to use as the drag event. Currently,
-    // JS engines do now allow user-defined Event subclasses.
-    let dragEvent = document.createEvent('MouseEvent');
-
-    // Initialize the mouse event data.
-    dragEvent.initMouseEvent(
-      type,
-      true,
-      true,
-      window,
-      0,
-      event.screenX,
-      event.screenY,
-      event.clientX,
-      event.clientY,
-      event.ctrlKey,
-      event.altKey,
-      event.shiftKey,
-      event.metaKey,
-      event.button,
-      related
-    );
-
-    // Forcefully add the custom drag event properties.
-    (dragEvent as any).dropAction = 'none';
-    (dragEvent as any).mimeData = drag.mimeData;
-    (dragEvent as any).proposedAction = drag.proposedAction;
-    (dragEvent as any).supportedActions = drag.supportedActions;
-    (dragEvent as any).source = drag.source;
-
-    // Return the fully initialized drag event.
-    return dragEvent as IDragEvent;
-  }
 }

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -34,7 +34,7 @@ export type SupportedActions =
  * events, a drop target must cancel the `'lm-dragenter'` event by
  * calling the event's `preventDefault()` method.
  */
-export interface IDragEvent extends MouseEvent {
+export interface IDragEvent extends PointerEvent {
   /**
    * The drop action supported or taken by the drop target.
    *
@@ -412,7 +412,7 @@ export class Drag implements IDisposable {
   /**
    * Update the drag scroll element under the mouse.
    */
-  private _updateDragScroll(event: MouseEvent): void {
+  private _updateDragScroll(event: PointerEvent): void {
     // Find the scroll target under the mouse.
     let target = Private.findScrollTarget(event);
 
@@ -433,7 +433,7 @@ export class Drag implements IDisposable {
   /**
    * Update the current target node using the given mouse event.
    */
-  private _updateCurrentTarget(event: MouseEvent): void {
+  private _updateCurrentTarget(event: PointerEvent): void {
     // Fetch common local state.
     let prevTarget = this._currentTarget;
     let currTarget = this._currentTarget;
@@ -790,7 +790,7 @@ namespace Private {
   /**
    * Find the drag scroll target under the mouse, if any.
    */
-  export function findScrollTarget(event: MouseEvent): IScrollTarget | null {
+  export function findScrollTarget(event: PointerEvent): IScrollTarget | null {
     // Look up the client mouse position.
     let x = event.clientX;
     let y = event.clientY;
@@ -922,7 +922,7 @@ namespace Private {
     drag: Drag,
     currElem: Element | null,
     currTarget: Element | null,
-    event: MouseEvent
+    event: PointerEvent
   ): Element | null {
     // If the current element is null, return null as the new target.
     if (!currElem) {
@@ -977,7 +977,7 @@ namespace Private {
     drag: Drag,
     prevTarget: Element | null,
     currTarget: Element | null,
-    event: MouseEvent
+    event: PointerEvent
   ): void {
     // If the previous target is null, do nothing.
     if (!prevTarget) {
@@ -1010,7 +1010,7 @@ namespace Private {
     drag: Drag,
     prevTarget: Element | null,
     currTarget: Element | null,
-    event: MouseEvent
+    event: PointerEvent
   ): void {
     // If the previous target is null, do nothing.
     if (!prevTarget) {
@@ -1041,7 +1041,7 @@ namespace Private {
   export function dispatchDragOver(
     drag: Drag,
     currTarget: Element | null,
-    event: MouseEvent
+    event: PointerEvent
   ): DropAction {
     // If there is no current target, the drop action is none.
     if (!currTarget) {
@@ -1080,7 +1080,7 @@ namespace Private {
   export function dispatchDrop(
     drag: Drag,
     currTarget: Element | null,
-    event: MouseEvent
+    event: PointerEvent
   ): DropAction {
     // If there is no current target, the drop action is none.
     if (!currTarget) {
@@ -1140,7 +1140,7 @@ namespace Private {
   function createDragEvent(
     type: string,
     drag: Drag,
-    event: MouseEvent,
+    event: PointerEvent,
     related: Element | null
   ): IDragEvent {
     // Create a new mouse event to use as the drag event. Currently,

--- a/packages/dragdrop/tests/src/index.spec.ts
+++ b/packages/dragdrop/tests/src/index.spec.ts
@@ -11,7 +11,7 @@ import { expect } from 'chai';
 
 import { MimeData } from '@lumino/coreutils';
 
-import { Drag, IDragEvent } from '@lumino/dragdrop';
+import { Drag } from '@lumino/dragdrop';
 
 import '@lumino/dragdrop/style/index.css';
 
@@ -42,37 +42,37 @@ class DropTarget {
     this.events.push(event.type);
     switch (event.type) {
       case 'lm-dragenter':
-        this._evtDragEnter(event as IDragEvent);
+        this._evtDragEnter(event as Drag.Event);
         break;
       case 'lm-dragleave':
-        this._evtDragLeave(event as IDragEvent);
+        this._evtDragLeave(event as Drag.Event);
         break;
       case 'lm-dragover':
-        this._evtDragOver(event as IDragEvent);
+        this._evtDragOver(event as Drag.Event);
         break;
       case 'lm-drop':
-        this._evtDrop(event as IDragEvent);
+        this._evtDrop(event as Drag.Event);
         break;
     }
   }
 
-  private _evtDragEnter(event: IDragEvent): void {
+  private _evtDragEnter(event: Drag.Event): void {
     event.preventDefault();
     event.stopPropagation();
   }
 
-  private _evtDragLeave(event: IDragEvent): void {
+  private _evtDragLeave(event: Drag.Event): void {
     event.preventDefault();
     event.stopPropagation();
   }
 
-  private _evtDragOver(event: IDragEvent): void {
+  private _evtDragOver(event: Drag.Event): void {
     event.preventDefault();
     event.stopPropagation();
     event.dropAction = event.proposedAction;
   }
 
-  private _evtDrop(event: IDragEvent): void {
+  private _evtDrop(event: Drag.Event): void {
     event.preventDefault();
     event.stopPropagation();
     if (event.proposedAction === 'none') {

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -15,7 +15,7 @@ import { IDisposable } from '@lumino/disposable';
 
 import { ElementExt, Platform } from '@lumino/domutils';
 
-import { Drag, IDragEvent } from '@lumino/dragdrop';
+import { Drag } from '@lumino/dragdrop';
 
 import { ConflatableMessage, Message, MessageLoop } from '@lumino/messaging';
 
@@ -434,16 +434,16 @@ export class DockPanel extends Widget {
   handleEvent(event: Event): void {
     switch (event.type) {
       case 'lm-dragenter':
-        this._evtDragEnter(event as IDragEvent);
+        this._evtDragEnter(event as Drag.Event);
         break;
       case 'lm-dragleave':
-        this._evtDragLeave(event as IDragEvent);
+        this._evtDragLeave(event as Drag.Event);
         break;
       case 'lm-dragover':
-        this._evtDragOver(event as IDragEvent);
+        this._evtDragOver(event as Drag.Event);
         break;
       case 'lm-drop':
-        this._evtDrop(event as IDragEvent);
+        this._evtDrop(event as Drag.Event);
         break;
       case 'pointerdown':
         this._evtPointerDown(event as MouseEvent);
@@ -519,7 +519,7 @@ export class DockPanel extends Widget {
   /**
    * Handle the `'lm-dragenter'` event for the dock panel.
    */
-  private _evtDragEnter(event: IDragEvent): void {
+  private _evtDragEnter(event: Drag.Event): void {
     // If the factory mime type is present, mark the event as
     // handled in order to get the rest of the drag events.
     if (event.mimeData.hasData('application/vnd.lumino.widget-factory')) {
@@ -531,7 +531,7 @@ export class DockPanel extends Widget {
   /**
    * Handle the `'lm-dragleave'` event for the dock panel.
    */
-  private _evtDragLeave(event: IDragEvent): void {
+  private _evtDragLeave(event: Drag.Event): void {
     // Mark the event as handled.
     event.preventDefault();
     event.stopPropagation();
@@ -545,7 +545,7 @@ export class DockPanel extends Widget {
   /**
    * Handle the `'lm-dragover'` event for the dock panel.
    */
-  private _evtDragOver(event: IDragEvent): void {
+  private _evtDragOver(event: Drag.Event): void {
     // Mark the event as handled.
     event.preventDefault();
     event.stopPropagation();
@@ -565,7 +565,7 @@ export class DockPanel extends Widget {
   /**
    * Handle the `'lm-drop'` event for the dock panel.
    */
-  private _evtDrop(event: IDragEvent): void {
+  private _evtDrop(event: Drag.Event): void {
     // Mark the event as handled.
     event.preventDefault();
     event.stopPropagation();

--- a/review/api/dragdrop.api.md
+++ b/review/api/dragdrop.api.md
@@ -17,14 +17,30 @@ export class Drag implements IDisposable {
     get isDisposed(): boolean;
     readonly mimeData: MimeData;
     protected moveDragImage(clientX: number, clientY: number): void;
-    readonly proposedAction: DropAction;
+    readonly proposedAction: Drag.DropAction;
     readonly source: any;
-    start(clientX: number, clientY: number): Promise<DropAction>;
-    readonly supportedActions: SupportedActions;
+    start(clientX: number, clientY: number): Promise<Drag.DropAction>;
+    readonly supportedActions: Drag.SupportedActions;
 }
 
 // @public
 export namespace Drag {
+    export type DropAction = 'none' | 'copy' | 'link' | 'move';
+    export class Event extends DragEvent {
+        constructor(event: PointerEvent, options: Event.IOptions);
+        dropAction: DropAction;
+        readonly mimeData: MimeData;
+        readonly proposedAction: DropAction;
+        readonly source: any;
+        readonly supportedActions: SupportedActions;
+    }
+    export namespace Event {
+        export interface IOptions {
+            drag: Drag;
+            related: Element | null;
+            type: 'lm-dragenter' | 'lm-dragexit' | 'lm-dragleave' | 'lm-dragover' | 'lm-drop';
+        }
+    }
     export interface IOptions {
         document?: Document | ShadowRoot;
         dragImage?: HTMLElement;
@@ -34,22 +50,12 @@ export namespace Drag {
         supportedActions?: SupportedActions;
     }
     export function overrideCursor(cursor: string, doc?: Document | ShadowRoot): IDisposable;
+    export type SupportedActions = DropAction | 'copy-link' | 'copy-move' | 'link-move' | 'all';
 }
 
-// @public
-export type DropAction = 'none' | 'copy' | 'link' | 'move';
-
-// @public
-export interface IDragEvent extends MouseEvent {
-    dropAction: DropAction;
-    readonly mimeData: MimeData;
-    readonly proposedAction: DropAction;
-    readonly source: any;
-    readonly supportedActions: SupportedActions;
+// @public @deprecated (undocumented)
+export interface IDragEvent extends Drag.Event {
 }
-
-// @public
-export type SupportedActions = DropAction | 'copy-link' | 'copy-move' | 'link-move' | 'all';
 
 // (No @packageDocumentation comment for this package)
 


### PR DESCRIPTION
- This PR updates `@lumino/dragdrop` to use [`new PointerEvent(...)`](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent) instances or sub-classes of `DragEvent` instead of [initMouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/initMouseEvent), which is deprecated.
- This PR **moves** the `DropAction` and `SupportedActions` type definitions into the `Drag` namespace. This does not seem to affect any downstream Lumino or JupyterLab code.
- This PR **deprecates** the `IDragEvent` interface and suggests client code use `Drag.Event` instead.

Fixes https://github.com/jupyterlab/lumino/issues/353
Partially fixes https://github.com/jupyterlab/lumino/issues/340

## Public API changes

### `@lumino/dragdrop`
| | `export` | name | note |
|-|-|-|-|
| ❌ | `type` | `DropAction` | Moved to `Drag.DropAction` |
| ❌ | `type` | `SupportedActions` | Moved to `Drag.SupportedActions` |
| ☑️ | `interface` | `IDragEvent` | `@deprecated`, use `Drag.Event` instead |

