### PR TITLE
Set npm tag to next for prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
         "examples/accordionpanel/index.html",
         "examples/datagrid/index.html",
         "examples/dockpanel/index.html"
-      ]
+      ],
+      "npm-cmd": "npm publish --tag next"
     },
     "hooks": {
       "after-build-changelog": [


### PR DESCRIPTION
All v2 alpha.0 versions have been deprecated as they were published on default npm tag. Hopefully we can get the final version out quickly so the [warning](https://www.npmjs.com/package/@lumino/algorithm) on the default package page disappears...

Once this is merged, I will carry out a new alpha release.