### PR TITLE
Improve datagrid performance

### DIFF
--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -30,12 +30,30 @@ import { getKeyboardLayout } from '@lumino/keyboard';
 import '../style/index.css';
 
 class MergedCellModel extends DataModel {
+  constructor() {
+    super();
+
+    // Initializing the body groups
+    for (
+      let r = 0, c = 0;
+      r < this.rowCount('body') && c < this.columnCount('body');
+      r += 3, c += 3
+    ) {
+      this.bodyGroups.push({ r1: r, c1: c, r2: r + 2, c2: c + 2 });
+    }
+
+    // Initializing the row-header groups
+    for (let r = 0; r < this.rowCount('body'); r += 2) {
+      this.rowHeaderGroups.push({ r1: r, c1: 0, r2: r + 1, c2: 1 });
+    }
+  }
+
   rowCount(region: DataModel.RowRegion): number {
-    return region === 'body' ? 20 : 3;
+    return region === 'body' ? 500 : 3;
   }
 
   columnCount(region: DataModel.ColumnRegion): number {
-    return region === 'body' ? 6 : 3;
+    return region === 'body' ? 500 : 3;
   }
 
   data(region: DataModel.CellRegion, row: number, column: number): any {
@@ -53,11 +71,11 @@ class MergedCellModel extends DataModel {
 
   groupCount(region: DataModel.RowRegion): number {
     if (region === 'body') {
-      return 3;
+      return this.bodyGroups.length;
     } else if (region === 'column-header') {
       return 1;
     } else if (region === 'row-header') {
-      return 2;
+      return this.rowHeaderGroups.length;
     } else if (region === 'corner-header') {
       return 1;
     }
@@ -66,11 +84,7 @@ class MergedCellModel extends DataModel {
 
   group(region: DataModel.CellRegion, groupIndex: number): CellGroup | null {
     if (region === 'body') {
-      return [
-        { r1: 1, c1: 1, r2: 2, c2: 2 },
-        { r1: 5, c1: 1, r2: 5, c2: 2 },
-        { r1: 3, c1: 5, r2: 4, c2: 5 }
-      ][groupIndex];
+      return this.bodyGroups[groupIndex];
     }
 
     if (region === 'column-header') {
@@ -78,10 +92,7 @@ class MergedCellModel extends DataModel {
     }
 
     if (region === 'row-header') {
-      return [
-        { r1: 0, c1: 0, r2: 1, c2: 1 },
-        { r1: 4, c1: 0, r2: 5, c2: 0 }
-      ][groupIndex];
+      return this.rowHeaderGroups[groupIndex];
     }
 
     if (region === 'corner-header') {
@@ -90,6 +101,9 @@ class MergedCellModel extends DataModel {
 
     return null;
   }
+
+  rowHeaderGroups: CellGroup[] = [];
+  bodyGroups: CellGroup[] = [];
 }
 
 class LargeDataModel extends DataModel {

--- a/packages/datagrid/src/cellgroup.ts
+++ b/packages/datagrid/src/cellgroup.ts
@@ -23,34 +23,6 @@ export interface CellGroup {
  * A collection of helper functions relating to merged cell groups
  */
 export namespace CellGroup {
-  export function areCellsMerged(
-    dataModel: DataModel,
-    rgn: DataModel.CellRegion,
-    cell1: number[],
-    cell2: number[]
-  ): boolean {
-    const numGroups = dataModel.groupCount(rgn);
-    const [row1, column1] = cell1;
-    const [row2, column2] = cell2;
-
-    for (let i = 0; i < numGroups; i++) {
-      const group = dataModel.group(rgn, i)!;
-      if (
-        row1 >= group.r1 &&
-        row1 <= group.r2 &&
-        column1 >= group.c1 &&
-        column1 <= group.c2 &&
-        row2 >= group.r1 &&
-        row2 <= group.r2 &&
-        column2 >= group.c1 &&
-        column2 <= group.c2
-      ) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   /**
    * Checks if two cell-groups are intersecting
    * in the given axis.

--- a/packages/datagrid/src/cellgroup.ts
+++ b/packages/datagrid/src/cellgroup.ts
@@ -272,29 +272,6 @@ export namespace CellGroup {
   }
 
   /**
-   * Checks if cell group 1 is above cell group 2.
-   * @param group1 cell group 1.
-   * @param group2 cell group 2.
-   * @returns boolean.
-   */
-  export function isCellGroupAbove(
-    group1: CellGroup,
-    group2: CellGroup
-  ): boolean {
-    return group2.r2 >= group1.r1;
-  }
-
-  /**
-   * Checks if cell group 1 is below cell group 2.
-   */
-  export function isCellGroupBelow(
-    group1: CellGroup,
-    group2: CellGroup
-  ): boolean {
-    return group2.r1 <= group1.r2;
-  }
-
-  /**
    * Merges a target cell group with any cell groups
    * it intersects with at a given row or column.
    * @param dataModel data model of the grid.

--- a/packages/datagrid/src/cellgroup.ts
+++ b/packages/datagrid/src/cellgroup.ts
@@ -4,7 +4,6 @@
  */
 
 import { DataModel } from './datamodel';
-import { SectionList } from './sectionlist';
 
 /**
  * An interface describing a merged cell group.
@@ -50,78 +49,6 @@ export namespace CellGroup {
       }
     }
     return false;
-  }
-
-  /**
-   * Calculates the cell boundary offsets needed for
-   * a row or column at the given index by taking
-   * into account merged cell groups in the region.
-   * @param dataModel
-   * @param regions
-   * @param axis
-   * @param sectionList
-   * @param index
-   */
-  export function calculateMergeOffsets(
-    dataModel: DataModel,
-    regions: DataModel.CellRegion[],
-    axis: 'row' | 'column',
-    sectionList: SectionList,
-    index: number
-  ): [number, number, CellGroup] {
-    let mergeStartOffset = 0;
-    let mergeEndOffset = 0;
-    let mergedCellGroups: CellGroup[] = [];
-
-    for (const region of regions) {
-      mergedCellGroups = mergedCellGroups.concat(
-        getCellGroupsAtRegion(dataModel, region)
-      );
-    }
-
-    let groupsAtAxis: CellGroup[] = [];
-
-    if (axis === 'row') {
-      for (const region of regions) {
-        groupsAtAxis = groupsAtAxis.concat(
-          getCellGroupsAtRow(dataModel, region, index)
-        );
-      }
-    } else {
-      for (const region of regions) {
-        groupsAtAxis = groupsAtAxis.concat(
-          getCellGroupsAtColumn(dataModel, region, index)
-        );
-      }
-    }
-
-    if (groupsAtAxis.length === 0) {
-      return [0, 0, { r1: -1, r2: -1, c1: -1, c2: -1 }];
-    }
-
-    let joinedGroup = groupsAtAxis[0];
-
-    for (let g = 0; g < mergedCellGroups.length; g++) {
-      const group = mergedCellGroups[g];
-      if (areCellGroupsIntersectingAtAxis(joinedGroup, group, axis)) {
-        joinedGroup = joinCellGroups([group, joinedGroup]);
-        mergedCellGroups.splice(g, 1);
-        g = 0;
-      }
-    }
-
-    let minRow = joinedGroup.r1;
-    let maxRow = joinedGroup.r2;
-
-    for (let r = index - 1; r >= minRow; r--) {
-      mergeStartOffset += sectionList.sizeOf(r);
-    }
-
-    for (let r = index + 1; r <= maxRow; r++) {
-      mergeEndOffset += sectionList.sizeOf(r);
-    }
-
-    return [mergeStartOffset, mergeEndOffset, joinedGroup];
   }
 
   /**

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3275,8 +3275,6 @@ export class DataGrid extends Widget {
       };
 
       let backgroundColor = undefined;
-      let horizontalColor = undefined;
-      let verticalColor = undefined;
 
       switch (rgn) {
         case 'body':
@@ -3286,10 +3284,6 @@ export class DataGrid extends Widget {
           paintRgn.yMax = this.headerHeight + this.bodyHeight;
 
           backgroundColor = this._style.backgroundColor;
-          horizontalColor =
-            this._style.horizontalGridLineColor || this._style.gridLineColor;
-          verticalColor =
-            this._style.verticalGridLineColor || this._style.gridLineColor;
           break;
         case 'row-header':
           paintRgn.xMin = 0;
@@ -3298,21 +3292,13 @@ export class DataGrid extends Widget {
           paintRgn.yMax = this.headerHeight + this.bodyHeight;
 
           backgroundColor = this._style.headerBackgroundColor;
-          horizontalColor =
-            this._style.headerHorizontalGridLineColor ||
-            this._style.headerGridLineColor;
-          verticalColor =
-            this._style.headerVerticalGridLineColor ||
-            this._style.headerGridLineColor;
           break;
       }
 
       this._paintMergedCells(
         cellGroups,
         paintRgn as Private.PaintRegion,
-        backgroundColor,
-        horizontalColor,
-        verticalColor
+        backgroundColor
       );
     }
 
@@ -3448,8 +3434,6 @@ export class DataGrid extends Widget {
       };
 
       let backgroundColor = undefined;
-      let horizontalColor = undefined;
-      let verticalColor = undefined;
 
       switch (rgn) {
         case 'body':
@@ -3459,10 +3443,6 @@ export class DataGrid extends Widget {
           paintRgn.yMax = this.headerHeight + this.bodyHeight;
 
           backgroundColor = this._style.backgroundColor;
-          horizontalColor =
-            this._style.horizontalGridLineColor || this._style.gridLineColor;
-          verticalColor =
-            this._style.verticalGridLineColor || this._style.gridLineColor;
           break;
         case 'column-header':
           paintRgn.xMin = this.headerWidth;
@@ -3471,21 +3451,13 @@ export class DataGrid extends Widget {
           paintRgn.yMax = this.headerHeight;
 
           backgroundColor = this._style.headerBackgroundColor;
-          horizontalColor =
-            this._style.headerHorizontalGridLineColor ||
-            this._style.headerGridLineColor;
-          verticalColor =
-            this._style.headerVerticalGridLineColor ||
-            this._style.headerGridLineColor;
           break;
       }
 
       this._paintMergedCells(
         cellGroups,
         paintRgn as Private.PaintRegion,
-        backgroundColor,
-        horizontalColor,
-        verticalColor
+        backgroundColor
       );
     }
 
@@ -3617,11 +3589,7 @@ export class DataGrid extends Widget {
       this._paintMergedCells(
         cellGroups,
         paintRgn as Private.PaintRegion,
-        this._style.headerBackgroundColor,
-        this._style.headerHorizontalGridLineColor ||
-          this._style.headerGridLineColor,
-        this._style.headerVerticalGridLineColor ||
-          this._style.headerGridLineColor
+        this._style.headerBackgroundColor
       );
     }
 
@@ -3756,11 +3724,7 @@ export class DataGrid extends Widget {
       this._paintMergedCells(
         cellGroups,
         paintRgn as Private.PaintRegion,
-        this._style.headerBackgroundColor,
-        this._style.headerHorizontalGridLineColor ||
-          this._style.headerGridLineColor,
-        this._style.headerVerticalGridLineColor ||
-          this._style.headerGridLineColor
+        this._style.headerBackgroundColor
       );
     }
 
@@ -4313,9 +4277,7 @@ export class DataGrid extends Widget {
     this._paintMergedCells(
       cellGroups,
       rgn,
-      this._style.backgroundColor,
-      this._style.horizontalGridLineColor || this._style.gridLineColor,
-      this._style.verticalGridLineColor || this._style.gridLineColor
+      this._style.backgroundColor
     );
   }
 
@@ -4465,10 +4427,7 @@ export class DataGrid extends Widget {
     this._paintMergedCells(
       cellGroups,
       rgn,
-      this._style.headerBackgroundColor,
-      this._style.headerHorizontalGridLineColor ||
-        this._style.headerGridLineColor,
-      this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
+      this._style.headerBackgroundColor
     );
   }
 
@@ -4618,10 +4577,7 @@ export class DataGrid extends Widget {
     this._paintMergedCells(
       cellGroups,
       rgn,
-      this._style.headerBackgroundColor,
-      this._style.headerHorizontalGridLineColor ||
-        this._style.headerGridLineColor,
-      this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
+      this._style.headerBackgroundColor
     );
   }
 
@@ -4755,10 +4711,7 @@ export class DataGrid extends Widget {
     this._paintMergedCells(
       cellGroups,
       rgn,
-      this._style.headerBackgroundColor,
-      this._style.headerHorizontalGridLineColor ||
-        this._style.headerGridLineColor,
-      this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
+      this._style.headerBackgroundColor
     );
   }
 
@@ -5070,9 +5023,7 @@ export class DataGrid extends Widget {
   private _paintMergedCells(
     cellGroups: CellGroup[],
     rgn: Private.PaintRegion,
-    backgroundColor: string | undefined,
-    verticalColor: string | undefined,
-    horizontalColor: string | undefined
+    backgroundColor: string | undefined
   ): void {
     // Bail if there is no data model.
     if (!this._dataModel) {
@@ -5176,12 +5127,16 @@ export class DataGrid extends Widget {
       config.metadata = metadata;
 
       // Compute the actual X bounds for the cell.
-      let x1 = Math.max(rgn.xMin, x);
-      let x2 = Math.min(x + width - 1, rgn.xMax);
+      const x1 = Math.max(rgn.xMin, x);
+      const x2 = Math.min(x + width - 2, rgn.xMax);
 
       // Compute the actual Y bounds for the cell.
-      let y1 = Math.max(rgn.yMin, y);
-      let y2 = Math.min(y + height - 1, rgn.yMax);
+      const y1 = Math.max(rgn.yMin, y);
+      const y2 = Math.min(y + height - 2, rgn.yMax);
+
+      if (x2 <= x1 || y2 <= y1) {
+        continue;
+      }
 
       // Draw the background.
       if (backgroundColor) {
@@ -5208,38 +5163,6 @@ export class DataGrid extends Widget {
       gc.restore();
 
       this._blitContent(this._buffer, x1, y1, x2 - x1 + 1, y2 - y1 + 1, x1, y1);
-
-      if (verticalColor) {
-        // Begin the path for the grid lines.
-        this._canvasGC.beginPath();
-
-        // Why do we not need this?
-        // this._canvasGC.moveTo(x1, y1);
-        // this._canvasGC.lineTo(x1, y2);
-
-        this._canvasGC.moveTo(x2 + 0.5, y1);
-        this._canvasGC.lineTo(x2 + 0.5, y2 + 1);
-
-        // Stroke the lines with the specified color.
-        this._canvasGC.strokeStyle = verticalColor;
-        this._canvasGC.stroke();
-      }
-
-      if (horizontalColor) {
-        // Begin the path for the grid lines.
-        this._canvasGC.beginPath();
-
-        // Why do we not need this?
-        // this._canvasGC.moveTo(x1, y1);
-        // this._canvasGC.lineTo(x2, y1);
-
-        this._canvasGC.moveTo(x1, y2 + 0.5);
-        this._canvasGC.lineTo(x2 + 1, y2 + 0.5);
-
-        // Stroke the lines with the specified color.
-        this._canvasGC.strokeStyle = horizontalColor;
-        this._canvasGC.stroke();
-      }
     }
 
     // Dispose of the wrapped gc.
@@ -5262,7 +5185,8 @@ export class DataGrid extends Widget {
     }
 
     // Compute the X bounds for the horizontal lines.
-    let x1 = Math.max(rgn.xMin, rgn.x);
+    const x1 = Math.max(rgn.xMin, rgn.x);
+    const x2 = Math.min(rgn.x + rgn.width, rgn.xMax + 1);
 
     // Begin the path for the grid lines.
     this._canvasGC.beginPath();
@@ -5271,8 +5195,8 @@ export class DataGrid extends Widget {
     this._canvasGC.lineWidth = 1;
 
     // Fetch the geometry.
-    let bh = this.bodyHeight;
-    let ph = this.pageHeight;
+    const bh = this.bodyHeight;
+    const ph = this.pageHeight;
 
     // Fetch the number of grid lines to be drawn.
     let n = rgn.rowSizes.length;
@@ -5299,7 +5223,6 @@ export class DataGrid extends Widget {
 
       // Draw the line if it's in range of the dirty rect.
       if (pos >= rgn.yMin && pos <= rgn.yMax) {
-        const x2 = Math.min(rgn.x + rgn.width, rgn.xMax + 1);
         this._canvasGC.moveTo(x1, pos + 0.5);
         this._canvasGC.lineTo(x2, pos + 0.5);
       }
@@ -5326,7 +5249,8 @@ export class DataGrid extends Widget {
     }
 
     // Compute the Y bounds for the vertical lines.
-    let y1 = Math.max(rgn.yMin, rgn.y);
+    const y1 = Math.max(rgn.yMin, rgn.y);
+    const y2 = Math.min(rgn.y + rgn.height, rgn.yMax + 1);
 
     // Begin the path for the grid lines
     this._canvasGC.beginPath();
@@ -5335,8 +5259,8 @@ export class DataGrid extends Widget {
     this._canvasGC.lineWidth = 1;
 
     // Fetch the geometry.
-    let bw = this.bodyWidth;
-    let pw = this.pageWidth;
+    const bw = this.bodyWidth;
+    const pw = this.pageWidth;
 
     // Fetch the number of grid lines to be drawn.
     let n = rgn.columnSizes.length;
@@ -5363,7 +5287,6 @@ export class DataGrid extends Widget {
 
       // Draw the line if it's in range of the dirty rect.
       if (pos >= rgn.xMin && pos <= rgn.xMax) {
-        let y2 = Math.min(rgn.y + rgn.height, rgn.yMax + 1);
         this._canvasGC.moveTo(pos + 0.5, y1);
         this._canvasGC.lineTo(pos + 0.5, y2);
       }

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3833,7 +3833,8 @@ export class DataGrid extends Widget {
         // Otherwise it will be cut in two by the valid content, and drawn incorrectly
         for (const rgn of ['body', 'row-header'] as DataModel.CellRegion[]) {
           const cellgroups = CellGroup.getCellGroupsAtRegion(
-            this.dataModel, rgn
+            this.dataModel,
+            rgn
           );
 
           let paintRgn = {

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3293,11 +3293,7 @@ export class DataGrid extends Widget {
           break;
       }
 
-      this._paintMergedCells(
-        cellGroups,
-        paintRgn,
-        backgroundColor
-      );
+      this._paintMergedCells(cellGroups, paintRgn, backgroundColor);
     }
 
     // Paint the overlay.
@@ -3450,11 +3446,7 @@ export class DataGrid extends Widget {
           break;
       }
 
-      this._paintMergedCells(
-        cellGroups,
-        paintRgn,
-        backgroundColor
-      );
+      this._paintMergedCells(cellGroups, paintRgn, backgroundColor);
     }
 
     // Paint the overlay.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -4274,11 +4274,7 @@ export class DataGrid extends Widget {
     });
 
     // Draw merged cells
-    this._paintMergedCells(
-      cellGroups,
-      rgn,
-      this._style.backgroundColor
-    );
+    this._paintMergedCells(cellGroups, rgn, this._style.backgroundColor);
   }
 
   /**
@@ -4424,11 +4420,7 @@ export class DataGrid extends Widget {
     });
 
     // Draw merged cells
-    this._paintMergedCells(
-      cellGroups,
-      rgn,
-      this._style.headerBackgroundColor
-    );
+    this._paintMergedCells(cellGroups, rgn, this._style.headerBackgroundColor);
   }
 
   /**
@@ -4574,11 +4566,7 @@ export class DataGrid extends Widget {
     });
 
     // Draw merged cells
-    this._paintMergedCells(
-      cellGroups,
-      rgn,
-      this._style.headerBackgroundColor
-    );
+    this._paintMergedCells(cellGroups, rgn, this._style.headerBackgroundColor);
   }
 
   /**
@@ -4708,11 +4696,7 @@ export class DataGrid extends Widget {
     });
 
     // Draw merged cells
-    this._paintMergedCells(
-      cellGroups,
-      rgn,
-      this._style.headerBackgroundColor
-    );
+    this._paintMergedCells(cellGroups, rgn, this._style.headerBackgroundColor);
   }
 
   /**

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3382,27 +3382,39 @@ export class DataGrid extends Widget {
         yMax: 0
       };
 
+      let backgroundColor = undefined;
+      let horizontalColor = undefined;
+      let verticalColor = undefined;
+
       switch (rgn) {
         case 'body':
           paintRgn.xMin = this.headerWidth;
           paintRgn.xMax = this.headerWidth + this.bodyWidth;
           paintRgn.yMin = this.headerHeight;
           paintRgn.yMax = this.headerHeight + this.bodyHeight;
+
+          backgroundColor = this._style.backgroundColor;
+          horizontalColor = this._style.horizontalGridLineColor || this._style.gridLineColor;
+          verticalColor = this._style.verticalGridLineColor || this._style.gridLineColor;
           break;
         case 'column-header':
           paintRgn.xMin = this.headerWidth;
           paintRgn.xMax = this.headerWidth + this.bodyWidth;
           paintRgn.yMin = 0;
           paintRgn.yMax = this.headerHeight;
+
+          backgroundColor = this._style.headerBackgroundColor;
+          horizontalColor = this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor;
+          verticalColor = this._style.headerVerticalGridLineColor || this._style.headerGridLineColor;
           break;
       }
 
       this._paintMergedCells(
         cellGroups,
         paintRgn as Private.PaintRegion,
-        this._style.backgroundColor,
-        this._style.horizontalGridLineColor || this._style.gridLineColor,
-        this._style.verticalGridLineColor || this._style.gridLineColor
+        backgroundColor,
+        horizontalColor,
+        verticalColor
       );
     }
 

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3264,8 +3264,6 @@ export class DataGrid extends Widget {
         index
       );
 
-      // TODO We're not creating a fully implemented paint-region,
-      // We probably need another type
       let paintRgn = {
         region: rgn,
         xMin: 0,
@@ -3297,7 +3295,7 @@ export class DataGrid extends Widget {
 
       this._paintMergedCells(
         cellGroups,
-        paintRgn as Private.PaintRegion,
+        paintRgn,
         backgroundColor
       );
     }
@@ -3423,8 +3421,6 @@ export class DataGrid extends Widget {
         index
       );
 
-      // TODO We're not creating a fully implemented paint-region,
-      // We probably need another type
       let paintRgn = {
         region: rgn,
         xMin: 0,
@@ -3456,7 +3452,7 @@ export class DataGrid extends Widget {
 
       this._paintMergedCells(
         cellGroups,
-        paintRgn as Private.PaintRegion,
+        paintRgn,
         backgroundColor
       );
     }
@@ -3561,8 +3557,6 @@ export class DataGrid extends Widget {
         index
       );
 
-      // TODO We're not creating a fully implemented paint-region,
-      // We probably need another type
       let paintRgn = {
         region: rgn,
         xMin: 0,
@@ -3588,7 +3582,7 @@ export class DataGrid extends Widget {
 
       this._paintMergedCells(
         cellGroups,
-        paintRgn as Private.PaintRegion,
+        paintRgn,
         this._style.headerBackgroundColor
       );
     }
@@ -3696,8 +3690,6 @@ export class DataGrid extends Widget {
         index
       );
 
-      // TODO We're not creating a fully implemented paint-region,
-      // We probably need another type
       let paintRgn = {
         region: rgn,
         xMin: 0,
@@ -3723,7 +3715,7 @@ export class DataGrid extends Widget {
 
       this._paintMergedCells(
         cellGroups,
-        paintRgn as Private.PaintRegion,
+        paintRgn,
         this._style.headerBackgroundColor
       );
     }
@@ -5006,7 +4998,7 @@ export class DataGrid extends Widget {
    */
   private _paintMergedCells(
     cellGroups: CellGroup[],
-    rgn: Private.PaintRegion,
+    rgn: Private.PixelRegion,
     backgroundColor: string | undefined
   ): void {
     // Bail if there is no data model.
@@ -6580,9 +6572,9 @@ namespace Private {
   }
 
   /**
-   * An object which represents a region to be painted.
+   * An object which represents a canvas region in pixels.
    */
-  export type PaintRegion = {
+  export type PixelRegion = {
     /**
      * The min X coordinate the of the dirty viewport rect.
      *
@@ -6616,6 +6608,16 @@ namespace Private {
     yMax: number;
 
     /**
+     * The cell region.
+     */
+    region: DataModel.CellRegion;
+  };
+
+  /**
+   * An object which represents a region to be painted.
+   */
+  export type PaintRegion = PixelRegion & {
+    /**
      * The X coordinate the of the region, in viewport coordinates.
      *
      * #### Notes
@@ -6646,11 +6648,6 @@ namespace Private {
      * This is aligned to the cell boundaries.
      */
     height: number;
-
-    /**
-     * The cell region being painted.
-     */
-    region: DataModel.CellRegion;
 
     /**
      * The row index of the first cell in the region.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3397,16 +3397,10 @@ export class DataGrid extends Widget {
           break;
       }
 
-      // Draw the background for merged cells
-      this._drawMergedCellsBackground(cellGroups, paintRgn as Private.PaintRegion, this._style.backgroundColor);
-
-      // Draw the cell groups for the paint region
-      this._drawMergedCells(cellGroups, paintRgn as Private.PaintRegion);
-
-      // Draw grid lines close to merged cells
-      this._drawMergedCellsBorder(
+      this._paintMergedCells(
         cellGroups,
         paintRgn as Private.PaintRegion,
+        this._style.backgroundColor,
         this._style.horizontalGridLineColor || this._style.gridLineColor,
         this._style.verticalGridLineColor || this._style.gridLineColor
       );
@@ -4136,16 +4130,11 @@ export class DataGrid extends Widget {
       return this.cellGroupInteresectsRegion(group, rgn);
     });
 
-    // Draw the background for merged cells
-    this._drawMergedCellsBackground(cellGroups, rgn, this._style.backgroundColor);
-
-    // Draw the cell groups for the paint region
-    this._drawMergedCells(cellGroups, rgn);
-
-    // Draw grid lines close to merged cells
-    this._drawMergedCellsBorder(
+    // Draw merged cells
+    this._paintMergedCells(
       cellGroups,
       rgn,
+      this._style.backgroundColor,
       this._style.horizontalGridLineColor || this._style.gridLineColor,
       this._style.verticalGridLineColor || this._style.gridLineColor
     );
@@ -4293,16 +4282,11 @@ export class DataGrid extends Widget {
       return this.cellGroupInteresectsRegion(group, rgn);
     });
 
-    // Draw the background for merged cells
-    this._drawMergedCellsBackground(cellGroups, rgn, this._style.headerBackgroundColor);
-
-    // Draw the cell groups for the paint region
-    this._drawMergedCells(cellGroups, rgn);
-
-    // Draw grid lines close to merged cells
-    this._drawMergedCellsBorder(
+    // Draw merged cells
+    this._paintMergedCells(
       cellGroups,
       rgn,
+      this._style.headerBackgroundColor,
       this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
       this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
     );
@@ -4450,18 +4434,12 @@ export class DataGrid extends Widget {
       return this.cellGroupInteresectsRegion(group, rgn);
     });
 
-    // Draw the background for merged cells
-    this._drawMergedCellsBackground(cellGroups, rgn, this._style.headerBackgroundColor);
-
-    // Draw the cell groups for the paint region
-    this._drawMergedCells(cellGroups, rgn);
-
-    // Draw grid lines close to merged cells
-    this._drawMergedCellsBorder(
+    // Draw merged cells
+    this._paintMergedCells(
       cellGroups,
       rgn,
-      this._style.headerHorizontalGridLineColor ||
-        this._style.headerGridLineColor,
+      this._style.headerBackgroundColor,
+      this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
       this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
     );
   }
@@ -4592,18 +4570,12 @@ export class DataGrid extends Widget {
       return this.cellGroupInteresectsRegion(group, rgn);
     });
 
-    // Draw the background for merged cells
-    this._drawMergedCellsBackground(cellGroups, rgn, this._style.headerBackgroundColor);
-
-    // Draw the cell groups for the paint region
-    this._drawMergedCells(cellGroups, rgn);
-
-    // Draw grid lines close to merged cells
-    this._drawMergedCellsBorder(
+    // Draw merged cells
+    this._paintMergedCells(
       cellGroups,
       rgn,
-      this._style.headerHorizontalGridLineColor ||
-        this._style.headerGridLineColor,
+      this._style.headerBackgroundColor,
+      this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
       this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
     );
   }
@@ -4908,77 +4880,15 @@ export class DataGrid extends Widget {
   }
 
   /**
-   * Draw the background for given group cells.
+   * Paint group cells.
    */
-  private _drawMergedCellsBackground(
+  private _paintMergedCells(
     cellGroups: CellGroup[],
     rgn: Private.PaintRegion,
-    color: string | undefined
+    backgroundColor: string | undefined,
+    verticalColor: string | undefined,
+    horizontalColor: string | undefined
   ): void {
-    // Bail if there is no color to draw.
-    if (!color) {
-      return;
-    }
-
-    // Unpack the region.
-    let { xMin, yMin, xMax, yMax } = rgn;
-
-    this._canvasGC.fillStyle = color;
-
-    for (const group of cellGroups) {
-      let width = 0;
-      for (let c = group.c1; c <= group.c2; c++) {
-        width += this._getColumnSize(rgn.region, c);
-      }
-
-      let height = 0;
-      for (let r = group.r1; r <= group.r2; r++) {
-        height += this._getRowSize(rgn.region, r);
-      }
-
-      let x = 0;
-      let y = 0;
-      switch (rgn.region) {
-        case 'body':
-          x = this._columnSections.offsetOf(group.c1) + this.headerWidth - this._scrollX;
-          y = this._rowSections.offsetOf(group.r1) + this.headerHeight - this._scrollY;
-          break;
-        case 'column-header':
-          x = this._columnSections.offsetOf(group.c1) + this.headerWidth - this._scrollX;
-          y = this._rowSections.offsetOf(group.r1) - this._scrollY;
-          break;
-        case 'row-header':
-          x = this._columnSections.offsetOf(group.c1) - this._scrollX;
-          y = this._rowSections.offsetOf(group.r1) + this.headerHeight - this._scrollY;
-          break;
-        case 'corner-header':
-          x = this._columnSections.offsetOf(group.c1);
-          y = this._rowSections.offsetOf(group.r1);
-          break;
-      }
-
-      // Compute the actual X bounds for the cell.
-      let x1 = Math.max(xMin, x);
-      let x2 = Math.min(x + width - 1, xMax);
-
-      // Compute the actual Y bounds for the cell.
-      let y1 = Math.max(yMin, y);
-      let y2 = Math.min(y + height - 1, yMax);
-
-      // Fill the region with the specified color.
-      this._canvasGC.fillRect(
-        x1,
-        y1,
-        x2 - x1 + 1,
-        y2 - y1 + 1
-      );
-    }
-  }
-
-  /**
-   * Draw the cell groups for the given paint region.
-   */
-  private _drawMergedCells(cellGroups: CellGroup[], rgn: Private.PaintRegion): void {
     // Bail if there is no data model.
     if (!this._dataModel) {
       return;
@@ -4996,6 +4906,12 @@ export class DataGrid extends Widget {
       value: null as any,
       metadata: DataModel.emptyMetadata
     };
+
+    if (backgroundColor) {
+      this._canvasGC.fillStyle = backgroundColor;
+    }
+    // Set the line width for the grid lines.
+    this._canvasGC.lineWidth = 1;
 
     // Save the buffer gc before wrapping.
     this._bufferGC.save();
@@ -5063,12 +4979,22 @@ export class DataGrid extends Widget {
       config.metadata = metadata;
 
       // Compute the actual X bounds for the cell.
-      let x1 = Math.max(rgn.xMin, config.x);
-      let x2 = Math.min(config.x + config.width - 1, rgn.xMax);
+      let x1 = Math.max(rgn.xMin, x);
+      let x2 = Math.min(x + width - 1, rgn.xMax);
 
       // Compute the actual Y bounds for the cell.
-      let y1 = Math.max(rgn.yMin, config.y);
-      let y2 = Math.min(config.y + config.height - 1, rgn.yMax);
+      let y1 = Math.max(rgn.yMin, y);
+      let y2 = Math.min(y + height - 1, rgn.yMax);
+
+      // Draw the background.
+      if (backgroundColor) {
+        this._canvasGC.fillRect(
+          x1,
+          y1,
+          x2 - x1 + 1,
+          y2 - y1 + 1
+        );
+      }
 
       // Get the renderer for the cell.
       let renderer = this._cellRenderers.get(config);
@@ -5098,63 +5024,6 @@ export class DataGrid extends Widget {
         x1,
         y1
       );
-    }
-
-    // Dispose of the wrapped gc.
-    gc.dispose();
-
-    // Restore the final buffer gc state.
-    this._bufferGC.restore();
-  }
-
-  /**
-   * Draw the cell groups for the given paint region.
-   */
-  private _drawMergedCellsBorder(
-      cellGroups: CellGroup[],
-      rgn: Private.PaintRegion,
-      verticalColor: string | undefined,
-      horizontalColor: string | undefined
-  ): void {
-    // Bail if there is no data model.
-    if (!this._dataModel) {
-      return;
-    }
-
-    // Set the line width for the grid lines.
-    this._canvasGC.lineWidth = 1;
-
-    for (const group of cellGroups) {
-      let width = 0;
-      for (let c = group.c1; c <= group.c2; c++) {
-        width += this._getColumnSize(rgn.region, c);
-      }
-
-      let height = 0;
-      for (let r = group.r1; r <= group.r2; r++) {
-        height += this._getRowSize(rgn.region, r);
-      }
-
-      let x = 0;
-      let y = 0;
-      switch (rgn.region) {
-        case 'body':
-          x = this._columnSections.offsetOf(group.c1) + this.headerWidth - this._scrollX;
-          y = this._rowSections.offsetOf(group.r1) + this.headerHeight - this._scrollY;
-          break;
-        case 'column-header':
-          x = this._columnSections.offsetOf(group.c1) + this.headerWidth - this._scrollX;
-          y = this._rowSections.offsetOf(group.r1) - this._scrollY;
-          break;
-        case 'row-header':
-          x = this._columnSections.offsetOf(group.c1) - this._scrollX;
-          y = this._rowSections.offsetOf(group.r1) + this.headerHeight - this._scrollY;
-          break;
-        case 'corner-header':
-          x = this._columnSections.offsetOf(group.c1);
-          y = this._rowSections.offsetOf(group.r1);
-          break;
-      }
 
       if (verticalColor) {
         // Begin the path for the grid lines.
@@ -5188,6 +5057,12 @@ export class DataGrid extends Widget {
         this._canvasGC.stroke();
       }
     }
+
+    // Dispose of the wrapped gc.
+    gc.dispose();
+
+    // Restore the final buffer gc state.
+    this._bufferGC.restore();
   }
 
   /**

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3189,14 +3189,14 @@ export class DataGrid extends Widget {
     }
 
     // Render entire grid if scrolling merged cells grid
-    const paintEverything = Private.shouldPaintEverything(this._dataModel!);
+    // const paintEverything = Private.shouldPaintEverything(this._dataModel!);
 
-    if (paintEverything) {
-      this.paintContent(0, 0, vw, vh);
-      this._paintOverlay();
-      this._syncScrollState();
-      return;
-    }
+    // if (paintEverything) {
+    //   this.paintContent(0, 0, vw, vh);
+    //   this._paintOverlay();
+    //   this._syncScrollState();
+    //   return;
+    // }
 
     // Compute the size delta.
     let delta = newSize - oldSize;
@@ -3311,14 +3311,14 @@ export class DataGrid extends Widget {
     }
 
     // Render entire grid if scrolling merged cells grid
-    const paintEverything = Private.shouldPaintEverything(this._dataModel!);
+    // const paintEverything = Private.shouldPaintEverything(this._dataModel!);
 
-    if (paintEverything) {
-      this.paintContent(0, 0, vw, vh);
-      this._paintOverlay();
-      this._syncScrollState();
-      return;
-    }
+    // if (paintEverything) {
+    //   this.paintContent(0, 0, vw, vh);
+    //   this._paintOverlay();
+    //   this._syncScrollState();
+    //   return;
+    // }
 
     // Compute the size delta.
     let delta = newSize - oldSize;
@@ -3433,14 +3433,14 @@ export class DataGrid extends Widget {
     }
 
     // Render entire grid if scrolling merged cells grid
-    const paintEverything = Private.shouldPaintEverything(this._dataModel!);
+    // const paintEverything = Private.shouldPaintEverything(this._dataModel!);
 
-    if (paintEverything) {
-      this.paintContent(0, 0, vw, vh);
-      this._paintOverlay();
-      this._syncScrollState();
-      return;
-    }
+    // if (paintEverything) {
+    //   this.paintContent(0, 0, vw, vh);
+    //   this._paintOverlay();
+    //   this._syncScrollState();
+    //   return;
+    // }
 
     // Compute the size delta.
     let delta = newSize - oldSize;
@@ -3531,14 +3531,14 @@ export class DataGrid extends Widget {
     }
 
     // Render entire grid if scrolling merged cells grid
-    const paintEverything = Private.shouldPaintEverything(this._dataModel!);
+    // const paintEverything = Private.shouldPaintEverything(this._dataModel!);
 
-    if (paintEverything) {
-      this.paintContent(0, 0, vw, vh);
-      this._paintOverlay();
-      this._syncScrollState();
-      return;
-    }
+    // if (paintEverything) {
+    //   this.paintContent(0, 0, vw, vh);
+    //   this._paintOverlay();
+    //   this._syncScrollState();
+    //   return;
+    // }
 
     // Paint the overlay.
     this._paintOverlay();
@@ -4652,17 +4652,17 @@ export class DataGrid extends Widget {
       return;
     }
 
-    // Determine if the cell intersects with a merged group at row or column
-    let intersectingColumnGroups = CellGroup.getCellGroupsAtColumn(
-      this._dataModel!,
-      rgn.region,
-      rgn.column
-    );
-    let intersectingRowGroups = CellGroup.getCellGroupsAtRow(
-      this._dataModel!,
-      rgn.region,
-      rgn.row
-    );
+    // // Determine if the region intersects with a merged group at row or column
+    // let intersectingColumnGroups = CellGroup.getCellGroupsAtColumn(
+    //   this._dataModel!,
+    //   rgn.region,
+    //   rgn.column
+    // );
+    // let intersectingRowGroups = CellGroup.getCellGroupsAtRow(
+    //   this._dataModel!,
+    //   rgn.region,
+    //   rgn.row
+    // );
 
     // move the bounds of the region if edges of the region are part of a merge group.
     // after the move, new region contains entirety of the merge groups
@@ -4761,38 +4761,40 @@ export class DataGrid extends Widget {
         yOffset = height;
 
         /**
-         * For merged cell regions, only rendering the merged region
-         * if the "parent" cell is the one being painted. Bail otherwise.
+         * For merged cell regions, don't do anything, we draw merged regions later.
          */
         if (groupIndex !== -1) {
-          const group = this.dataModel!.group(config.region, groupIndex)!;
-          if (group.r1 === row && group.c1 === column) {
-            width = 0;
-            for (let c = group.c1; c <= group.c2; c++) {
-              width += this._getColumnSize(config.region, c);
-            }
+          y += yOffset;
+          continue;
+        //   const group = this.dataModel!.group(config.region, groupIndex)!;
+        //   if (group.r1 === row && group.c1 === column) {
+        //     width = 0;
+        //     for (let c = group.c1; c <= group.c2; c++) {
+        //       width += this._getColumnSize(config.region, c);
+        //     }
 
-            height = 0;
-            for (let r = group.r1; r <= group.r2; r++) {
-              height += this._getRowSize(config.region, r);
-            }
-          } else {
-            y += yOffset;
-            continue;
-          }
-        } else {
-          /**
-           * Reset column width if we're rendering a column-header
-           * which is not part of a merged cell group.
-           */
-          if (rgn.region == 'column-header') {
-            width = rgn.columnSizes[i];
-          }
+        //     height = 0;
+        //     for (let r = group.r1; r <= group.r2; r++) {
+        //       height += this._getRowSize(config.region, r);
+        //     }
+        //   } else {
+        //     y += yOffset;
+        //     continue;
+        //   }
+        // } else {
+        //   /**
+        //    * Reset column width if we're rendering a column-header
+        //    * which is not part of a merged cell group.
+        //    */
+        //   if (rgn.region == 'column-header') {
+        //     width = rgn.columnSizes[i];
+        //   }
         }
 
         // Clear the buffer rect for the cell.
         gc.clearRect(x, y, width, height);
 
+        // Why are there two saves?
         // Save the GC state.
         gc.save();
 
@@ -4830,6 +4832,9 @@ export class DataGrid extends Widget {
 
         // Paint the cell into the off-screen buffer.
         try {
+          if (groupIndex !== -1) {
+            console.log('drawing merged cell anyway')
+          }
           renderer.paint(gc, config);
         } catch (err) {
           console.error(err);
@@ -4846,32 +4851,33 @@ export class DataGrid extends Widget {
         let y1 = Math.max(rgn.yMin, config.y);
         let y2 = Math.min(config.y + config.height - 1, rgn.yMax);
 
-        if (
-          intersectingColumnGroups.length !== 0 ||
-          intersectingRowGroups.length !== 0
-        ) {
-          if (x2 > x1 && y2 > y1) {
-            this._blitContent(
-              this._buffer,
-              x1,
-              y1,
-              x2 - x1 + 1,
-              y2 - y1 + 1,
-              x1,
-              y1
-            );
-          }
-        } else {
-          this._blitContent(
-            this._buffer,
-            x1,
-            y1,
-            x2 - x1 + 1,
-            y2 - y1 + 1,
-            x1,
-            y1
-          );
-        }
+        // TODO Do we still need this?
+        // if (
+        //   intersectingColumnGroups.length !== 0 ||
+        //   intersectingRowGroups.length !== 0
+        // ) {
+        //   if (x2 > x1 && y2 > y1) {
+        //     this._blitContent(
+        //       this._buffer,
+        //       x1,
+        //       y1,
+        //       x2 - x1 + 1,
+        //       y2 - y1 + 1,
+        //       x1,
+        //       y1
+        //     );
+        //   }
+        // } else {
+        this._blitContent(
+          this._buffer,
+          x1,
+          y1,
+          x2 - x1 + 1,
+          y2 - y1 + 1,
+          x1,
+          y1
+        );
+        // }
 
         // Increment the running Y coordinate.
         y += yOffset;
@@ -4882,6 +4888,100 @@ export class DataGrid extends Widget {
 
       // Increment the running X coordinate.
       x += xOffset;
+    }
+
+    // Draw merged groups that intersects with the region
+    const cellGroups = CellGroup.getCellGroupsAtRegion(
+      this.dataModel!,
+      rgn.region
+    );
+
+    for (const group of cellGroups) {
+      let x = 0;
+      for (let c = 0; c < group.c1; c++) {
+        x += this._getColumnSize(rgn.region, c);
+      }
+
+      let y = 0;
+      for (let r = 0; r < group.r1; r++) {
+        y += this._getRowSize(rgn.region, r);
+      }
+
+      let width = 0;
+      for (let c = group.c1; c <= group.c2; c++) {
+        width += this._getColumnSize(rgn.region, c);
+      }
+
+      let height = 0;
+      for (let r = group.r1; r <= group.r2; r++) {
+        height += this._getRowSize(rgn.region, r);
+      }
+
+      let value: any;
+      try {
+        value = this._dataModel.data(rgn.region, group.r1, group.c1);
+      } catch (err) {
+        value = undefined;
+        console.error(err);
+      }
+
+      // Get the metadata for the cell.
+      let metadata: DataModel.Metadata;
+      try {
+        metadata = this._dataModel.metadata(rgn.region, group.r1, group.c1);
+      } catch (err) {
+        metadata = DataModel.emptyMetadata;
+        console.error(err);
+      }
+
+      config.x = rgn.x + x;
+      config.y = rgn.y + y;
+      config.width = width;
+      config.height = height;
+      config.region = rgn.region;
+      config.row = group.r1;
+      config.column = group.c1;
+      config.value = value;
+      config.metadata = metadata;
+
+      console.log('trying to draw', JSON.stringify(config))
+
+      // Get the renderer for the cell.
+      let renderer = this._cellRenderers.get(config);
+
+      // Clear the buffer rect for the cell.
+      gc.clearRect(x, y, width, height);
+
+      // Save the GC state.
+      gc.save();
+
+      // Paint the cell into the off-screen buffer.
+      try {
+        renderer.paint(gc, config);
+      } catch (err) {
+        console.error(err);
+      }
+
+      // Restore the GC state.
+      gc.restore();
+
+      // Compute the actual X bounds for the cell.
+      let x1 = Math.max(rgn.xMin, config.x);
+      let x2 = Math.min(config.x + config.width - 1, rgn.xMax);
+
+      // Compute the actual Y bounds for the cell.
+      let y1 = Math.max(rgn.yMin, config.y);
+      let y2 = Math.min(config.y + config.height - 1, rgn.yMax);
+
+      this._blitContent(
+        this._buffer,
+        x1,
+        y1,
+        x2 - x1 + 1,
+        y2 - y1 + 1,
+        x1,
+        y1
+      );
     }
 
     // Dispose of the wrapped gc.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3828,6 +3828,45 @@ export class DataGrid extends Widget {
           width,
           Math.abs(dy)
         );
+
+        // Repaint merged cells that are intersected by the scroll level
+        // Otherwise it will be cut in two by the valid content, and drawn incorrectly
+        for (const rgn of ['body', 'row-header'] as DataModel.CellRegion[]) {
+          const cellgroups = CellGroup.getCellGroupsAtRegion(
+            this.dataModel, rgn
+          );
+
+          let paintRgn = {
+            region: rgn,
+            xMin: 0,
+            xMax: 0,
+            yMin: 0,
+            yMax: 0
+          };
+
+          let backgroundColor = undefined;
+
+          switch (rgn) {
+            case 'body':
+              paintRgn.xMin = this.headerWidth;
+              paintRgn.xMax = this.headerWidth + this.bodyWidth;
+              paintRgn.yMin = this.headerHeight;
+              paintRgn.yMax = this.headerHeight + this.bodyHeight;
+
+              backgroundColor = this._style.backgroundColor;
+              break;
+            case 'row-header':
+              paintRgn.xMin = 0;
+              paintRgn.xMax = this.headerWidth;
+              paintRgn.yMin = this.headerHeight;
+              paintRgn.yMax = this.headerHeight + this.bodyHeight;
+
+              backgroundColor = this._style.headerBackgroundColor;
+              break;
+          }
+
+          this._paintMergedCells(cellgroups, paintRgn, backgroundColor);
+        }
       }
     }
 
@@ -3852,6 +3891,46 @@ export class DataGrid extends Widget {
           Math.abs(dx),
           height
         );
+
+        // Repaint merged cells that are intersected by the scroll level
+        // Otherwise it will be cut in two by the valid content, and drawn incorrectly
+        for (const rgn of ['body', 'column-header'] as DataModel.CellRegion[]) {
+          const cellGroups = CellGroup.getCellGroupsAtRegion(
+            this.dataModel,
+            rgn
+          );
+
+          let paintRgn = {
+            region: rgn,
+            xMin: 0,
+            xMax: 0,
+            yMin: 0,
+            yMax: 0
+          };
+
+          let backgroundColor = undefined;
+
+          switch (rgn) {
+            case 'body':
+              paintRgn.xMin = this.headerWidth;
+              paintRgn.xMax = this.headerWidth + this.bodyWidth;
+              paintRgn.yMin = this.headerHeight;
+              paintRgn.yMax = this.headerHeight + this.bodyHeight;
+
+              backgroundColor = this._style.backgroundColor;
+              break;
+            case 'column-header':
+              paintRgn.xMin = this.headerWidth;
+              paintRgn.xMax = this.headerWidth + this.bodyWidth;
+              paintRgn.yMin = 0;
+              paintRgn.yMax = this.headerHeight;
+
+              backgroundColor = this._style.headerBackgroundColor;
+              break;
+          }
+
+          this._paintMergedCells(cellGroups, paintRgn, backgroundColor);
+        }
       }
     }
 

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -5085,10 +5085,10 @@ export class DataGrid extends Widget {
             this._columnSections.offsetOf(group.c1) +
             this.headerWidth -
             this._scrollX;
-          y = this._rowSections.offsetOf(group.r1) - this._scrollY;
+          y = this._rowSections.offsetOf(group.r1);
           break;
         case 'row-header':
-          x = this._columnSections.offsetOf(group.c1) - this._scrollX;
+          x = this._columnSections.offsetOf(group.c1);
           y =
             this._rowSections.offsetOf(group.r1) +
             this.headerHeight -

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -5294,29 +5294,6 @@ export class DataGrid extends Widget {
         continue;
       }
 
-      let xStart = 0;
-      let lineStarted = false;
-      let lines = [];
-      let leftCurrent = x1;
-
-      for (let c = rgn.column; c < rgn.column + rgn.columnSizes.length; c++) {
-        const cIndex = c - rgn.column;
-
-        if (!lineStarted) {
-          lineStarted = true;
-          xStart = leftCurrent;
-        }
-
-        leftCurrent += rgn.columnSizes[cIndex];
-        if (c === rgn.column) {
-          leftCurrent -= rgn.xMin - rgn.x;
-        }
-      }
-
-      if (lineStarted) {
-        lines.push([xStart, rgn.xMax + 1]);
-      }
-
       // Compute the Y position of the line.
       let pos = y + size - 1;
 
@@ -5379,29 +5356,6 @@ export class DataGrid extends Widget {
       // Skip zero sized columns.
       if (size === 0) {
         continue;
-      }
-
-      let yStart = 0;
-      let lineStarted = false;
-      let lines = [];
-      let topCurrent = y1;
-
-      for (let r = rgn.row; r < rgn.row + rgn.rowSizes.length; r++) {
-        const rIndex = r - rgn.row;
-
-        if (!lineStarted) {
-          lineStarted = true;
-          yStart = topCurrent;
-        }
-
-        topCurrent += rgn.rowSizes[rIndex];
-        if (r === rgn.row) {
-          topCurrent -= rgn.yMin - rgn.y;
-        }
-      }
-
-      if (lineStarted) {
-        lines.push([yStart, rgn.yMax + 1]);
       }
 
       // Compute the X position of the line.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3188,16 +3188,6 @@ export class DataGrid extends Widget {
       return;
     }
 
-    // Render entire grid if scrolling merged cells grid
-    // const paintEverything = Private.shouldPaintEverything(this._dataModel!);
-
-    // if (paintEverything) {
-    //   this.paintContent(0, 0, vw, vh);
-    //   this._paintOverlay();
-    //   this._syncScrollState();
-    //   return;
-    // }
-
     // Compute the size delta.
     let delta = newSize - oldSize;
 
@@ -3309,16 +3299,6 @@ export class DataGrid extends Widget {
       this._syncScrollState();
       return;
     }
-
-    // Render entire grid if scrolling merged cells grid
-    // const paintEverything = Private.shouldPaintEverything(this._dataModel!);
-
-    // if (paintEverything) {
-    //   this.paintContent(0, 0, vw, vh);
-    //   this._paintOverlay();
-    //   this._syncScrollState();
-    //   return;
-    // }
 
     // Compute the size delta.
     let delta = newSize - oldSize;
@@ -3432,16 +3412,6 @@ export class DataGrid extends Widget {
       return;
     }
 
-    // Render entire grid if scrolling merged cells grid
-    // const paintEverything = Private.shouldPaintEverything(this._dataModel!);
-
-    // if (paintEverything) {
-    //   this.paintContent(0, 0, vw, vh);
-    //   this._paintOverlay();
-    //   this._syncScrollState();
-    //   return;
-    // }
-
     // Compute the size delta.
     let delta = newSize - oldSize;
 
@@ -3529,16 +3499,6 @@ export class DataGrid extends Widget {
       this._syncScrollState();
       return;
     }
-
-    // Render entire grid if scrolling merged cells grid
-    // const paintEverything = Private.shouldPaintEverything(this._dataModel!);
-
-    // if (paintEverything) {
-    //   this.paintContent(0, 0, vw, vh);
-    //   this._paintOverlay();
-    //   this._syncScrollState();
-    //   return;
-    // }
 
     // Paint the overlay.
     this._paintOverlay();

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3255,6 +3255,57 @@ export class DataGrid extends Widget {
       this.paintContent(0, vh + delta, vw, -delta);
     }
 
+    // Repaint merged cells that are intersected by the resized row
+    // Otherwise it will be cut in two by the valid content, and drawn incorrectly
+    for (const rgn of ['body', 'row-header'] as DataModel.CellRegion[]) {
+      const cellGroups = CellGroup.getCellGroupsAtRow(this.dataModel!, rgn, index);
+
+      // TODO We're not creating a fully implemented paint-region,
+      // We probably need another type
+      let paintRgn = {
+        region: rgn,
+        xMin: 0,
+        xMax: 0,
+        yMin: 0,
+        yMax: 0
+      };
+
+      let backgroundColor = undefined;
+      let horizontalColor = undefined;
+      let verticalColor = undefined;
+
+      switch (rgn) {
+        case 'body':
+          paintRgn.xMin = this.headerWidth;
+          paintRgn.xMax = this.headerWidth + this.bodyWidth;
+          paintRgn.yMin = this.headerHeight;
+          paintRgn.yMax = this.headerHeight + this.bodyHeight;
+
+          backgroundColor = this._style.backgroundColor;
+          horizontalColor = this._style.horizontalGridLineColor || this._style.gridLineColor;
+          verticalColor = this._style.verticalGridLineColor || this._style.gridLineColor;
+          break;
+        case 'row-header':
+          paintRgn.xMin = 0;
+          paintRgn.xMax = this.headerWidth;
+          paintRgn.yMin = this.headerHeight;
+          paintRgn.yMax = this.headerHeight + this.bodyHeight;
+
+          backgroundColor = this._style.headerBackgroundColor;
+          horizontalColor = this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor;
+          verticalColor = this._style.headerVerticalGridLineColor || this._style.headerGridLineColor;
+          break;
+      }
+
+      this._paintMergedCells(
+        cellGroups,
+        paintRgn as Private.PaintRegion,
+        backgroundColor,
+        horizontalColor,
+        verticalColor
+      );
+    }
+
     // Paint the overlay.
     this._paintOverlay();
 
@@ -3506,6 +3557,45 @@ export class DataGrid extends Widget {
       this.paintContent(vw + delta, 0, -delta, vh);
     }
 
+    // Repaint merged cells that are intersected by the resized row
+    // Otherwise it will be cut in two by the valid content, and drawn incorrectly
+    for (const rgn of ['corner-header', 'row-header'] as DataModel.CellRegion[]) {
+      const cellGroups = CellGroup.getCellGroupsAtColumn(this.dataModel!, rgn, index);
+
+      // TODO We're not creating a fully implemented paint-region,
+      // We probably need another type
+      let paintRgn = {
+        region: rgn,
+        xMin: 0,
+        xMax: 0,
+        yMin: 0,
+        yMax: 0
+      };
+
+      switch (rgn) {
+        case 'corner-header':
+          paintRgn.xMin = 0;
+          paintRgn.xMax = this.headerWidth;
+          paintRgn.yMin = 0;
+          paintRgn.yMax = this.headerHeight;
+          break;
+        case 'row-header':
+          paintRgn.xMin = 0;
+          paintRgn.xMax = this.headerWidth;
+          paintRgn.yMin = this.headerHeight;
+          paintRgn.yMax = this.headerHeight + this.bodyHeight;
+          break;
+      }
+
+      this._paintMergedCells(
+        cellGroups,
+        paintRgn as Private.PaintRegion,
+        this._style.headerBackgroundColor,
+        this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
+        this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
+      );
+    }
+
     // Paint the overlay.
     this._paintOverlay();
 
@@ -3595,6 +3685,45 @@ export class DataGrid extends Widget {
       this.paintContent(0, y, vw, vh - y);
     } else if (delta < 0) {
       this.paintContent(0, vh + delta, vw, -delta);
+    }
+
+    // Repaint merged cells that are intersected by the resized row
+    // Otherwise it will be cut in two by the valid content, and drawn incorrectly
+    for (const rgn of ['corner-header', 'column-header'] as DataModel.CellRegion[]) {
+      const cellGroups = CellGroup.getCellGroupsAtRow(this.dataModel!, rgn, index);
+
+      // TODO We're not creating a fully implemented paint-region,
+      // We probably need another type
+      let paintRgn = {
+        region: rgn,
+        xMin: 0,
+        xMax: 0,
+        yMin: 0,
+        yMax: 0
+      };
+
+      switch (rgn) {
+        case 'corner-header':
+          paintRgn.xMin = 0;
+          paintRgn.xMax = this.headerWidth;
+          paintRgn.yMin = 0;
+          paintRgn.yMax = this.headerHeight;
+          break;
+        case 'column-header':
+          paintRgn.xMin = this.headerWidth;
+          paintRgn.xMax = this.headerWidth + this.bodyWidth;
+          paintRgn.yMin = 0;
+          paintRgn.yMax = this.headerHeight;
+          break;
+      }
+
+      this._paintMergedCells(
+        cellGroups,
+        paintRgn as Private.PaintRegion,
+        this._style.headerBackgroundColor,
+        this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
+        this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
+      );
     }
 
     // Paint the overlay.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -5183,26 +5183,10 @@ export class DataGrid extends Widget {
 
       for (let c = rgn.column; c < rgn.column + rgn.columnSizes.length; c++) {
         const cIndex = c - rgn.column;
-        const cellUp = [rgn.row + j, c];
-        const cellDown = [rgn.row + j + 1, c];
 
-        if (
-          CellGroup.areCellsMerged(
-            this.dataModel!,
-            rgn.region,
-            cellUp,
-            cellDown
-          )
-        ) {
-          if (lineStarted) {
-            lines.push([xStart, leftCurrent]);
-          }
-          lineStarted = false;
-        } else {
-          if (!lineStarted) {
-            lineStarted = true;
-            xStart = leftCurrent;
-          }
+        if (!lineStarted) {
+          lineStarted = true;
+          xStart = leftCurrent;
         }
 
         leftCurrent += rgn.columnSizes[cIndex];
@@ -5296,26 +5280,10 @@ export class DataGrid extends Widget {
 
       for (let r = rgn.row; r < rgn.row + rgn.rowSizes.length; r++) {
         const rIndex = r - rgn.row;
-        const cellLeft = [r, rgn.column + i];
-        const cellRight = [r, rgn.column + i + 1];
 
-        if (
-          CellGroup.areCellsMerged(
-            this.dataModel!,
-            rgn.region,
-            cellLeft,
-            cellRight
-          )
-        ) {
-          if (lineStarted) {
-            lines.push([yStart, topCurrent]);
-          }
-          lineStarted = false;
-        } else {
-          if (!lineStarted) {
-            lineStarted = true;
-            yStart = topCurrent;
-          }
+        if (!lineStarted) {
+          lineStarted = true;
+          yStart = topCurrent;
         }
 
         topCurrent += rgn.rowSizes[rIndex];

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3404,12 +3404,12 @@ export class DataGrid extends Widget {
       this._drawMergedCells(cellGroups, paintRgn as Private.PaintRegion);
 
       // Draw grid lines close to merged cells
-      // this._drawMergedCellsBorder(
-      //   cellGroups,
-      //   rgn,
-      //   this._style.horizontalGridLineColor || this._style.gridLineColor,
-      //   this._style.verticalGridLineColor || this._style.gridLineColor
-      // );
+      this._drawMergedCellsBorder(
+        cellGroups,
+        paintRgn as Private.PaintRegion,
+        this._style.horizontalGridLineColor || this._style.gridLineColor,
+        this._style.verticalGridLineColor || this._style.gridLineColor
+      );
     }
 
     // Paint the overlay.
@@ -3808,56 +3808,6 @@ export class DataGrid extends Widget {
   }
 
   /**
-   * Force a repaint of cells group.
-   */
-  //  protected paintCellGroup(cellGroup: CellGroup, rgn: DataModel.CellRegion, xMin: number, xMax: number, yMin: number, yMax: number) {
-  //   const mergedCellRegion: Private.PaintRegion = {
-  //     region: rgn,
-  //     xMin: ,
-  //     yMin: ,
-  //     xMax: x2,
-  //     yMax: y2,
-  //     x,
-  //     y,
-  //     width,
-  //     height,
-  //     row: r1,
-  //     column: c1,
-  //     rowSizes,
-  //     columnSizes
-  //   };
-
-    // Draw the background.
-    // this._drawBackground(mergedCellRegion, this._style.backgroundColor);
-
-    // Draw the row background.
-    // this._drawRowBackground(mergedCellRegion, this._style.rowBackgroundColor);
-
-    // Draw the column background.
-    // this._drawColumnBackground(mergedCellRegion, this._style.columnBackgroundColor);
-
-  //   this._drawCellGroup(cellGroup, mergedCellRegion);
-  // }
-
-  // /**
-  //  * Force a repaint of some grouped cells that are intersecting a given column.
-  //  */
-  // protected paintMergedCellsAtColumn(rgn: DataModel.CellRegion, index: number, xMin: number, xMax: number, yMin: number, yMax: number) {
-  //   const cellGroups = CellGroup.getCellGroupsAtColumn(this.dataModel!, rgn, index);
-
-  //   this._drawMergedCellsGroups(cellGroups, rgn, xMin, yMin, xMax, yMax);
-  // }
-
-  // /**
-  //  * Force a repaint of some grouped cells that are intersecting a given row.
-  //  */
-  //  protected paintMergedCellsAtRow(rgn: DataModel.CellRegion, index: number, xMin: number, xMax: number, yMin: number, yMax: number) {
-  //   const cellGroups = CellGroup.getCellGroupsAtRow(this.dataModel!, rgn, index);
-
-  //   this._drawMergedCellsGroups(cellGroups, rgn, xMin, yMin, xMax, yMax);
-  // }
-
-  /**
    * Resizes body column headers so their text fits
    * without clipping or wrapping.
    * @param dataModel
@@ -4193,12 +4143,12 @@ export class DataGrid extends Widget {
     this._drawMergedCells(cellGroups, rgn);
 
     // Draw grid lines close to merged cells
-    // this._drawMergedCellsBorder(
-    //   cellGroups,
-    //   rgn,
-    //   this._style.horizontalGridLineColor || this._style.gridLineColor,
-    //   this._style.verticalGridLineColor || this._style.gridLineColor
-    // );
+    this._drawMergedCellsBorder(
+      cellGroups,
+      rgn,
+      this._style.horizontalGridLineColor || this._style.gridLineColor,
+      this._style.verticalGridLineColor || this._style.gridLineColor
+    );
   }
 
   /**
@@ -4348,6 +4298,14 @@ export class DataGrid extends Widget {
 
     // Draw the cell groups for the paint region
     this._drawMergedCells(cellGroups, rgn);
+
+    // Draw grid lines close to merged cells
+    this._drawMergedCellsBorder(
+      cellGroups,
+      rgn,
+      this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
+      this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
+    );
   }
 
   /**
@@ -4497,6 +4455,15 @@ export class DataGrid extends Widget {
 
     // Draw the cell groups for the paint region
     this._drawMergedCells(cellGroups, rgn);
+
+    // Draw grid lines close to merged cells
+    this._drawMergedCellsBorder(
+      cellGroups,
+      rgn,
+      this._style.headerHorizontalGridLineColor ||
+        this._style.headerGridLineColor,
+      this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
+    );
   }
 
   /**
@@ -4630,6 +4597,15 @@ export class DataGrid extends Widget {
 
     // Draw the cell groups for the paint region
     this._drawMergedCells(cellGroups, rgn);
+
+    // Draw grid lines close to merged cells
+    this._drawMergedCellsBorder(
+      cellGroups,
+      rgn,
+      this._style.headerHorizontalGridLineColor ||
+        this._style.headerGridLineColor,
+      this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
+    );
   }
 
   /**
@@ -5132,6 +5108,23 @@ export class DataGrid extends Widget {
   }
 
   /**
+   * Draw the cell groups for the given paint region.
+   */
+  private _drawMergedCellsBorder(
+      cellGroups: CellGroup[],
+      rgn: Private.PaintRegion,
+      verticalColor: string | undefined,
+      horizontalColor: string | undefined
+  ): void {
+    // Bail if there is no data model.
+    if (!this._dataModel) {
+      return;
+    }
+
+
+  }
+
+  /**
    * Draw the horizontal grid lines for the given paint region.
    */
   private _drawHorizontalGridLines(
@@ -5204,19 +5197,9 @@ export class DataGrid extends Widget {
 
       // Draw the line if it's in range of the dirty rect.
       if (pos >= rgn.yMin && pos <= rgn.yMax) {
-        // Render entire grid if scrolling merged cells grid
-        const extendLines = Private.shouldPaintEverything(this._dataModel!);
-        if (extendLines) {
-          for (const line of lines) {
-            const [x1, x2] = line;
-            this._canvasGC.moveTo(x1, pos + 0.5);
-            this._canvasGC.lineTo(x2, pos + 0.5);
-          }
-        } else {
-          const x2 = Math.min(rgn.x + rgn.width, rgn.xMax + 1);
-          this._canvasGC.moveTo(x1, pos + 0.5);
-          this._canvasGC.lineTo(x2, pos + 0.5);
-        }
+        const x2 = Math.min(rgn.x + rgn.width, rgn.xMax + 1);
+        this._canvasGC.moveTo(x1, pos + 0.5);
+        this._canvasGC.lineTo(x2, pos + 0.5);
       }
 
       // Increment the running Y coordinate.
@@ -5301,19 +5284,9 @@ export class DataGrid extends Widget {
 
       // Draw the line if it's in range of the dirty rect.
       if (pos >= rgn.xMin && pos <= rgn.xMax) {
-        // Render entire grid if scrolling merged cells grid
-        const extendLines = Private.shouldPaintEverything(this._dataModel!);
-        if (extendLines) {
-          for (const line of lines) {
-            // this._canvasGC.strokeStyle = color;
-            this._canvasGC.moveTo(pos + 0.5, line[0]);
-            this._canvasGC.lineTo(pos + 0.5, line[1]);
-          }
-        } else {
-          let y2 = Math.min(rgn.y + rgn.height, rgn.yMax + 1);
-          this._canvasGC.moveTo(pos + 0.5, y1);
-          this._canvasGC.lineTo(pos + 0.5, y2);
-        }
+        let y2 = Math.min(rgn.y + rgn.height, rgn.yMax + 1);
+        this._canvasGC.moveTo(pos + 0.5, y1);
+        this._canvasGC.lineTo(pos + 0.5, y2);
       }
 
       // Increment the running X coordinate.
@@ -6604,34 +6577,6 @@ namespace Private {
     canvas.width = 0;
     canvas.height = 0;
     return canvas;
-  }
-
-  /**
-   * A function to check whether the entire grid should be rendered
-   * when dealing with merged cell regions.
-   * @param dataModel grid's data model.
-   * @returns boolean.
-   */
-  export function shouldPaintEverything(dataModel: DataModel): boolean {
-    const colGroups = CellGroup.getCellGroupsAtRegion(
-      dataModel!,
-      'column-header'
-    );
-    const rowHeaderGroups = CellGroup.getCellGroupsAtRegion(
-      dataModel!,
-      'row-header'
-    );
-    const cornerHeaderGroups = CellGroup.getCellGroupsAtRegion(
-      dataModel!,
-      'corner-header'
-    );
-    const bodyGroups = CellGroup.getCellGroupsAtRegion(dataModel!, 'body');
-    return (
-      colGroups.length > 0 ||
-      rowHeaderGroups.length > 0 ||
-      cornerHeaderGroups.length > 0 ||
-      bodyGroups.length > 0
-    );
   }
 
   /**

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -5121,7 +5121,73 @@ export class DataGrid extends Widget {
       return;
     }
 
+    // Set the line width for the grid lines.
+    this._canvasGC.lineWidth = 1;
 
+    for (const group of cellGroups) {
+      let width = 0;
+      for (let c = group.c1; c <= group.c2; c++) {
+        width += this._getColumnSize(rgn.region, c);
+      }
+
+      let height = 0;
+      for (let r = group.r1; r <= group.r2; r++) {
+        height += this._getRowSize(rgn.region, r);
+      }
+
+      let x = 0;
+      let y = 0;
+      switch (rgn.region) {
+        case 'body':
+          x = this._columnSections.offsetOf(group.c1) + this.headerWidth - this._scrollX;
+          y = this._rowSections.offsetOf(group.r1) + this.headerHeight - this._scrollY;
+          break;
+        case 'column-header':
+          x = this._columnSections.offsetOf(group.c1) + this.headerWidth - this._scrollX;
+          y = this._rowSections.offsetOf(group.r1) - this._scrollY;
+          break;
+        case 'row-header':
+          x = this._columnSections.offsetOf(group.c1) - this._scrollX;
+          y = this._rowSections.offsetOf(group.r1) + this.headerHeight - this._scrollY;
+          break;
+        case 'corner-header':
+          x = this._columnSections.offsetOf(group.c1);
+          y = this._rowSections.offsetOf(group.r1);
+          break;
+      }
+
+      if (verticalColor) {
+        // Begin the path for the grid lines.
+        this._canvasGC.beginPath();
+
+        // Why do we not need this?
+        // this._canvasGC.moveTo(x, y);
+        // this._canvasGC.lineTo(x, y + height);
+
+        this._canvasGC.moveTo(x + width - 0.5, y);
+        this._canvasGC.lineTo(x + width - 0.5, y + height);
+
+        // Stroke the lines with the specified color.
+        this._canvasGC.strokeStyle = verticalColor;
+        this._canvasGC.stroke();
+      }
+
+      if (horizontalColor) {
+        // Begin the path for the grid lines.
+        this._canvasGC.beginPath();
+
+        // Why do we not need this?
+        // this._canvasGC.moveTo(x, y);
+        // this._canvasGC.lineTo(x + width, y);
+
+        this._canvasGC.moveTo(x, y + height - 0.5);
+        this._canvasGC.lineTo(x + width, y + height - 0.5);
+
+        // Stroke the lines with the specified color.
+        this._canvasGC.strokeStyle = horizontalColor;
+        this._canvasGC.stroke();
+      }
+    }
   }
 
   /**

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3258,7 +3258,11 @@ export class DataGrid extends Widget {
     // Repaint merged cells that are intersected by the resized row
     // Otherwise it will be cut in two by the valid content, and drawn incorrectly
     for (const rgn of ['body', 'row-header'] as DataModel.CellRegion[]) {
-      const cellGroups = CellGroup.getCellGroupsAtRow(this.dataModel!, rgn, index);
+      const cellGroups = CellGroup.getCellGroupsAtRow(
+        this.dataModel!,
+        rgn,
+        index
+      );
 
       // TODO We're not creating a fully implemented paint-region,
       // We probably need another type
@@ -3282,8 +3286,10 @@ export class DataGrid extends Widget {
           paintRgn.yMax = this.headerHeight + this.bodyHeight;
 
           backgroundColor = this._style.backgroundColor;
-          horizontalColor = this._style.horizontalGridLineColor || this._style.gridLineColor;
-          verticalColor = this._style.verticalGridLineColor || this._style.gridLineColor;
+          horizontalColor =
+            this._style.horizontalGridLineColor || this._style.gridLineColor;
+          verticalColor =
+            this._style.verticalGridLineColor || this._style.gridLineColor;
           break;
         case 'row-header':
           paintRgn.xMin = 0;
@@ -3292,8 +3298,12 @@ export class DataGrid extends Widget {
           paintRgn.yMax = this.headerHeight + this.bodyHeight;
 
           backgroundColor = this._style.headerBackgroundColor;
-          horizontalColor = this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor;
-          verticalColor = this._style.headerVerticalGridLineColor || this._style.headerGridLineColor;
+          horizontalColor =
+            this._style.headerHorizontalGridLineColor ||
+            this._style.headerGridLineColor;
+          verticalColor =
+            this._style.headerVerticalGridLineColor ||
+            this._style.headerGridLineColor;
           break;
       }
 
@@ -3421,7 +3431,11 @@ export class DataGrid extends Widget {
     // Repaint merged cells that are intersected by the resized column
     // Otherwise it will be cut in two by the valid content, and drawn incorrectly
     for (const rgn of ['body', 'column-header'] as DataModel.CellRegion[]) {
-      const cellGroups = CellGroup.getCellGroupsAtColumn(this.dataModel!, rgn, index);
+      const cellGroups = CellGroup.getCellGroupsAtColumn(
+        this.dataModel!,
+        rgn,
+        index
+      );
 
       // TODO We're not creating a fully implemented paint-region,
       // We probably need another type
@@ -3445,8 +3459,10 @@ export class DataGrid extends Widget {
           paintRgn.yMax = this.headerHeight + this.bodyHeight;
 
           backgroundColor = this._style.backgroundColor;
-          horizontalColor = this._style.horizontalGridLineColor || this._style.gridLineColor;
-          verticalColor = this._style.verticalGridLineColor || this._style.gridLineColor;
+          horizontalColor =
+            this._style.horizontalGridLineColor || this._style.gridLineColor;
+          verticalColor =
+            this._style.verticalGridLineColor || this._style.gridLineColor;
           break;
         case 'column-header':
           paintRgn.xMin = this.headerWidth;
@@ -3455,8 +3471,12 @@ export class DataGrid extends Widget {
           paintRgn.yMax = this.headerHeight;
 
           backgroundColor = this._style.headerBackgroundColor;
-          horizontalColor = this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor;
-          verticalColor = this._style.headerVerticalGridLineColor || this._style.headerGridLineColor;
+          horizontalColor =
+            this._style.headerHorizontalGridLineColor ||
+            this._style.headerGridLineColor;
+          verticalColor =
+            this._style.headerVerticalGridLineColor ||
+            this._style.headerGridLineColor;
           break;
       }
 
@@ -3559,8 +3579,15 @@ export class DataGrid extends Widget {
 
     // Repaint merged cells that are intersected by the resized row
     // Otherwise it will be cut in two by the valid content, and drawn incorrectly
-    for (const rgn of ['corner-header', 'row-header'] as DataModel.CellRegion[]) {
-      const cellGroups = CellGroup.getCellGroupsAtColumn(this.dataModel!, rgn, index);
+    for (const rgn of [
+      'corner-header',
+      'row-header'
+    ] as DataModel.CellRegion[]) {
+      const cellGroups = CellGroup.getCellGroupsAtColumn(
+        this.dataModel!,
+        rgn,
+        index
+      );
 
       // TODO We're not creating a fully implemented paint-region,
       // We probably need another type
@@ -3591,8 +3618,10 @@ export class DataGrid extends Widget {
         cellGroups,
         paintRgn as Private.PaintRegion,
         this._style.headerBackgroundColor,
-        this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
-        this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
+        this._style.headerHorizontalGridLineColor ||
+          this._style.headerGridLineColor,
+        this._style.headerVerticalGridLineColor ||
+          this._style.headerGridLineColor
       );
     }
 
@@ -3689,8 +3718,15 @@ export class DataGrid extends Widget {
 
     // Repaint merged cells that are intersected by the resized row
     // Otherwise it will be cut in two by the valid content, and drawn incorrectly
-    for (const rgn of ['corner-header', 'column-header'] as DataModel.CellRegion[]) {
-      const cellGroups = CellGroup.getCellGroupsAtRow(this.dataModel!, rgn, index);
+    for (const rgn of [
+      'corner-header',
+      'column-header'
+    ] as DataModel.CellRegion[]) {
+      const cellGroups = CellGroup.getCellGroupsAtRow(
+        this.dataModel!,
+        rgn,
+        index
+      );
 
       // TODO We're not creating a fully implemented paint-region,
       // We probably need another type
@@ -3721,8 +3757,10 @@ export class DataGrid extends Widget {
         cellGroups,
         paintRgn as Private.PaintRegion,
         this._style.headerBackgroundColor,
-        this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
-        this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
+        this._style.headerHorizontalGridLineColor ||
+          this._style.headerGridLineColor,
+        this._style.headerVerticalGridLineColor ||
+          this._style.headerGridLineColor
       );
     }
 
@@ -4428,7 +4466,8 @@ export class DataGrid extends Widget {
       cellGroups,
       rgn,
       this._style.headerBackgroundColor,
-      this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
+      this._style.headerHorizontalGridLineColor ||
+        this._style.headerGridLineColor,
       this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
     );
   }
@@ -4580,7 +4619,8 @@ export class DataGrid extends Widget {
       cellGroups,
       rgn,
       this._style.headerBackgroundColor,
-      this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
+      this._style.headerHorizontalGridLineColor ||
+        this._style.headerGridLineColor,
       this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
     );
   }
@@ -4716,7 +4756,8 @@ export class DataGrid extends Widget {
       cellGroups,
       rgn,
       this._style.headerBackgroundColor,
-      this._style.headerHorizontalGridLineColor || this._style.headerGridLineColor,
+      this._style.headerHorizontalGridLineColor ||
+        this._style.headerGridLineColor,
       this._style.headerVerticalGridLineColor || this._style.headerGridLineColor
     );
   }
@@ -5007,7 +5048,10 @@ export class DataGrid extends Widget {
   }
 
   // TODO Move this in the utils file (but we need the PaintRegion typing)
-  private cellGroupInteresectsRegion(group: CellGroup, rgn: Private.PaintRegion) {
+  private cellGroupInteresectsRegion(
+    group: CellGroup,
+    rgn: Private.PaintRegion
+  ) {
     const rgnR1 = rgn.row;
     const rgnR2 = rgn.row + rgn.rowSizes.length;
 
@@ -5092,16 +5136,28 @@ export class DataGrid extends Widget {
       let y = 0;
       switch (rgn.region) {
         case 'body':
-          x = this._columnSections.offsetOf(group.c1) + this.headerWidth - this._scrollX;
-          y = this._rowSections.offsetOf(group.r1) + this.headerHeight - this._scrollY;
+          x =
+            this._columnSections.offsetOf(group.c1) +
+            this.headerWidth -
+            this._scrollX;
+          y =
+            this._rowSections.offsetOf(group.r1) +
+            this.headerHeight -
+            this._scrollY;
           break;
         case 'column-header':
-          x = this._columnSections.offsetOf(group.c1) + this.headerWidth - this._scrollX;
+          x =
+            this._columnSections.offsetOf(group.c1) +
+            this.headerWidth -
+            this._scrollX;
           y = this._rowSections.offsetOf(group.r1) - this._scrollY;
           break;
         case 'row-header':
           x = this._columnSections.offsetOf(group.c1) - this._scrollX;
-          y = this._rowSections.offsetOf(group.r1) + this.headerHeight - this._scrollY;
+          y =
+            this._rowSections.offsetOf(group.r1) +
+            this.headerHeight -
+            this._scrollY;
           break;
         case 'corner-header':
           x = this._columnSections.offsetOf(group.c1);
@@ -5129,12 +5185,7 @@ export class DataGrid extends Widget {
 
       // Draw the background.
       if (backgroundColor) {
-        this._canvasGC.fillRect(
-          x1,
-          y1,
-          x2 - x1 + 1,
-          y2 - y1 + 1
-        );
+        this._canvasGC.fillRect(x1, y1, x2 - x1 + 1, y2 - y1 + 1);
       }
 
       // Get the renderer for the cell.
@@ -5156,15 +5207,7 @@ export class DataGrid extends Widget {
       // Restore the GC state.
       gc.restore();
 
-      this._blitContent(
-        this._buffer,
-        x1,
-        y1,
-        x2 - x1 + 1,
-        y2 - y1 + 1,
-        x1,
-        y1
-      );
+      this._blitContent(this._buffer, x1, y1, x2 - x1 + 1, y2 - y1 + 1, x1, y1);
 
       if (verticalColor) {
         // Begin the path for the grid lines.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -5218,7 +5218,7 @@ export class DataGrid extends Widget {
         // this._canvasGC.lineTo(x1, y2);
 
         this._canvasGC.moveTo(x2 + 0.5, y1);
-        this._canvasGC.lineTo(x2 + 0.5, y2);
+        this._canvasGC.lineTo(x2 + 0.5, y2 + 1);
 
         // Stroke the lines with the specified color.
         this._canvasGC.strokeStyle = verticalColor;
@@ -5234,7 +5234,7 @@ export class DataGrid extends Widget {
         // this._canvasGC.lineTo(x2, y1);
 
         this._canvasGC.moveTo(x1, y2 + 0.5);
-        this._canvasGC.lineTo(x2, y2 + 0.5);
+        this._canvasGC.lineTo(x2 + 1, y2 + 0.5);
 
         // Stroke the lines with the specified color.
         this._canvasGC.strokeStyle = horizontalColor;

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -5030,11 +5030,11 @@ export class DataGrid extends Widget {
         this._canvasGC.beginPath();
 
         // Why do we not need this?
-        // this._canvasGC.moveTo(x, y);
-        // this._canvasGC.lineTo(x, y + height);
+        // this._canvasGC.moveTo(x1, y1);
+        // this._canvasGC.lineTo(x1, y2);
 
-        this._canvasGC.moveTo(x + width - 0.5, y);
-        this._canvasGC.lineTo(x + width - 0.5, y + height);
+        this._canvasGC.moveTo(x2 + 0.5, y1);
+        this._canvasGC.lineTo(x2 + 0.5, y2);
 
         // Stroke the lines with the specified color.
         this._canvasGC.strokeStyle = verticalColor;
@@ -5046,11 +5046,11 @@ export class DataGrid extends Widget {
         this._canvasGC.beginPath();
 
         // Why do we not need this?
-        // this._canvasGC.moveTo(x, y);
-        // this._canvasGC.lineTo(x + width, y);
+        // this._canvasGC.moveTo(x1, y1);
+        // this._canvasGC.lineTo(x2, y1);
 
-        this._canvasGC.moveTo(x, y + height - 0.5);
-        this._canvasGC.lineTo(x + width, y + height - 0.5);
+        this._canvasGC.moveTo(x1, y2 + 0.5);
+        this._canvasGC.lineTo(x2, y2 + 0.5);
 
         // Stroke the lines with the specified color.
         this._canvasGC.strokeStyle = horizontalColor;

--- a/review/api/datagrid.api.md
+++ b/review/api/datagrid.api.md
@@ -131,16 +131,11 @@ export interface CellGroup {
 export namespace CellGroup {
     export function areCellGroupsIntersecting(group1: CellGroup, group2: CellGroup): boolean;
     export function areCellGroupsIntersectingAtAxis(group1: CellGroup, group2: CellGroup, axis: 'row' | 'column'): boolean;
-    // (undocumented)
-    export function areCellsMerged(dataModel: DataModel, rgn: DataModel.CellRegion, cell1: number[], cell2: number[]): boolean;
-    export function calculateMergeOffsets(dataModel: DataModel, regions: DataModel.CellRegion[], axis: 'row' | 'column', sectionList: SectionList, index: number): [number, number, CellGroup];
     export function getCellGroupsAtColumn(dataModel: DataModel, rgn: DataModel.CellRegion, column: number): CellGroup[];
     export function getCellGroupsAtRegion(dataModel: DataModel, rgn: DataModel.CellRegion): CellGroup[];
     export function getCellGroupsAtRow(dataModel: DataModel, rgn: DataModel.CellRegion, row: number): CellGroup[];
     export function getGroup(dataModel: DataModel, rgn: DataModel.CellRegion, row: number, column: number): CellGroup | null;
     export function getGroupIndex(dataModel: DataModel, rgn: DataModel.CellRegion, row: number, column: number): number;
-    export function isCellGroupAbove(group1: CellGroup, group2: CellGroup): boolean;
-    export function isCellGroupBelow(group1: CellGroup, group2: CellGroup): boolean;
     export function joinCellGroups(groups: CellGroup[]): CellGroup;
     export function joinCellGroupsIntersectingAtAxis(dataModel: DataModel, regions: DataModel.CellRegion[], axis: 'row' | 'column', group: CellGroup): CellGroup;
     export function joinCellGroupWithMergedCellGroups(dataModel: DataModel, group: CellGroup, region: DataModel.CellRegion): CellGroup;


### PR DESCRIPTION
cc. @ibdafna 

This PR improves the performance of the grid by reworking the drawing of merged cells logic.

- Before (resizing/scrolling a 1M cells grid with merged cells freezes):

https://user-images.githubusercontent.com/21197331/188858914-860b06bf-4005-4439-9814-93150ee4e5cc.mp4

- After (resizing/scrolling a 1M cells grid with merged cells works smoothly):

https://user-images.githubusercontent.com/21197331/188859052-f09e20a2-dac7-46a4-b985-4b9cbaf0238e.mp4


Note for the tester: You will see a big difference in performance if you zoom out a lot and show a lot of cells.