### PR TITLE
Automated Changelog Entry for 2022.9.15-alpha.6 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2022.9.15-alpha.6
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/algorithm@2.0.0-alpha.5...14aed9f818ef3d6dac4693eb3d7722dc27820664))
+
+### Enhancements made
+
+- Improve title on accordion label [#406](https://github.com/jupyterlab/lumino/pull/406) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Fix resizing and mode switching in `DockPanel` [#411](https://github.com/jupyterlab/lumino/pull/411) ([@afshin](https://github.com/afshin))
+- Fix labelledby to support multiple elements on page [#407](https://github.com/jupyterlab/lumino/pull/407) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Bump packages to v2 alpha 6 [#413](https://github.com/jupyterlab/lumino/pull/413) ([@fcollonval](https://github.com/fcollonval))
+- Bump actions/setup-node from 1 to 3 [#405](https://github.com/jupyterlab/lumino/pull/405) ([@dependabot](https://github.com/dependabot))
+- Bump tj-actions/changed-files from 29.0.3 to 29.0.4 [#404](https://github.com/jupyterlab/lumino/pull/404) ([@dependabot](https://github.com/dependabot))
+- Bump actions/cache from 2 to 3 [#403](https://github.com/jupyterlab/lumino/pull/403) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-09-09&to=2022-09-15&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-09-09..2022-09-15&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2022-09-09..2022-09-15&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-09-09..2022-09-15&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Avidartf+updated%3A2022-09-09..2022-09-15&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2022.9.9-alpha.5
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/algorithm@2.0.0-alpha.4...9ddf6c5dc51e04f0a289ebfb2f2e9993b2b87a48))
@@ -25,8 +53,6 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-09-06&to=2022-09-09&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-09-06..2022-09-09&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2022-09-06..2022-09-09&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-09-06..2022-09-09&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Agabalafou+updated%3A2022-09-06..2022-09-09&type=Issues) | [@thetorpedodog](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Athetorpedodog+updated%3A2022-09-06..2022-09-09&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2022-09-06..2022-09-09&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2022.9.6
 


### PR DESCRIPTION
Automated Changelog Entry for 2022.9.15-alpha.6 on main
```
npm workspace versions:
@lumino/example-accordionpanel: 0.9.0-alpha.6
@lumino/example-datagrid: 0.33.0-alpha.6
@lumino/example-dockpanel: 0.22.0-alpha.6
@lumino/example-dockpanel-amd: 0.5.0-alpha.6
@lumino/example-dockpanel-iife: 0.5.0-alpha.6
@lumino/algorithm: 2.0.0-alpha.6
@lumino/application: 2.0.0-alpha.6
@lumino/collections: 2.0.0-alpha.6
@lumino/commands: 2.0.0-alpha.6
@lumino/coreutils: 2.0.0-alpha.6
@lumino/datagrid: 1.0.0-alpha.6
@lumino/default-theme: 1.0.0-alpha.6
@lumino/disposable: 2.0.0-alpha.6
@lumino/domutils: 2.0.0-alpha.6
@lumino/dragdrop: 2.0.0-alpha.6
@lumino/keyboard: 2.0.0-alpha.6
@lumino/messaging: 2.0.0-alpha.6
@lumino/polling: 2.0.0-alpha.6
@lumino/properties: 2.0.0-alpha.6
@lumino/signaling: 2.0.0-alpha.6
@lumino/virtualdom: 2.0.0-alpha.6
@lumino/widgets: 2.0.0-alpha.6
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/lumino/releases/tag/untagged-b9c3aa563af4f0ec15de  |
| Since | @lumino/algorithm@2.0.0-alpha.5 |