### PR TITLE
Datagrid: Do not prevent page scroll if we are not actually scrolling the grid

### DIFF
--- a/packages/datagrid/src/basicmousehandler.ts
+++ b/packages/datagrid/src/basicmousehandler.ts
@@ -682,8 +682,23 @@ export class BasicMouseHandler implements DataGrid.IMouseHandler {
         throw 'unreachable';
     }
 
-    // Scroll by the desired amount.
-    grid.scrollBy(dx, dy);
+    // Only scroll and stop the event propagation if needed.
+    if (
+      // Scrolling left and not reached min already
+      (dx < 0 && grid.scrollX !== 0) ||
+      // Scrolling right and not reached max already
+      (dx > 0 && grid.scrollX !== grid.maxScrollX) ||
+      // Scrolling top and not reached min already
+      (dy < 0 && grid.scrollY !== 0) ||
+      // Scrolling down and not reached max already
+      (dy > 0 && grid.scrollY !== grid.maxScrollY)
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      // Scroll by the desired amount.
+      grid.scrollBy(dx, dy);
+    }
   }
 
   /**

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -3088,10 +3088,6 @@ export class DataGrid extends Widget {
       return;
     }
 
-    // Stop the event propagation.
-    event.preventDefault();
-    event.stopPropagation();
-
     // Dispatch to the mouse handler.
     this._mouseHandler.onWheel(this, event);
   }


### PR DESCRIPTION
The Datagrid was always preventing the propagation of the wheel event, preventing the scrolling of the page when using the wheel on top of a grid that does not need scrolling. This PR fixes it by only stopping the propagation if the grid actually needs scrolling.

cc. @ibdafna 

https://user-images.githubusercontent.com/21197331/196924993-bb0c246d-e598-4597-b30e-5c80684f264a.mp4