### PR TITLE
Dynamic extensions reloading

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -373,10 +373,16 @@ export class Application<T extends Widget> {
           }
         })
       );
-      dependent.service = null;
-      dependent.activated = false;
       if (promise) {
-        promises.push(promise);
+        promises.push(
+          promise.then(() => {
+            dependent.service = null;
+            dependent.activated = false;
+          })
+        );
+      } else {
+        dependent.service = null;
+        dependent.activated = false;
       }
     }
     await Promise.all(promises);
@@ -835,7 +841,7 @@ namespace Private {
    * @returns A list of dependent plugin ids in order of deactivation
    *
    * #### Notes
-   * The final item of the return list is always the plugin of interest.
+   * The final item of the returned list is always the plugin of interest.
    */
   export function findDependents(
     id: string,

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -302,11 +302,8 @@ export class Application<T extends Widget = Widget> {
     // Resolve the optional services for the plugin.
     const optional = plugin.optional.map(t => this.resolveOptionalService(t));
 
-    // Create the array of promises to resolve.
-    const promises = required.concat(optional);
-
     // Setup the resolver promise for the plugin.
-    plugin.promise = Promise.all(promises)
+    plugin.promise = Promise.all([...required, ...optional])
       .then(services => plugin!.activate.apply(undefined, [this, ...services]))
       .then(service => {
         plugin!.service = service;
@@ -516,7 +513,7 @@ export class Application<T extends Widget = Widget> {
     Promise.all(promises).then(() => {
       this.attachShell(hostID);
       this.addEventListeners();
-      this._delegate.resolve(undefined);
+      this._delegate.resolve();
     });
 
     // Return the pending delegate promise.

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -246,13 +246,13 @@ export class Application<T extends Widget> {
   }
 
   /**
-   * Register a plugin with the application.
+   * Deregister a plugin with the application.
    *
    * @param id - The ID of the plugin of interest.
    *
-   * @param force - Whether to unregister the plugin even if it is active.
+   * @param force - Whether to deregister the plugin even if it is active.
    */
-  unregisterPlugin(id: string, force?: boolean): void {
+  deregisterPlugin(id: string, force?: boolean): void {
     const plugin = this._plugins.get(id);
     if (!plugin) {
       return;
@@ -848,7 +848,6 @@ namespace Private {
     }
 
     const sorted = topologicSort(edges);
-
     const index = sorted.findIndex(candidate => candidate === id);
 
     if (index === -1) {
@@ -866,30 +865,30 @@ namespace Private {
     options: Application.IStartOptions
   ): string[] {
     // Create a map to hold the plugin IDs.
-    const resultMap = new Map<string, boolean>();
+    const collection = new Map<string, boolean>();
 
     // Collect the auto-start plugins.
     for (const id in plugins) {
       if (plugins.get(id)!.autoStart) {
-        resultMap.set(id, true);
+        collection.set(id, true);
       }
     }
 
     // Add the startup plugins.
     if (options.startPlugins) {
       for (const id of options.startPlugins) {
-        resultMap.set(id, true);
+        collection.set(id, true);
       }
     }
 
     // Remove the ignored plugins.
     if (options.ignorePlugins) {
       for (const id of options.ignorePlugins) {
-        resultMap.delete(id);
+        collection.delete(id);
       }
     }
 
-    // Return the final startup plugins.
-    return Array.from(resultMap.keys());
+    // Return the collected startup plugins.
+    return Array.from(collection.keys());
   }
 }

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -18,6 +18,10 @@ import { ContextMenu, Menu, Widget } from '@lumino/widgets';
 /**
  * A user-defined application plugin.
  *
+ * @typeparam T - The type for the application.
+ *
+ * @typeparam U - The service type, if the plugin `provides` one.
+ *
  * #### Notes
  * Plugins are the foundation for building an extensible application.
  *
@@ -29,7 +33,7 @@ import { ContextMenu, Menu, Widget } from '@lumino/widgets';
  * service producer from the service consumer, allowing an application
  * to be easily customized by third parties in a type-safe fashion.
  */
-export interface IPlugin<T extends Application<Widget>, U> {
+export interface IPlugin<T extends Application, U> {
   /**
    * The human readable ID of the plugin.
    *
@@ -115,12 +119,14 @@ export interface IPlugin<T extends Application<Widget>, U> {
 /**
  * A class for creating pluggable applications.
  *
+ * @typeparam T - The type of the application shell.
+ *
  * #### Notes
  * The `Application` class is useful when creating large, complex
  * UI applications with the ability to be safely extended by third
  * party code via plugins.
  */
-export class Application<T extends Widget> {
+export class Application<T extends Widget = Widget> {
   /**
    * Construct a new application.
    *
@@ -716,13 +722,13 @@ namespace Private {
     /**
      * The function which activates the plugin.
      */
-    readonly activate: (app: any, ...args: any[]) => any;
+    readonly activate: (app: Application, ...args: any[]) => any;
 
     /**
      * The optional function which deactivates the plugin.
      */
     readonly deactivate:
-      | ((app: Application<Widget>, ...args: any[]) => void | Promise<void>)
+      | ((app: Application, ...args: any[]) => void | Promise<void>)
       | null;
 
     /**

--- a/packages/application/tests/src/index.spec.ts
+++ b/packages/application/tests/src/index.spec.ts
@@ -9,8 +9,508 @@
 |----------------------------------------------------------------------------*/
 import { expect } from 'chai';
 
+import { Application } from '@lumino/application';
+import { ContextMenu, Widget } from '@lumino/widgets';
+import { CommandRegistry } from '@lumino/commands';
+import { Token } from '@lumino/coreutils';
+
 describe('@lumino/application', () => {
-  it('should pass', () => {
-    expect(true).to.equal(true);
+  describe('Application', () => {
+    describe('#constructor', () => {
+      it('should instantiate an application', () => {
+        const shell = new Widget();
+        const app = new Application({
+          shell
+        });
+
+        expect(app).to.be.instanceOf(Application);
+        expect(app.commands).to.be.instanceOf(CommandRegistry);
+        expect(app.contextMenu).to.be.instanceOf(ContextMenu);
+        expect(app.shell).to.equal(shell);
+      });
+    });
+
+    describe('#hasPlugin', () => {
+      it('should be true for registered plugin', () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+
+        expect(app.hasPlugin(id)).to.be.true;
+      });
+
+      it('should be false for unregistered plugin', () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+
+        expect(app.hasPlugin('plugin2')).to.be.false;
+      });
+    });
+
+    describe('#isPluginActivated', () => {
+      it('should be true for activated plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+        await app.activatePlugin(id);
+        expect(app.isPluginActivated(id)).to.be.true;
+      });
+
+      it('should be false for not activated plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+        expect(app.isPluginActivated(id)).to.be.false;
+      });
+
+      it('should be false for unregistered plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+        await app.activatePlugin(id);
+        expect(app.isPluginActivated('no-registered')).to.be.false;
+      });
+    });
+
+    describe('#listPlugins', () => {
+      it('should list the registered plugin', () => {
+        const app = new Application({ shell: new Widget() });
+        const ids = ['plugin1', 'plugin2'];
+        ids.forEach(id => {
+          app.registerPlugin({
+            id,
+            activate: () => {
+              // no-op
+            }
+          });
+        });
+
+        expect(app.listPlugins()).to.deep.equal(ids);
+      });
+    });
+
+    describe('#registerPlugin', () => {
+      it('should register a plugin', () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+
+        expect(app.hasPlugin(id)).to.be.true;
+      });
+
+      it('should not register an already registered plugin', () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+
+        expect(function () {
+          app.registerPlugin({
+            id,
+            activate: () => {
+              // no-op
+            }
+          });
+        }).to.throw();
+      });
+
+      it('should not register a plugin introducing a cycle', () => {
+        const app = new Application({ shell: new Widget() });
+        const id1 = 'plugin1';
+        const token1 = new Token<any>(id1);
+        const id2 = 'plugin2';
+        const token2 = new Token<any>(id2);
+        const id3 = 'plugin3';
+        const token3 = new Token<any>(id3);
+        app.registerPlugin({
+          id: id1,
+          activate: () => {
+            // no-op
+          },
+          requires: [token3],
+          provides: token1
+        });
+        app.registerPlugin({
+          id: id2,
+          activate: () => {
+            // no-op
+          },
+          requires: [token1],
+          provides: token2
+        });
+
+        expect(function () {
+          app.registerPlugin({
+            id: id3,
+            activate: () => {
+              // no-op
+            },
+            requires: [token2],
+            provides: token3
+          });
+        }).to.throw();
+      });
+    });
+
+    describe('#unregisterPlugin', () => {
+      it('should unregistered a deactivated registered plugin', () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+
+        app.unregisterPlugin(id);
+
+        expect(app.hasPlugin(id)).to.be.false;
+      });
+
+      it('should not unregistered an activated registered plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+
+        await app.activatePlugin(id);
+
+        expect(() => {
+          app.unregisterPlugin(id);
+        }).to.throw();
+        expect(app.hasPlugin(id)).to.be.true;
+      });
+
+      it('should force unregistered an activated registered plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+
+        await app.activatePlugin(id);
+
+        app.unregisterPlugin(id, true);
+        expect(app.hasPlugin(id)).to.be.false;
+      });
+    });
+
+    describe('#activatePlugin', () => {
+      it('should activate a registered plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+        await app.activatePlugin(id);
+        expect(app.isPluginActivated(id)).to.be.true;
+      });
+
+      it('should throw an error when activating a unregistered plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+
+        try {
+          await app.activatePlugin('other-id');
+        } catch (reason) {
+          return;
+        }
+
+        expect(false, 'app.activatePlugin did not throw').to.be.true;
+      });
+
+      it('should tolerate activating an activated plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+        await app.activatePlugin(id);
+
+        await app.activatePlugin(id);
+
+        expect(app.isPluginActivated(id)).to.be.true;
+      });
+
+      it('should activate all required services', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id1 = 'plugin1';
+        const token1 = new Token<any>(id1);
+        const id2 = 'plugin2';
+        const token2 = new Token<any>(id2);
+        const id3 = 'plugin3';
+        const token3 = new Token<any>(id3);
+        app.registerPlugin({
+          id: id1,
+          activate: () => {
+            // no-op
+          },
+          provides: token1
+        });
+        app.registerPlugin({
+          id: id2,
+          activate: () => {
+            // no-op
+          },
+          requires: [token1],
+          provides: token2
+        });
+        app.registerPlugin({
+          id: id3,
+          activate: () => {
+            // no-op
+          },
+          requires: [token2],
+          provides: token3
+        });
+
+        await app.activatePlugin(id3);
+
+        expect(app.isPluginActivated(id3)).to.be.true;
+        expect(app.isPluginActivated(id1)).to.be.true;
+        expect(app.isPluginActivated(id2)).to.be.true;
+      });
+
+      it('should try activating all optional services', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id1 = 'plugin1';
+        const token1 = new Token<any>(id1);
+        const id2 = 'plugin2';
+        const token2 = new Token<any>(id2);
+        const id3 = 'plugin3';
+        const token3 = new Token<any>(id3);
+        app.registerPlugin({
+          id: id1,
+          activate: () => {
+            // no-op
+          },
+          provides: token1
+        });
+        app.registerPlugin({
+          id: id2,
+          activate: () => {
+            throw new Error(`Force failure during '${id2}' activation`);
+          },
+          provides: token2
+        });
+        app.registerPlugin({
+          id: id3,
+          activate: () => {
+            // no-op
+          },
+          optional: [token1, token2],
+          provides: token3
+        });
+
+        await app.activatePlugin(id3);
+
+        expect(app.isPluginActivated(id3)).to.be.true;
+        expect(app.isPluginActivated(id1)).to.be.true;
+        expect(app.isPluginActivated(id2)).to.be.false;
+      });
+    });
+
+    describe('#deactivatePlugin', () => {
+      it('should call deactivate on the plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        let deactivated: boolean | null = null;
+        app.registerPlugin({
+          id,
+          activate: () => {
+            deactivated = false;
+          },
+          deactivate: () => {
+            deactivated = true;
+          }
+        });
+
+        await app.activatePlugin(id);
+
+        expect(deactivated).to.be.false;
+
+        const others = await app.deactivatePlugin(id);
+
+        expect(deactivated).to.be.true;
+        expect(others.length).to.equal(0);
+      });
+
+      it('should throw an error if the plugin does not support deactivation', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          }
+        });
+
+        await app.activatePlugin(id);
+
+        try {
+          await app.deactivatePlugin(id);
+        } catch (r) {
+          return;
+        }
+
+        expect(true, 'app.deactivatePlugin did not throw').to.be.false;
+      });
+
+      it('should throw an error if the plugin has dependants not support deactivation', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id1 = 'plugin1';
+        const token1 = new Token<any>(id1);
+        const id2 = 'plugin2';
+        const token2 = new Token<any>(id2);
+        const id3 = 'plugin3';
+        const token3 = new Token<any>(id3);
+        app.registerPlugin({
+          id: id1,
+          activate: () => {
+            // no-op
+          },
+          deactivate: () => {
+            // no-op
+          },
+          provides: token1
+        });
+        app.registerPlugin({
+          id: id2,
+          activate: () => {
+            // no-op
+          },
+          deactivate: () => {
+            // no-op
+          },
+          requires: [token1],
+          provides: token2
+        });
+        app.registerPlugin({
+          id: id3,
+          activate: () => {
+            // no-op
+          },
+          requires: [token2],
+          provides: token3
+        });
+
+        await app.activatePlugin(id3);
+
+        try {
+          await app.deactivatePlugin(id1);
+        } catch (r) {
+          return;
+        }
+
+        expect(true, 'app.deactivatePlugin did not throw').to.be.false;
+      });
+
+      it('should deactivate all dependents (optional or not)', async () => {
+        const app = new Application({ shell: new Widget() });
+        let deactivated: boolean | null = null;
+        const id1 = 'plugin1';
+        const token1 = new Token<any>(id1);
+        const id2 = 'plugin2';
+        const token2 = new Token<any>(id2);
+        const id3 = 'plugin3';
+        const token3 = new Token<any>(id3);
+        app.registerPlugin({
+          id: id1,
+          activate: () => {
+            deactivated = false;
+          },
+          deactivate: () => {
+            deactivated = true;
+          },
+          provides: token1
+        });
+        app.registerPlugin({
+          id: id2,
+          activate: () => {
+            // no-op
+          },
+          deactivate: () => {
+            // no-op
+          },
+          requires: [token1],
+          provides: token2
+        });
+        app.registerPlugin({
+          id: id3,
+          activate: () => {
+            // no-op
+          },
+          deactivate: () => {
+            // no-op
+          },
+          optional: [token2],
+          provides: token3
+        });
+
+        await app.activatePlugin(id3);
+
+        const others = await app.deactivatePlugin(id1);
+
+        expect(deactivated).to.be.true;
+        expect(others).to.deep.equal([id3, id2]);
+        expect(app.isPluginActivated(id2)).to.be.false;
+        expect(app.isPluginActivated(id3)).to.be.false;
+      });
+    });
   });
 });

