### PR TITLE
Automated Changelog Entry for 2022.8.30 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2022.8.30
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/algorithm@2.0.0-alpha.2...e76aa2e8463aeae489ca79598e3dac9bb504272f))
+
+### Bugs fixed
+
+- Fix service type [#382](https://github.com/jupyterlab/lumino/pull/382) ([@afshin](https://github.com/afshin))
+
+### Maintenance and upkeep improvements
+
+- Bump packages to v2-alpha.3 [#383](https://github.com/jupyterlab/lumino/pull/383) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-08-29&to=2022-08-30&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-08-29..2022-08-30&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-08-29..2022-08-30&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2022.8.29
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/algorithm@2.0.0-alpha.1...ed506c2b38e28bae14cdc829f7606cd7aaf92907))
@@ -33,8 +53,6 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-08-22&to=2022-08-29&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-08-22..2022-08-29&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2022-08-22..2022-08-29&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2022-08-22..2022-08-29&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-08-22..2022-08-29&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Agabalafou+updated%3A2022-08-22..2022-08-29&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2022.8.22-alpha.1
 


### PR DESCRIPTION
Automated Changelog Entry for 2022.8.30 on main
```
npm workspace versions:
@lumino/example-accordionpanel: 0.9.0-alpha.3
@lumino/example-datagrid: 0.33.0-alpha.3
@lumino/example-dockpanel: 0.22.0-alpha.3
@lumino/example-dockpanel-amd: 0.5.0-alpha.3
@lumino/example-dockpanel-iife: 0.5.0-alpha.3
@lumino/algorithm: 2.0.0-alpha.3
@lumino/application: 2.0.0-alpha.3
@lumino/collections: 2.0.0-alpha.3
@lumino/commands: 2.0.0-alpha.3
@lumino/coreutils: 2.0.0-alpha.3
@lumino/datagrid: 1.0.0-alpha.3
@lumino/default-theme: 1.0.0-alpha.3
@lumino/disposable: 2.0.0-alpha.3
@lumino/domutils: 2.0.0-alpha.3
@lumino/dragdrop: 2.0.0-alpha.3
@lumino/keyboard: 2.0.0-alpha.3
@lumino/messaging: 2.0.0-alpha.3
@lumino/polling: 2.0.0-alpha.3
@lumino/properties: 2.0.0-alpha.3
@lumino/signaling: 2.0.0-alpha.3
@lumino/virtualdom: 2.0.0-alpha.3
@lumino/widgets: 2.0.0-alpha.3
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/lumino  |
| Branch  | main  |
| Version Spec | 2022.8.30 |
| Since | @lumino/algorithm@2.0.0-alpha.2 |