### PR TITLE
Switch to using `setTimeout` for all deferred processing.

### DIFF
--- a/packages/polling/src/poll.ts
+++ b/packages/polling/src/poll.ts
@@ -326,13 +326,7 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
   private _state: IPoll.State<T, U, V>;
   private _tick = new PromiseDelegate<this>();
   private _ticked = new Signal<this, IPoll.State<T, U, V>>(this);
-  /*
-   * If set, the timeout handle for this poller. We use this complex formulation
-   * for the type since the NodeJS environment has a different return type
-   * (`NodeJS.Timeout`) from the browser environment (`number`) and we want this
-   * to compile in both places.
-   */
-  private _timeout?: ReturnType<typeof setTimeout>;
+  private _timeout?: ReturnType<typeof setTimeout>; // Support node and browser.
 }
 
 /**
@@ -401,8 +395,7 @@ export namespace Poll {
     standby?: Standby | (() => boolean | Standby);
   }
   /**
-   * An interval value that indicates the poll should tick immediately,
-   * i.e. 0 msec.
+   * An interval value (0ms) that indicates the poll should tick immediately.
    */
   export const IMMEDIATE = 0;
 

--- a/packages/polling/src/poll.ts
+++ b/packages/polling/src/poll.ts
@@ -10,22 +10,6 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { IPoll } from './index';
 
 /**
- * A function to defer an action immediately.
- */
-const defer =
-  typeof requestAnimationFrame === 'function'
-    ? requestAnimationFrame
-    : setImmediate;
-
-/**
- * A function to cancel a deferred action.
- */
-const cancel: (timeout: any) => void =
-  typeof cancelAnimationFrame === 'function'
-    ? cancelAnimationFrame
-    : clearImmediate;
-
-/**
  * A class that wraps an asynchronous function to poll at a regular interval
  * with exponential increases to the interval length if the poll fails.
  *
@@ -64,7 +48,7 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
     this.name = options.name || Private.DEFAULT_NAME;
 
     if ('auto' in options ? options.auto : true) {
-      defer(() => void this.start());
+      setTimeout(() => this.start());
     }
   }
 
@@ -227,7 +211,6 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
     }
 
     // Update poll state.
-    const last = this.state;
     const pending = this._tick;
     const scheduled = new PromiseDelegate<this>();
     const state = {
@@ -241,16 +224,17 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
     this._tick = scheduled;
 
     // Clear the schedule if possible.
-    if (last.interval === Poll.IMMEDIATE) {
-      cancel(this._timeout);
-    } else {
-      clearTimeout(this._timeout);
-    }
+    clearTimeout(this._timeout);
 
     // Emit ticked signal, resolve pending promise, and await its settlement.
     this._ticked.emit(this.state);
     pending.resolve(this);
     await pending.promise;
+
+    if (state.interval === Poll.NEVER) {
+      this._timeout = undefined;
+      return;
+    }
 
     // Schedule next execution and cache its timeout handle.
     const execute = () => {
@@ -260,12 +244,7 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
 
       this._execute();
     };
-    this._timeout =
-      state.interval === Poll.IMMEDIATE
-        ? defer(execute)
-        : state.interval === Poll.NEVER
-        ? -1
-        : setTimeout(execute, state.interval);
+    this._timeout = setTimeout(execute, state.interval);
   }
 
   /**
@@ -347,7 +326,13 @@ export class Poll<T = any, U = any, V extends string = 'standby'>
   private _state: IPoll.State<T, U, V>;
   private _tick = new PromiseDelegate<this>();
   private _ticked = new Signal<this, IPoll.State<T, U, V>>(this);
-  private _timeout: any = -1;
+  /*
+   * If set, the timeout handle for this poller. We use this complex formulation
+   * for the type since the NodeJS environment has a different return type
+   * (`NodeJS.Timeout`) from the browser environment (`number`) and we want this
+   * to compile in both places.
+   */
+  private _timeout?: ReturnType<typeof setTimeout>;
 }
 
 /**
@@ -416,7 +401,8 @@ export namespace Poll {
     standby?: Standby | (() => boolean | Standby);
   }
   /**
-   * An interval value that indicates the poll should tick immediately.
+   * An interval value that indicates the poll should tick immediately,
+   * i.e. 0 msec.
    */
   export const IMMEDIATE = 0;
 


### PR DESCRIPTION
As noted on issue #392, using `requestAnimationFrame` means that no deferred tasks can take place while the user has the browser window in the background. This can lead to a bad experience for long-lasting tasks, particularly setup tasks (when a user might start JupyterLab, switch somewhere else when it loads, and then come back).

This change instead uses `setTimeout` (with a timeout of zero, either implicitly or explicitly), which immediately puts the task on the event loop to be run (subject to less severe browser throttling). This allows these tasks to occur in the background (and should hopefully not be too taxing on user resources).

https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#timeouts_in_inactive_tabs

> Firefox Desktop and Chrome both have a minimum timeout of 1 second > for inactive tabs.