### PR TITLE
Fix bug that prevents any startup plugins from activating

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -855,7 +855,7 @@ namespace Private {
     const collection = new Map<string, boolean>();
 
     // Collect the auto-start plugins.
-    for (const id in plugins) {
+    for (const [id] of plugins) {
       if (plugins.get(id)!.autoStart) {
         collection.set(id, true);
       }

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -855,7 +855,7 @@ namespace Private {
     const collection = new Map<string, boolean>();
 
     // Collect the auto-start plugins.
-    for (const [id] of plugins) {
+    for (const id of plugins.keys()) {
       if (plugins.get(id)!.autoStart) {
         collection.set(id, true);
       }

--- a/packages/application/tests/src/index.spec.ts
+++ b/packages/application/tests/src/index.spec.ts
@@ -72,6 +72,20 @@ describe('@lumino/application', () => {
         expect(app.isPluginActivated(id)).to.be.true;
       });
 
+      it('should be true for an autoStart plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          },
+          autoStart: true
+        });
+        await app.start();
+        expect(app.isPluginActivated(id)).to.be.true;
+      });
+
       it('should be false for not activated plugin', async () => {
         const app = new Application({ shell: new Widget() });
         const id = 'plugin1';


### PR DESCRIPTION
This  makes the current version of `@lumino/application` unusable.