### PR TITLE
Add blocking signal feature

### DIFF
--- a/packages/signaling/package.json
+++ b/packages/signaling/package.json
@@ -44,7 +44,8 @@
     "displayName": "signaling"
   },
   "dependencies": {
-    "@lumino/algorithm": "^2.0.0-alpha.6"
+    "@lumino/algorithm": "^2.0.0-alpha.6",
+    "@lumino/properties": "^2.0.0-alpha.6"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.6.0",

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -32,6 +32,16 @@ export type Slot<T, U> = (sender: T, args: U) => void;
  */
 export interface ISignal<T, U> {
   /**
+   * Block the signal during the execution of a callback.
+   *
+   * ### Notes
+   * The callback function must be synchronous.
+   *
+   * @param fn The callback during which the signal is blocked
+   */
+  block(fn: () => void): void;
+
+  /**
    * Connect a slot to the signal.
    *
    * @param slot - The slot to invoke when the signal is emitted.
@@ -138,6 +148,23 @@ export class Signal<T, U> implements ISignal<T, U> {
   readonly sender: T;
 
   /**
+   * Block the signal during the execution of a callback.
+   *
+   * ### Notes
+   * The callback function must be synchronous.
+   *
+   * @param fn The callback during which the signal is blocked
+   */
+  block(fn: () => void): void {
+    this._blockedCount++;
+    try {
+      fn();
+    } finally {
+      this._blockedCount--;
+    }
+  }
+
+  /**
    * Connect a slot to the signal.
    *
    * @param slot - The slot to invoke when the signal is emitted.
@@ -176,14 +203,38 @@ export class Signal<T, U> implements ISignal<T, U> {
    * Exceptions thrown by connected slots will be caught and logged.
    */
   emit(args: U): void {
-    Private.emit(this, args);
+    if (!this._blockedCount) {
+      Private.emit(this, args);
+    }
   }
+
+  private _blockedCount = 0;
 }
 
 /**
  * The namespace for the `Signal` class statics.
  */
 export namespace Signal {
+  /**
+   * Block all signals emitted by an object during
+   * the execution of a callback.
+   *
+   * ### Notes
+   * The callback function must be synchronous.
+   *
+   * @param sender The signals sender
+   * @param fn The callback during which all signals are blocked
+   */
+  export function blockAll(sender: unknown, fn: () => void): void {
+    Private.blockedSenders.unshift(sender);
+    try {
+      fn();
+    } finally {
+      const index = Private.blockedSenders.indexOf(sender);
+      Private.blockedSenders.splice(index, 1);
+    }
+  }
+
   /**
    * Remove all connections between a sender and receiver.
    *
@@ -524,6 +575,10 @@ namespace Private {
    * Exceptions thrown by connected slots will be caught and logged.
    */
   export function emit<T, U>(signal: Signal<T, U>, args: U): void {
+    if (blockedSenders.includes(signal.sender)) {
+      return;
+    }
+
     // If there are no receivers, there is nothing to do.
     let receivers = receiversForSender.get(signal.sender);
     if (!receivers || receivers.length === 0) {
@@ -664,4 +719,12 @@ namespace Private {
   function isDeadConnection(connection: IConnection): boolean {
     return connection.signal === null;
   }
+
+  /**
+   * The list of senders that are blocked.
+   *
+   * ### Notes
+   * This is an array as a sender may be blocked recursively
+   */
+  export const blockedSenders: Array<unknown> = [];
 }

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -724,7 +724,7 @@ namespace Private {
    * The list of senders that are blocked.
    *
    * ### Notes
-   * This is an array as a sender may be blocked recursively
+   * This is an array as a sender may be blocked recursively.
    */
   export const blockedSenders: Array<unknown> = [];
 }

--- a/packages/signaling/tests/src/index.spec.ts
+++ b/packages/signaling/tests/src/index.spec.ts
@@ -74,7 +74,7 @@ describe('@lumino/signaling', () => {
         obj.two.connect(handler2.onTwo, handler2);
 
         obj.two.block(() => {
-          obj.two.emit(15);
+          obj.two.emit(4);
         });
 
         expect(handler1.twoSender).to.equal(null);
@@ -97,7 +97,7 @@ describe('@lumino/signaling', () => {
         obj.two.connect(handler2.onTwo, handler2);
 
         obj.two.block(() => {
-          obj.two.emit(15);
+          obj.two.emit(4);
           obj.two.block(() => {
             obj.two.emit(42);
           });
@@ -351,7 +351,7 @@ describe('@lumino/signaling', () => {
       });
     });
 
-    describe('.block()', () => {
+    describe('.blockAll()', () => {
       it('should block all signals from a given sender', () => {
         let obj = new TestObject();
         let handler1 = new TestHandler();

--- a/packages/signaling/tests/src/index.spec.ts
+++ b/packages/signaling/tests/src/index.spec.ts
@@ -396,7 +396,7 @@ describe('@lumino/signaling', () => {
             obj.one.emit(undefined);
             obj.two.emit(12);
           });
-          
+
           obj.one.emit(undefined);
           obj.two.emit(6);
         });

--- a/packages/signaling/tests/src/index.spec.ts
+++ b/packages/signaling/tests/src/index.spec.ts
@@ -101,6 +101,7 @@ describe('@lumino/signaling', () => {
           obj.two.block(() => {
             obj.two.emit(42);
           });
+          obj.two.emit(6);
         });
 
         expect(handler1.twoSender).to.equal(null);
@@ -389,12 +390,15 @@ describe('@lumino/signaling', () => {
 
         Signal.blockAll(obj, () => {
           obj.one.emit(undefined);
-          obj.two.emit(42);
+          obj.two.emit(4);
 
           Signal.blockAll(obj, () => {
             obj.one.emit(undefined);
             obj.two.emit(12);
           });
+          
+          obj.one.emit(undefined);
+          obj.two.emit(6);
         });
 
         expect(handler1.oneCount).to.equal(0);

--- a/review/api/signaling.api.md
+++ b/review/api/signaling.api.md
@@ -6,6 +6,7 @@
 
 // @public
 export interface ISignal<T, U> {
+    block(fn: () => void): void;
     connect(slot: Slot<T, U>, thisArg?: any): boolean;
     disconnect(slot: Slot<T, U>, thisArg?: any): boolean;
 }
@@ -13,6 +14,7 @@ export interface ISignal<T, U> {
 // @public
 export class Signal<T, U> implements ISignal<T, U> {
     constructor(sender: T);
+    block(fn: () => void): void;
     connect(slot: Slot<T, U>, thisArg?: unknown): boolean;
     disconnect(slot: Slot<T, U>, thisArg?: unknown): boolean;
     emit(args: U): void;
@@ -21,6 +23,7 @@ export class Signal<T, U> implements ISignal<T, U> {
 
 // @public
 export namespace Signal {
+    export function blockAll(sender: unknown, fn: () => void): void;
     export function clearData(object: unknown): void;
     export function disconnectAll(object: unknown): void;
     export function disconnectBetween(sender: unknown, receiver: unknown): void;


### PR DESCRIPTION
## Reference

Add blocking signal feature - this inspired by the [Qt signal API](https://doc.qt.io/qt-6/qobject.html#blockSignals).

Use cases are:
- To reset an object to a given state
- When you are synchronizing two objects, you need to temporary break the signal loop (this is the primary goal to ease code clarity for synchronizing modelDB and shared models).

It will block signal emission for the duration of a synchronous callback

## Code changes

Add 
- `ISignal.block(callback: () => void): void` to block a single signal during a callback execution
- and `Signal.blockAll(sender, callback: () => void): void` to block all signals during a callback execution from a given sender.