### PR TITLE
Follow on to #411 addressing `yield*`

### DIFF
--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -24,7 +24,7 @@ In many places where the Lumino `iter()` utility function has been replaced in L
 
 ### Consider `yield*` usage carefully
 
-If you have a method or function that returns an `Iterable` or `IterableIterator`, you might simply return values using the `yield` keyword. If you are returning the contents of another iterable, you can use `yield*`. However, if your logic depends on some predicate, remember that the predicate is check _when you iterate_ if you use `yield*`. For example, consider the following:
+If you have a method or function that returns an iterator, you might simply return values using the `yield` keyword. If you are returning the contents of another iterable, you can use `yield*`. However, if your logic depends on some predicate, remember that the predicate is checked _when you iterate_ if you use `yield*`. For example, consider the following:
 
 ```typescript
 const source = [1, 2, 3, 4, 5];
@@ -36,6 +36,7 @@ function* counter(): IterableIterator {
   }
 }
 
+// This is how a client would use the `counter()` function.
 const iterable = counter();
 flagged = true;
 console.log(Array.from(iterable)); // []
@@ -44,6 +45,8 @@ console.log(Array.from(iterable)); // []
 Instead, if we modify the code:
 
 ```typescript
+import { empty } from '@lumino/algorithm';
+
 const source = [1, 2, 3, 4, 5];
 let flagged = false;
 
@@ -54,12 +57,13 @@ function counter(): IterableIterator<number> {
   return empty();
 }
 
+// This is how a client would use the `counter()` function.
 const iterable = counter();
 flagged = true;
 console.log(Array.from(iterable)); // [1, 2, 3, 4. 5]
 ```
 
-Both are _correct_, but depending on your use case, one may be more appropriate than the other. Crucially, the two implementations are _not_ identical.
+In these two examples, the client code that consumes `counter()` is identical. But the results are different. Both implementations are _correct_, but depending on your use case, one may be more appropriate than the other. The important thing to consider is that the two implementations are _not_ identical and yield different results.
 
 ### Use `Array.from(...)` sparingly
 

--- a/packages/algorithm/src/empty.ts
+++ b/packages/algorithm/src/empty.ts
@@ -11,8 +11,6 @@
 /**
  * Create an empty iterator.
  *
- * @deprecated
- *
  * @returns A new iterator which yields nothing.
  *
  * #### Example

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -7,7 +7,7 @@
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
-import { ArrayExt } from '@lumino/algorithm';
+import { ArrayExt, empty } from '@lumino/algorithm';
 
 import { ElementExt } from '@lumino/domutils';
 
@@ -146,7 +146,7 @@ export class DockLayout extends Layout {
    * This iterator includes the generated tab bars.
    */
   [Symbol.iterator](): IterableIterator<Widget> {
-    return this._root ? this._root.iterAllWidgets() : Private.empty;
+    return this._root ? this._root.iterAllWidgets() : empty();
   }
 
   /**
@@ -158,7 +158,7 @@ export class DockLayout extends Layout {
    * This iterator does not include the generated tab bars.
    */
   widgets(): IterableIterator<Widget> {
-    return this._root ? this._root.iterUserWidgets() : Private.empty;
+    return this._root ? this._root.iterUserWidgets() : empty();
   }
 
   /**
@@ -171,7 +171,7 @@ export class DockLayout extends Layout {
    * of each tab bar in the layout.
    */
   selectedWidgets(): IterableIterator<Widget> {
-    return this._root ? this._root.iterSelectedWidgets() : Private.empty;
+    return this._root ? this._root.iterSelectedWidgets() : empty();
   }
 
   /**
@@ -183,7 +183,7 @@ export class DockLayout extends Layout {
    * This iterator does not include the user widgets.
    */
   tabBars(): IterableIterator<TabBar<Widget>> {
-    return this._root ? this._root.iterTabBars() : Private.empty;
+    return this._root ? this._root.iterTabBars() : empty();
   }
 
   /**
@@ -192,7 +192,7 @@ export class DockLayout extends Layout {
    * @returns A new iterator over the handles in the layout.
    */
   handles(): IterableIterator<HTMLDivElement> {
-    return this._root ? this._root.iterHandles() : Private.empty;
+    return this._root ? this._root.iterHandles() : empty();
   }
 
   /**
@@ -1424,11 +1424,6 @@ export namespace DockLayout {
  * The namespace for the module implementation details.
  */
 namespace Private {
-  /**
-   * An empty iterator.
-   */
-  export const empty = [][Symbol.iterator]();
-
   /**
    * A fraction used for sizing root panels; ~= `1 / golden_ratio`.
    */

--- a/review/api/algorithm.api.md
+++ b/review/api/algorithm.api.md
@@ -53,7 +53,7 @@ export function chain<T>(...objects: Iterable<T>[]): IterableIterator<T>;
 // @public @deprecated
 export function each<T>(object: Iterable<T>, fn: (value: T, index: number) => boolean | void): void;
 
-// @public @deprecated
+// @public
 export function empty<T>(): IterableIterator<T>;
 
 // @public


### PR DESCRIPTION
This PR:
- adds a section in the migration guide for `yield*` usage
- un-deprecates `empty()`

cc: @vidartf, you might find this and https://github.com/jupyterlab/lumino/pull/411 interesting