### PR TITLE
Add support for list of keystrokes

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1186,26 +1186,40 @@ export namespace CommandRegistry {
   }
 
   /**
-   * Format a keystroke for display on the local system.
+   * Format keystrokes for display on the local system.
+   *
+   * If a list of keystrokes is provided, it will be displayed as
+   * a comma-separated string
+   *
+   * @param keystroke The keystrokes to format
+   * @returns The keystrokes representation
    */
-  export function formatKeystroke(keystroke: string): string {
-    let mods = [];
-    let separator = Platform.IS_MAC ? ' ' : '+';
-    let parts = parseKeystroke(keystroke);
-    if (parts.ctrl) {
-      mods.push('Ctrl');
+  export function formatKeystroke(
+    keystroke: string | readonly string[]
+  ): string {
+    return typeof keystroke === 'string'
+      ? formatSingleKey(keystroke)
+      : keystroke.map(formatSingleKey).join(', ');
+
+    function formatSingleKey(key: string) {
+      let mods = [];
+      let separator = Platform.IS_MAC ? ' ' : '+';
+      let parts = parseKeystroke(key);
+      if (parts.ctrl) {
+        mods.push('Ctrl');
+      }
+      if (parts.alt) {
+        mods.push('Alt');
+      }
+      if (parts.shift) {
+        mods.push('Shift');
+      }
+      if (Platform.IS_MAC && parts.cmd) {
+        mods.push('Cmd');
+      }
+      mods.push(parts.key);
+      return mods.map(Private.formatKey).join(separator);
     }
-    if (parts.alt) {
-      mods.push('Alt');
-    }
-    if (parts.shift) {
-      mods.push('Shift');
-    }
-    if (Platform.IS_MAC && parts.cmd) {
-      mods.push('Cmd');
-    }
-    mods.push(parts.key);
-    return mods.map(Private.formatKey).join(separator);
   }
 
   /**

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -1271,6 +1271,11 @@ describe('@lumino/commands', () => {
           expect(label).to.equal('Alt+Down');
         }
       });
+
+      it('should format a list of keys', () => {
+        let label = CommandRegistry.formatKeystroke(['D', 'D']);
+        expect(label).to.equal('D, D');
+      });
     });
 
     describe('.normalizeKeystroke()', () => {

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -957,9 +957,7 @@ export namespace CommandPalette {
      */
     formatItemShortcut(data: IItemRenderData): h.Child {
       let kb = data.item.keyBinding;
-      return kb
-        ? kb.keys.map(CommandRegistry.formatKeystroke).join(', ')
-        : null;
+      return kb ? CommandRegistry.formatKeystroke(kb.keys) : null;
     }
 
     /**

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1369,9 +1369,7 @@ export namespace Menu {
      */
     formatShortcut(data: IRenderData): h.Child {
       let kb = data.item.keyBinding;
-      return kb
-        ? kb.keys.map(CommandRegistry.formatKeystroke).join(', ')
-        : null;
+      return kb ? CommandRegistry.formatKeystroke(kb.keys) : null;
     }
   }
 

--- a/review/api/commands.api.md
+++ b/review/api/commands.api.md
@@ -48,7 +48,7 @@ export namespace CommandRegistry {
     export type Description = {
         args: ReadonlyJSONObject | null;
     };
-    export function formatKeystroke(keystroke: string): string;
+    export function formatKeystroke(keystroke: string | readonly string[]): string;
     export interface ICommandChangedArgs {
         readonly id: string | undefined;
         readonly type: 'added' | 'removed' | 'changed' | 'many-changed';


### PR DESCRIPTION
## Reference

Xref: https://github.com/jupyterlab/jupyterlab/issues/13180


## Code changes

Support passing a list of keys to `Command.formatKeystroke` to get a comma-separated representation as the one used in menus.
