### PR TITLE
Make `Poll` an async iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -800,7 +800,7 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
     @lumino/example-datagrid@0.11.0
     @lumino/datagrid@0.14.0
 
-- Make private \_drawCornerHeaderRegion protected drawCornerHeaderRegion [#116](https://github.com/jupyterlab/lumino/pull/116) ([@lmcnichols](https://github.com/lmcnichols))
+- Make private \_drawCornerHeaderRegion protected drawCornerHeaderRegion [#116](https://github.com/jupyterlab/lumino/pull/116) (@lmcnichols)
 - Text eliding with ellipsis on datagrid text renderer [#105](https://github.com/jupyterlab/lumino/pull/105) ([@nmichaud](https://github.com/nmichaud))
 
 ## 2020-8-20
@@ -816,9 +816,9 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
 
 - mouseDown now uses cell, column, and row selection modes [#114](https://github.com/jupyterlab/lumino/pull/114) ([@kgoo124](https://github.com/kgoo124))
 - Double-click to edit tab title in TabBars [#112](https://github.com/jupyterlab/lumino/pull/112) ([@nmichaud](https://github.com/nmichaud))
-- Give extending classes access to some of the data grid's paint utilities. [#111](https://github.com/jupyterlab/lumino/pull/111) ([@lmcnichols](https://github.com/lmcnichols))
+- Give extending classes access to some of the data grid's paint utilities. [#111](https://github.com/jupyterlab/lumino/pull/111) (@lmcnichols)
 - Fix for DockPanel.tabsMovable to set false to all tabs [#109](https://github.com/jupyterlab/lumino/pull/109) ([@nmichaud](https://github.com/nmichaud))
-- Modified function spliceArray in datastore/src/listfield.ts so that it behaves like Array.splice on large inputs. [#101](https://github.com/jupyterlab/lumino/pull/101) ([@lmcnichols](https://github.com/lmcnichols))
+- Modified function spliceArray in datastore/src/listfield.ts so that it behaves like Array.splice on large inputs. [#101](https://github.com/jupyterlab/lumino/pull/101) (@lmcnichols)
 - Bump elliptic from 6.5.2 to 6.5.3 [#99](https://github.com/jupyterlab/lumino/pull/99) ([@dependabot](https://github.com/dependabot))
 
 ## 2020-7-27
@@ -832,7 +832,7 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
     @lumino/datagrid@0.12.0
     @lumino/application@1.10.4
 
-- Change the Drag class's private method \_moveDragImage to a public method moveDragImage. [#96](https://github.com/jupyterlab/lumino/pull/96) ([@lmcnichols](https://github.com/lmcnichols))
+- Change the Drag class's private method \_moveDragImage to a public method moveDragImage. [#96](https://github.com/jupyterlab/lumino/pull/96) (@lmcnichols)
 
 ## 2020-7-21
 
@@ -858,14 +858,14 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
     @lumino/application@1.10.3
     @lumino/algorithm@1.3.3
 
-- Have the DataGrid syncViewport when receiving a DataModel.ChangedArgs signal of type "rows-moved" or "columns-moved" [#94](https://github.com/jupyterlab/lumino/pull/94) ([@lmcnichols](https://github.com/lmcnichols))
+- Have the DataGrid syncViewport when receiving a DataModel.ChangedArgs signal of type "rows-moved" or "columns-moved" [#94](https://github.com/jupyterlab/lumino/pull/94) (@lmcnichols)
 
 ## 2020-7-21
 
     @lumino/example-datagrid@0.8.0
     @lumino/datagrid@0.11.0
 
-- Make cursorForHandle and it's argument type accessible from outside BasicMouseHandler. [#92](https://github.com/jupyterlab/lumino/pull/92) ([@lmcnichols](https://github.com/lmcnichols))
+- Make cursorForHandle and it's argument type accessible from outside BasicMouseHandler. [#92](https://github.com/jupyterlab/lumino/pull/92) (@lmcnichols)
 - Bump lodash from 4.17.15 to 4.17.19 [#90](https://github.com/jupyterlab/lumino/pull/90) ([@dependabot](https://github.com/dependabot))
 
 ## 2020-7-5

--- a/packages/polling/README.md
+++ b/packages/polling/README.md
@@ -1,0 +1,123 @@
+# @lumino/polling
+
+This package provides a class for generic polling functionality (`Poll`). It
+also provides rate limiters (`Debouncer` and `Throttler`).
+
+The `Poll` class provides three different ways to "subscribe" to poll ticks:
+
+- [`@lumino/signaling`](../signaling/): `Poll#ticked` is a Lumino signal that
+  emits each time there is a poll tick.
+- `Promise`-based: `Poll#tick` is a promise that resolves after every tick and
+  only rejects when the poll is disposed.
+- `AsyncIterable`: `Poll#[`Symbol.asyncIterator`]` implements the async iterable
+  protocol that allows iteration using [`for-await...of`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loops.
+
+## Example usage
+
+These are examples from the unit tests for this package. They
+demonstrate the three different ways polling is supported.
+
+### Using `Poll#tick` promise
+
+Here, we set up the testing state variables and create a new `Poll` instance.
+
+```typescript
+const expected = 'started resolved resolved';
+const ticker: IPoll.Phase<any>[] = [];
+const tock = (poll: Poll) => {
+  ticker.push(poll.state.phase);
+  poll.tick.then(tock).catch(() => undefined);
+};
+const poll = new Poll({
+  auto: false,
+  factory: () => Promise.resolve(),
+  frequency: { interval: 100, backoff: false }
+});
+```
+
+Next we assign the `tock` function to run after the poll ticks and
+we start the poll.
+
+```typescript
+void poll.tick.then(tock);
+void poll.start();
+```
+
+And we verify that the `ticker` did indeed get populated when `tock`
+was called and the next promise was captured as well.
+
+```typescript
+await sleep(1000); // Sleep for longer than the interval.
+expect(ticker.join(' ').startsWith(expected)).to.equal(true);
+poll.dispose();
+```
+
+### Using `Poll#ticked` signal
+
+Here, we set up the testing state variables and create a new `Poll` instance.
+
+```typescript
+const poll = new Poll<void, void>({
+  factory: () => Promise.resolve(),
+  frequency: { interval: 100, backoff: false }
+});
+```
+
+Here we connect to the `ticked` signal and simply check that each
+tick matches the poll `state` accessor's contents.
+
+```typescript
+poll.ticked.connect((_, tick) => {
+  expect(tick).to.equal(poll.state);
+});
+await sleep(1000); // Sleep for longer than the interval.
+poll.dispose();
+```
+
+### Using `Poll` as an `AsyncIterable`
+
+Here, we set up the testing state variables and create a new `Poll` instance.
+
+```typescript
+let poll: Poll;
+let total = 2;
+let i = 0;
+
+poll = new Poll({
+  auto: false,
+  factory: () => Promise.resolve(++i > total ? poll.dispose() : void 0),
+  frequency: { interval: Poll.IMMEDIATE }
+});
+
+const expected = `started ${'resolved '.repeat(total)}disposed`;
+const ticker: IPoll.Phase<any>[] = [];
+```
+
+Then the poll is started:
+
+```typescript
+void poll.start();
+```
+
+Instead of connecting to the `ticked` signal or awaiting the `tick` promise, we can now use a `for-await...of` loop:
+
+```typescript
+for await (const state of poll) {
+  ticker.push(state.phase);
+  if (poll.isDisposed) {
+    break;
+  }
+}
+```
+
+And we check to make sure the results are as expected:
+
+```typescript
+// ticker and expected both equal:
+// 'started resolved resolved disposed'
+expect(ticker.join(' ')).to.equal(expected);
+```
+
+### Note for consumers of async iterators
+
+The `Poll` class itself only uses `ES6` (and `DOM`) types in its `lib` collection **but** in order to use `for-await...of` loops in TypeScript, you will need to use `ES2018` or above in your `lib` array in `tsconfig.json`.

--- a/packages/polling/README.md
+++ b/packages/polling/README.md
@@ -89,7 +89,7 @@ poll = new Poll({
   frequency: { interval: Poll.IMMEDIATE }
 });
 
-const expected = `started ${'resolved '.repeat(total)}disposed`;
+const expected = `started${' resolved'.repeat(total)}`;
 const ticker: IPoll.Phase<any>[] = [];
 ```
 

--- a/packages/polling/src/index.ts
+++ b/packages/polling/src/index.ts
@@ -18,7 +18,8 @@ export { Debouncer, RateLimiter, Throttler } from './ratelimiter';
  *
  * @typeparam V - The type to extend the phases supported by a poll.
  */
-export interface IPoll<T, U, V extends string> {
+export interface IPoll<T, U, V extends string>
+  extends AsyncIterable<IPoll.State<T, U, V>> {
   /**
    * A signal emitted when the poll is disposed.
    */
@@ -49,8 +50,8 @@ export interface IPoll<T, U, V extends string> {
    *
    * #### Notes
    * Usually this will resolve after `state.interval` milliseconds from
-   * `state.timestamp`. It can resolve earlier if the user starts or refreshes the
-   * poll, etc.
+   * `state.timestamp`. It can resolve earlier if the user starts or refreshes
+   * the poll, etc.
    */
   readonly tick: Promise<IPoll<T, U, V>>;
 

--- a/packages/polling/src/poll.ts
+++ b/packages/polling/src/poll.ts
@@ -157,10 +157,9 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
    * Return an async iterator that yields every tick.
    */
   async *[Symbol.asyncIterator](): AsyncIterableIterator<IPoll.State<T, U, V>> {
-    yield this.state;
     while (!this.isDisposed) {
-      await this.tick.catch(() => undefined);
       yield this.state;
+      await this.tick.catch(() => undefined);
     }
   }
 

--- a/packages/polling/src/poll.ts
+++ b/packages/polling/src/poll.ts
@@ -154,6 +154,17 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
   }
 
   /**
+   * Return an async iterator that yields every tick.
+   */
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<IPoll.State<T, U, V>> {
+    yield this.state;
+    while (!this.isDisposed) {
+      await this.tick.catch(() => undefined);
+      yield this.state;
+    }
+  }
+
+  /**
    * Dispose the poll.
    */
   dispose(): void {

--- a/packages/polling/tests/src/poll.spec.ts
+++ b/packages/polling/tests/src/poll.spec.ts
@@ -238,8 +238,8 @@ describe('Poll', () => {
       expect(ticker.join(' ')).to.equal(expected);
     });
 
-    it('should yield disposal', async () => {
-      const total = 2;
+    it('should yield until disposed', async () => {
+      const total = 7;
       let i = 0;
       poll = new Poll({
         auto: false,
@@ -247,7 +247,7 @@ describe('Poll', () => {
         frequency: { interval: Poll.IMMEDIATE },
         name: '@lumino/polling:Poll#[Symbol.asyncIterator]-3'
       });
-      const expected = `started ${'resolved '.repeat(total)}disposed`;
+      const expected = `started${' resolved'.repeat(total)}`;
       const ticker: IPoll.Phase<any>[] = [];
       void poll.start();
       for await (const state of poll) {
@@ -256,6 +256,7 @@ describe('Poll', () => {
           break;
         }
       }
+      expect(poll.state.phase).to.equal('disposed');
       expect(ticker.join(' ')).to.equal(expected);
     });
   });

--- a/packages/polling/tests/src/poll.spec.ts
+++ b/packages/polling/tests/src/poll.spec.ts
@@ -256,7 +256,6 @@ describe('Poll', () => {
           break;
         }
       }
-      expect(poll.state.phase).to.equal('disposed');
       expect(ticker.join(' ')).to.equal(expected);
     });
   });

--- a/packages/polling/tests/tsconfig.json
+++ b/packages/polling/tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfigbase",
   "compilerOptions": {
-    "lib": ["DOM", "ES6"],
+    "lib": ["DOM", "ES2018"],
     "outDir": "lib",
     "rootDir": "src",
     "types": ["chai", "mocha"]

--- a/review/api/polling.api.md
+++ b/review/api/polling.api.md
@@ -15,7 +15,7 @@ export class Debouncer<T = any, U = any, V extends any[] = any[]> extends RateLi
 }
 
 // @public
-export interface IPoll<T, U, V extends string> {
+export interface IPoll<T, U, V extends string> extends AsyncIterable<IPoll.State<T, U, V>> {
     readonly disposed: ISignal<this, void>;
     readonly frequency: IPoll.Frequency;
     readonly isDisposed: boolean;
@@ -50,6 +50,7 @@ export interface IRateLimiter<T = any, U = any, V extends any[] = any[]> extends
 
 // @public
 export class Poll<T = any, U = any, V extends string = 'standby'> implements IObservableDisposable, IPoll<T, U, V> {
+    [Symbol.asyncIterator](): AsyncIterableIterator<IPoll.State<T, U, V>>;
     constructor(options: Poll.IOptions<T, U, V>);
     dispose(): void;
     get disposed(): ISignal<this, void>;


### PR DESCRIPTION
In this PR, the `IPoll` interface and the `Poll` class extend `AsyncIterable` (by implementing a [`Symbol.asyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) method) to support [`for-await...of`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of) loops.

This PR also adds a `README.md` file for the `@lumino/polling` package.

This functionality may be a natural fit for streams of events from the new [Jupyter event system](https://github.com/jupyter-server/jupyter_server/issues/780), other `WebSocket` connections, or other stream sources.

cc: @Zsailer @andrii-i @davidbrochart @3coins @vidartf (since you all have some interest in events and/or iterators)

---

### Example usage
The tests in this PR are illustrative. Here is one of them with some annotation:

Here, we set up the testing state variables and create a new `Poll` instance.
```typescript
const total = 2;
let i = 0;
poll = new Poll({
  auto: false,
  factory: () => Promise.resolve(++i > total ? poll.dispose() : void 0),
  frequency: { interval: Poll.IMMEDIATE },
  name: '@lumino/polling:Poll#[Symbol.asyncIterator]-3'
});
const expected = `started ${'resolved '.repeat(total)}disposed`;
const ticker: IPoll.Phase<any>[] = [];
```
Then the poll is started:
```typescript
void poll.start();
```
Instead of connecting to the `ticked` signal or awaiting the `tick` promise, we can now use a `for-await...of` loop:
```typescript
for await (const state of poll) {
  ticker.push(state.phase);
  if (poll.isDisposed) {
    break;
  }
}
```
And we check to make sure the results are as expected:
```typescript
// ticker and expected are both: 'started resolved resolved disposed'
expect(ticker.join(' ')).to.equal(expected);
```
### Note for consumers of async iterators
The `Poll` class itself only uses `ES6` (and `DOM`) types in its `lib` collection **but** in order to use `for-await...of` loops in TypeScript, you will need to use `ES2018` or above in your `lib` array in `tsconfig.json`.

---

Fixes #385 
cf. partially addresses https://github.com/jupyterlab/lumino/issues/339