--- a/packages/application/tests/src/index.spec.ts
+++ b/packages/application/tests/src/index.spec.ts
@@ -187,8 +187,8 @@ describe('@lumino/application', () => {
       });
     });
 
-    describe('#unregisterPlugin', () => {
-      it('should unregistered a deactivated registered plugin', () => {
+    describe('#deregisterPlugin', () => {
+      it('should deregister a deactivated registered plugin', () => {
         const app = new Application({ shell: new Widget() });
         const id = 'plugin1';
         app.registerPlugin({
@@ -198,12 +198,12 @@ describe('@lumino/application', () => {
           }
         });
 
-        app.unregisterPlugin(id);
+        app.deregisterPlugin(id);
 
         expect(app.hasPlugin(id)).to.be.false;
       });
 
-      it('should not unregistered an activated registered plugin', async () => {
+      it('should not deregister an activated registered plugin', async () => {
         const app = new Application({ shell: new Widget() });
         const id = 'plugin1';
         app.registerPlugin({
@@ -216,12 +216,12 @@ describe('@lumino/application', () => {
         await app.activatePlugin(id);
 
         expect(() => {
-          app.unregisterPlugin(id);
+          app.deregisterPlugin(id);
         }).to.throw();
         expect(app.hasPlugin(id)).to.be.true;
       });
 
-      it('should force unregistered an activated registered plugin', async () => {
+      it('should force deregister an activated registered plugin', async () => {
         const app = new Application({ shell: new Widget() });
         const id = 'plugin1';
         app.registerPlugin({
@@ -233,7 +233,7 @@ describe('@lumino/application', () => {
 
         await app.activatePlugin(id);
 
-        app.unregisterPlugin(id, true);
+        app.deregisterPlugin(id, true);
         expect(app.hasPlugin(id)).to.be.false;
       });
     });

--- a/packages/application/tests/tsconfig.json
+++ b/packages/application/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfigbase",
   "compilerOptions": {
-    "lib": ["ES6"],
+    "lib": ["DOM", "ES6"],
     "outDir": "lib",
     "rootDir": "src",
     "types": ["chai", "mocha"]

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -79,7 +79,7 @@ export class CommandRegistry {
    * @returns A new array of the registered command ids.
    */
   listCommands(): string[] {
-    return Object.keys(this._commands);
+    return Array.from(this._commands.keys());
   }
 
   /**
@@ -90,7 +90,7 @@ export class CommandRegistry {
    * @returns `true` if the command is registered, `false` otherwise.
    */
   hasCommand(id: string): boolean {
-    return id in this._commands;
+    return this._commands.has(id);
   }
 
   /**
@@ -109,7 +109,7 @@ export class CommandRegistry {
     options: CommandRegistry.ICommandOptions
   ): IDisposable {
     // Throw an error if the id is already registered.
-    if (id in this._commands) {
+    if (this._commands.has(id)) {
       throw new Error(`Command '${id}' already registered.`);
     }
 
@@ -145,7 +145,7 @@ export class CommandRegistry {
    * This will cause the `commandChanged` signal to be emitted.
    */
   notifyCommandChanged(id?: string): void {
-    if (id !== undefined && !(id in this._commands)) {
+    if (id !== undefined && !this._commands.has(id)) {
       throw new Error(`Command '${id}' is not registered.`);
     }
     this._commandChanged.emit({ id, type: id ? 'changed' : 'many-changed' });

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -114,7 +114,7 @@ export class CommandRegistry {
     }
 
     // Add the command to the registry.
-    this._commands[id] = Private.createCommand(options);
+    this._commands.set(id, Private.createCommand(options));
 
     // Emit the `commandChanged` signal.
     this._commandChanged.emit({ id, type: 'added' });
@@ -122,7 +122,7 @@ export class CommandRegistry {
     // Return a disposable which will remove the command.
     return new DisposableDelegate(() => {
       // Remove the command from the registry.
-      delete this._commands[id];
+      this._commands.delete(id);
 
       // Emit the `commandChanged` signal.
       this._commandChanged.emit({ id, type: 'removed' });
@@ -164,7 +164,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): Promise<CommandRegistry.Description> {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return Promise.resolve(
       cmd?.describedBy.call(undefined, args) ?? { args: null }
     );
@@ -184,7 +184,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): string {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd?.label.call(undefined, args) ?? '';
   }
 
@@ -202,7 +202,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): number {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.mnemonic.call(undefined, args) : -1;
   }
 
@@ -224,7 +224,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): VirtualElement.IRenderer | undefined {
-    return this._commands[id]?.icon.call(undefined, args);
+    return this._commands.get(id)?.icon.call(undefined, args);
   }
 
   /**
@@ -241,7 +241,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): string {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.iconClass.call(undefined, args) : '';
   }
 
@@ -259,7 +259,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): string {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.iconLabel.call(undefined, args) : '';
   }
 
@@ -277,7 +277,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): string {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.caption.call(undefined, args) : '';
   }
 
@@ -295,7 +295,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): string {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.usage.call(undefined, args) : '';
   }
 
@@ -313,7 +313,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): string {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.className.call(undefined, args) : '';
   }
 
@@ -331,7 +331,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): CommandRegistry.Dataset {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.dataset.call(undefined, args) : {};
   }
 
@@ -349,7 +349,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): boolean {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.isEnabled.call(undefined, args) : false;
   }
 
@@ -367,7 +367,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): boolean {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.isToggled.call(undefined, args) : false;
   }
 
@@ -385,7 +385,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyJSONObject = JSONExt.emptyObject
   ): boolean {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.isToggleable : false;
   }
 
@@ -403,7 +403,7 @@ export class CommandRegistry {
     id: string,
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): boolean {
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     return cmd ? cmd.isVisible.call(undefined, args) : false;
   }
 
@@ -425,7 +425,7 @@ export class CommandRegistry {
     args: ReadonlyPartialJSONObject = JSONExt.emptyObject
   ): Promise<any> {
     // Reject if the command is not registered.
-    let cmd = this._commands[id];
+    let cmd = this._commands.get(id);
     if (!cmd) {
       return Promise.reject(new Error(`Command '${id}' not registered.`));
     }
@@ -649,7 +649,7 @@ export class CommandRegistry {
   private _keydownEvents: KeyboardEvent[] = [];
   private _keyBindings: CommandRegistry.IKeyBinding[] = [];
   private _exactKeyMatch: CommandRegistry.IKeyBinding | null = null;
-  private _commands: { [id: string]: Private.ICommand } = Object.create(null);
+  private _commands = new Map<string, Private.ICommand>();
   private _commandChanged = new Signal<
     this,
     CommandRegistry.ICommandChangedArgs

--- a/review/api/application.api.md
+++ b/review/api/application.api.md
@@ -19,7 +19,8 @@ export class Application<T extends Widget> {
     readonly commands: CommandRegistry;
     readonly contextMenu: ContextMenu;
     deactivatePlugin(id: string): Promise<string[]>;
-    protected evtContextMenu(event: MouseEvent): void;
+    deregisterPlugin(id: string, force?: boolean): void;
+    protected evtContextMenu(event: PointerEvent): void;
     protected evtKeydown(event: KeyboardEvent): void;
     protected evtResize(event: Event): void;
     handleEvent(event: Event): void;
@@ -33,8 +34,6 @@ export class Application<T extends Widget> {
     readonly shell: T;
     start(options?: Application.IStartOptions): Promise<void>;
     get started(): Promise<void>;
-    // (undocumented)
-    unregisterPlugin(id: string, force?: boolean): void;
 }
 
 // @public

--- a/review/api/application.api.md
+++ b/review/api/application.api.md
@@ -11,7 +11,7 @@ import { Token } from '@lumino/coreutils';
 import { Widget } from '@lumino/widgets';
 
 // @public
-export class Application<T extends Widget> {
+export class Application<T extends Widget = Widget> {
     constructor(options: Application.IOptions<T>);
     activatePlugin(id: string): Promise<void>;
     protected addEventListeners(): void;
@@ -50,7 +50,7 @@ export namespace Application {
 }
 
 // @public
-export interface IPlugin<T extends Application<Widget>, U> {
+export interface IPlugin<T extends Application, U> {
     activate: (app: T, ...args: Token<any>[]) => U | Promise<U>;
     autoStart?: boolean;
     deactivate?: ((app: T, ...args: Token<any>[]) => void | Promise<void>) | null;

--- a/review/api/application.api.md
+++ b/review/api/application.api.md
@@ -18,11 +18,13 @@ export class Application<T extends Widget> {
     protected attachShell(id: string): void;
     readonly commands: CommandRegistry;
     readonly contextMenu: ContextMenu;
+    deactivatePlugin(id: string): Promise<string[]>;
     protected evtContextMenu(event: MouseEvent): void;
     protected evtKeydown(event: KeyboardEvent): void;
     protected evtResize(event: Event): void;
     handleEvent(event: Event): void;
     hasPlugin(id: string): boolean;
+    isPluginActivated(id: string): boolean;
     listPlugins(): string[];
     registerPlugin(plugin: IPlugin<this, any>): void;
     registerPlugins(plugins: IPlugin<this, any>[]): void;
@@ -31,6 +33,8 @@ export class Application<T extends Widget> {
     readonly shell: T;
     start(options?: Application.IStartOptions): Promise<void>;
     get started(): Promise<void>;
+    // (undocumented)
+    unregisterPlugin(id: string, force?: boolean): void;
 }
 
 // @public
@@ -47,12 +51,13 @@ export namespace Application {
 }
 
 // @public
-export interface IPlugin<T, U> {
-    activate: (app: T, ...args: any[]) => U | Promise<U>;
+export interface IPlugin<T extends Application<Widget>, U> {
+    activate: (app: T, ...args: Token<any>[]) => U | Promise<U>;
     autoStart?: boolean;
+    deactivate?: ((app: T, ...args: Token<any>[]) => void | Promise<void>) | null;
     id: string;
     optional?: Token<any>[];
-    provides?: Token<U>;
+    provides?: Token<U> | null;
     requires?: Token<any>[];
 }
 


### PR DESCRIPTION
Fixes #278

## Code changes

There are three additions to the API :
- `Application.unregisterPlugin()` method to remove the plugin from the plugin map and complement the existing `registerPlugin()`
- an optional `deactivate` method which plugins may decide to implement. If it is provided, it should undo all the changes the `activate` method made, including removing the added commands, menus, etc. to complement the current [`activate()`](https://github.com/jupyterlab/lumino/blob/578509cae6af5567975a6ed2e6bc9d8a1927a078/packages/application/src/index.ts#L84-L101) method.
- `Application.deactivatePlugin` method to call the `deactivate` method on the plugin and all of it dependants

The `unregisterPlugin` signature is:

```typescript
/**
 * @param id - id of the plugin to unregister
 * @param force - whether to unregister even if active
 */
async unregisterPlugin(id: str, force?: boolean)
```

`deactivatePlugin` reject if plugin or one of its dependents does not have `deactivate()` method:

```typescript
/**
 * Will deactivate the plugin and its dependant if and only if the plugin
 * and its dependants all support `deactivate`.
 * @returns other dependant plugins deactivated as a consequence
 */
deactivatePlugin(id: string): Promise<string[]>
```

> The return object is a list of plugin ids rather than a IPlugin list to avoid security hole that returning IPlugin will open (the activate function could be altered by deactivating and reactivating a Plugin with the proposed API in #278)

It is up to plugin authors to adopt the `deactivate` method. This is a backwards-compatible change.

The signature of `deactivate` is:

```typescript
deactivate?: (app: T, ...args: any[]) => void | Promise<void>; 
```

:warning: deactivating a plugin will deactivate all its dependents optional or not. In theory, we could reactivate the one having a optional relationship. I propose to keep it like this and to let sub class application decide what to do - the rational is that we anyway have to modify some API in JupyterLab itself to support dynamic reload.

---

Side effect I replace the use of objects by mapping because deleting a object key in JS is famous to reduce performance.