### PR TITLE
Automated Changelog Entry for 2022.8.29 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2022.8.29
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/algorithm@2.0.0-alpha.1...ed506c2b38e28bae14cdc829f7606cd7aaf92907))
+
+### Enhancements made
+
+- Dynamic extensions reloading [#377](https://github.com/jupyterlab/lumino/pull/377) ([@fcollonval](https://github.com/fcollonval))
+- Fix tab trap in menubar [#373](https://github.com/jupyterlab/lumino/pull/373) ([@gabalafou](https://github.com/gabalafou))
+
+### Maintenance and upkeep improvements
+
+- Bump alpha versions [#380](https://github.com/jupyterlab/lumino/pull/380) ([@blink1073](https://github.com/blink1073))
+- Bump tj-actions/changed-files from 28 to 29.0.2 [#379](https://github.com/jupyterlab/lumino/pull/379) ([@dependabot](https://github.com/dependabot))
+- Iterate on iterators [#378](https://github.com/jupyterlab/lumino/pull/378) ([@afshin](https://github.com/afshin))
+- Deprecate `each<T>(...)` [#376](https://github.com/jupyterlab/lumino/pull/376) ([@afshin](https://github.com/afshin))
+- Bump tj-actions/changed-files from 26.1 to 28 [#372](https://github.com/jupyterlab/lumino/pull/372) ([@dependabot](https://github.com/dependabot))
+
+### Documentation improvements
+
+- Iterate on iterators [#378](https://github.com/jupyterlab/lumino/pull/378) ([@afshin](https://github.com/afshin))
+- Deprecate `each<T>(...)` [#376](https://github.com/jupyterlab/lumino/pull/376) ([@afshin](https://github.com/afshin))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-08-22&to=2022-08-29&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-08-22..2022-08-29&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2022-08-22..2022-08-29&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2022-08-22..2022-08-29&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-08-22..2022-08-29&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Agabalafou+updated%3A2022-08-22..2022-08-29&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2022.8.22-alpha.1
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/v2022.7.21...bbfb9e2c37a2cf195a990c33a0ebbb1c64e9da26))
@@ -47,8 +77,6 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-07-21&to=2022-08-22&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-07-21..2022-08-22&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2022-07-21..2022-08-22&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Abollwyvl+updated%3A2022-07-21..2022-08-22&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2022-07-21..2022-08-22&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aellisonbg+updated%3A2022-07-21..2022-08-22&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-07-21..2022-08-22&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Agabalafou+updated%3A2022-07-21..2022-08-22&type=Issues) | [@ian-r-rose](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aian-r-rose+updated%3A2022-07-21..2022-08-22&type=Issues) | [@jasongrout](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ajasongrout+updated%3A2022-07-21..2022-08-22&type=Issues) | [@jweill-aws](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ajweill-aws+updated%3A2022-07-21..2022-08-22&type=Issues) | [@SylvainCorlay](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3ASylvainCorlay+updated%3A2022-07-21..2022-08-22&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Avidartf+updated%3A2022-07-21..2022-08-22&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2022-07-21..2022-08-22&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2022.8.8
 


### PR DESCRIPTION
Automated Changelog Entry for 2022.8.29 on main
```
npm workspace versions:
@lumino/example-accordionpanel: 0.9.0-alpha.2
@lumino/example-datagrid: 0.33.0-alpha.2
@lumino/example-dockpanel: 0.22.0-alpha.2
@lumino/example-dockpanel-amd: 0.5.0-alpha.2
@lumino/example-dockpanel-iife: 0.5.0-alpha.2
@lumino/algorithm: 2.0.0-alpha.2
@lumino/application: 2.0.0-alpha.2
@lumino/collections: 2.0.0-alpha.2
@lumino/commands: 2.0.0-alpha.2
@lumino/coreutils: 2.0.0-alpha.2
@lumino/datagrid: 1.0.0-alpha.2
@lumino/default-theme: 1.0.0-alpha.2
@lumino/disposable: 2.0.0-alpha.2
@lumino/domutils: 2.0.0-alpha.2
@lumino/dragdrop: 2.0.0-alpha.2
@lumino/keyboard: 2.0.0-alpha.2
@lumino/messaging: 2.0.0-alpha.2
@lumino/polling: 2.0.0-alpha.2
@lumino/properties: 2.0.0-alpha.2
@lumino/signaling: 2.0.0-alpha.2
@lumino/virtualdom: 2.0.0-alpha.2
@lumino/widgets: 2.0.0-alpha.2
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | main  |
| Version Spec | 2022.8.29 |
| Since | @lumino/algorithm@2.0.0-alpha.1 |