### PR TITLE
Fix tab trap in menubar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Lumino
 
 [![Build Status](https://github.com/jupyterlab/lumino/workflows/Tests/badge.svg?branch=main)](https://github.com/jupyterlab/lumino/actions?query=branch%3Amain+workflow%3A%22Tests%22)
-[![Documentation Status](https://readthedocs.org/projects/jupyterlab/badge/?version=stable)](http://lumino.readthedocs.io/en/stable/)
+[![Documentation Status](https://readthedocs.org/projects/jupyterlab/badge/?version=latest)](https://lumino.readthedocs.io/en/latest/)
 [![GitHub](https://img.shields.io/badge/issue_tracking-github-blue.svg)](https://github.com/jupyterlab/lumino/issues)
 [![Discourse](https://img.shields.io/badge/help_forum-discourse-blue.svg)](https://discourse.jupyter.org/c/jupyterlab)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/lumino/main?urlpath=lab/tree/examples)

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -409,6 +409,9 @@ export class MenuBar extends Widget {
 
   /**
    * Handle the `'keydown'` event for the menu bar.
+   *
+   * #### Notes
+   * All keys are trapped except the tab key that is ignored.
    */
   private _evtKeyDown(event: KeyboardEvent): void {
     // Fetch the key code for the event.
@@ -419,7 +422,7 @@ export class MenuBar extends Widget {
       return;
     }
 
-    // A menu bar handles all keydown events.
+    // A menu bar handles all other keydown events.
     event.preventDefault();
     event.stopPropagation();
 

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -411,12 +411,17 @@ export class MenuBar extends Widget {
    * Handle the `'keydown'` event for the menu bar.
    */
   private _evtKeyDown(event: KeyboardEvent): void {
+    // Fetch the key code for the event.
+    let kc = event.keyCode;
+
+    // Do not trap the tab key.
+    if (kc === 9) {
+      return;
+    }
+
     // A menu bar handles all keydown events.
     event.preventDefault();
     event.stopPropagation();
-
-    // Fetch the key code for the event.
-    let kc = event.keyCode;
 
     // Enter, Up Arrow, Down Arrow
     if (kc === 13 || kc === 38 || kc === 40) {

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -470,9 +470,9 @@ describe('@lumino/widgets', () => {
 
       context('keydown', () => {
         it('should bail on Tab', () => {
-          let evt = generate('keydown', { keyCode: 9 });
-          bar.node.dispatchEvent(evt);
-          expect(evt.defaultPrevented).to.equal(false);
+          let event = new KeyboardEvent('keydown', { keyCode: 9 });
+          bar.node.dispatchEvent(event);
+          expect(event.defaultPrevented).to.equal(false);
         });
 
         it('should open the active menu on Enter', () => {

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -469,6 +469,12 @@ describe('@lumino/widgets', () => {
       });
 
       context('keydown', () => {
+        it('should bail on Tab', () => {
+          let evt = generate('keydown', { keyCode: 9 });
+          bar.node.dispatchEvent(evt);
+          expect(evt.defaultPrevented).to.equal(false);
+        });
+
         it('should open the active menu on Enter', () => {
           let menu = bar.activeMenu!;
           bar.node.dispatchEvent(


### PR DESCRIPTION
There are a few tab traps in the JupyterLab UI. The worst offender is the top menu bar. The code change in this pull request is the most straightforward way to fix the menu bar tab trap in JupyterLab.

In terms of backwards compatibility, I have a hard time imagining that downstream dependents on Lumino would rely on the tab key event getting caught and swallowed (`event.preventDefault` + `event.stopPropagation`) by the Lumino menu bar, but it is something to consider.