### PR TITLE
Use `pull_request_target` to have write access on fork

### DIFF
--- a/.github/workflows/enforce-label.yml
+++ b/.github/workflows/enforce-label.yml
@@ -1,7 +1,7 @@
 name: Enforce PR label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled, opened, edited, synchronize]
 jobs:
   enforce-label:

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -1,7 +1,7 @@
 name: Fix License Headers
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: write


### PR DESCRIPTION
Write permission cannot be granted to `pull_request` event from forks.

This uses `pull_request_target` to fix the CI jobs.

See [documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)