### PR TITLE
Add async iterable `Stream` class that inherits from `Signal`

### DIFF
--- a/packages/signaling/package.json
+++ b/packages/signaling/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@lumino/algorithm": "^2.0.0-alpha.6",
+    "@lumino/coreutils": "^2.0.0-alpha.6",
     "@lumino/properties": "^2.0.0-alpha.6"
   },
   "devDependencies": {

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -86,6 +86,13 @@ export interface ISignal<T, U> {
 }
 
 /**
+ * An object that is both a signal and an async iterable iterator.
+ */
+export interface IStream<T, U>
+  extends ISignal<T, U>,
+    AsyncIterableIterator<U> {}
+
+/**
  * A concrete implementation of `ISignal`.
  *
  * #### Example
@@ -345,10 +352,7 @@ export namespace Signal {
 /**
  * A stream with the characteristics of a signal and an async iterator.
  */
-export class Stream<T, U>
-  extends Signal<T, U>
-  implements AsyncIterableIterator<U>
-{
+export class Stream<T, U> extends Signal<T, U> implements IStream<T, U> {
   /**
    * Return an async iterator that yields every emission.
    */

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -345,9 +345,9 @@ export namespace Signal {
 /**
  * A stream with the characteristics of a signal and an async iterator.
  */
-  export class Stream<T, U>
-    extends Signal<T, U>
-    implements AsyncIterableIterator<U>
+export class Stream<T, U>
+  extends Signal<T, U>
+  implements AsyncIterableIterator<U>
 {
   /**
    * Return an async iterator that yields every emission.

--- a/packages/signaling/tests/src/index.spec.ts
+++ b/packages/signaling/tests/src/index.spec.ts
@@ -585,30 +585,33 @@ describe('@lumino/signaling', () => {
 
   describe('Stream', () => {
     describe('#[Symbol.asyncIterator]()', () => {
-      it('should yield emissions and respected blocking', async () => {
+      it('should yield emissions and respect blocking', async () => {
         const stream = new Stream<unknown, string>({});
-        const expected = 'async';
+        const input = 'async';
+        const expected = 'aINTERRUPTEDsync';
         let emitted = '';
+        let once = true;
+        stream.connect((_, emitted) => {
+          if (once) {
+            once = false;
+            stream.emit('I');
+            stream.emit('N');
+            stream.emit('T');
+            stream.emit('E');
+            stream.emit('R');
+            stream.emit('R');
+            stream.emit('U');
+            stream.emit('P');
+            stream.emit('T');
+            stream.emit('E');
+            stream.emit('D');
+          }
+        });
         setTimeout(() => stream.block(() => stream.emit('BLOCKED EMISSION 1')));
-        expected.split('').forEach(x => setTimeout(() => stream.emit(x)));
+        input.split('').forEach(x => setTimeout(() => stream.emit(x)));
         setTimeout(() => stream.block(() => stream.emit('BLOCKED EMISSION 2')));
         for await (const letter of stream) {
           emitted = emitted.concat(letter);
-          if (emitted === expected) break;
-        }
-      });
-    });
-
-    describe('#next()', () => {
-      it('should resolve an iterator result and respect blocking', async () => {
-        const stream = new Stream<unknown, string>({});
-        const expected = 'next';
-        let emitted = '';
-        setTimeout(() => stream.block(() => stream.emit('BLOCKED EMISSION 1')));
-        expected.split('').forEach(x => setTimeout(() => stream.emit(x)));
-        setTimeout(() => stream.block(() => stream.emit('BLOCKED EMISSION 2')));
-        for (let it = await stream.next(); !it.done; it = await stream.next()) {
-          emitted = emitted.concat(it.value);
           if (emitted === expected) break;
         }
       });

--- a/packages/signaling/tests/src/index.spec.ts
+++ b/packages/signaling/tests/src/index.spec.ts
@@ -615,6 +615,32 @@ describe('@lumino/signaling', () => {
           if (emitted === expected) break;
         }
       });
+      it('should return an async iterator', async () => {
+        const stream = new Stream<unknown, string>({});
+        const input = 'iterator';
+        const expected = 'iAHEMterator';
+        let emitted = '';
+        let once = true;
+        stream.connect((_, emitted) => {
+          if (once) {
+            once = false;
+            stream.emit('A');
+            stream.emit('H');
+            stream.emit('E');
+            stream.emit('M');
+          }
+        });
+        setTimeout(() => stream.block(() => stream.emit('BLOCKED EMISSION 1')));
+        input.split('').forEach(x => setTimeout(() => stream.emit(x)));
+        setTimeout(() => stream.block(() => stream.emit('BLOCKED EMISSION 2')));
+        let it = stream[Symbol.asyncIterator]();
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const emission = await it.next();
+          emitted = emitted.concat(emission.value);
+          if (emitted === expected) break;
+        }
+      });
     });
   });
 });

--- a/packages/signaling/tests/src/index.spec.ts
+++ b/packages/signaling/tests/src/index.spec.ts
@@ -638,13 +638,13 @@ describe('@lumino/signaling', () => {
         input.split('').forEach(x => wait.then(() => stream.emit(x)));
         wait.then(() => stream.block(() => stream.emit('BLOCKED EMISSION 2')));
         wait.then(() => stream.stop());
+
         let it = stream[Symbol.asyncIterator]();
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-          const emission = await it.next();
-          emitted = emitted.concat(emission.value || '');
-          if (emission.done) break;
+        let emission: IteratorResult<string, any>;
+        while (!(emission = await it.next()).done) {
+          emitted = emitted.concat(emission.value);
         }
+
         expect(emitted).to.equal(expected);
       });
     });
@@ -699,13 +699,13 @@ describe('@lumino/signaling', () => {
         });
         input.split('').forEach(x => wait.then(() => stream.emit(x)));
         wait.then(() => stream.stop());
+
         let it = stream[Symbol.asyncIterator]();
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-          const emission = await it.next();
-          emitted = emitted.concat(emission.value || '');
-          if (emission.done) break;
+        let emission: IteratorResult<string, any>;
+        while (!(emission = await it.next()).done) {
+          emitted = emitted.concat(emission.value);
         }
+
         expect(emitted).to.equal(expected);
       });
     });

--- a/packages/signaling/tests/src/index.spec.ts
+++ b/packages/signaling/tests/src/index.spec.ts
@@ -639,7 +639,7 @@ describe('@lumino/signaling', () => {
         wait.then(() => stream.block(() => stream.emit('BLOCKED EMISSION 2')));
         wait.then(() => stream.stop());
 
-        let it = stream[Symbol.asyncIterator]();
+        const it = stream[Symbol.asyncIterator]();
         let emission: IteratorResult<string, any>;
         while (!(emission = await it.next()).done) {
           emitted = emitted.concat(emission.value);
@@ -700,7 +700,7 @@ describe('@lumino/signaling', () => {
         input.split('').forEach(x => wait.then(() => stream.emit(x)));
         wait.then(() => stream.stop());
 
-        let it = stream[Symbol.asyncIterator]();
+        const it = stream[Symbol.asyncIterator]();
         let emission: IteratorResult<string, any>;
         while (!(emission = await it.next()).done) {
           emitted = emitted.concat(emission.value);

--- a/packages/signaling/tests/src/index.spec.ts
+++ b/packages/signaling/tests/src/index.spec.ts
@@ -593,7 +593,7 @@ describe('@lumino/signaling', () => {
         expected.split('').forEach(x => setTimeout(() => stream.emit(x)));
         setTimeout(() => stream.block(() => stream.emit('BLOCKED EMISSION 2')));
         for await (const letter of stream) {
-          emitted = emitted.concat(letter)
+          emitted = emitted.concat(letter);
           if (emitted === expected) break;
         }
       });

--- a/review/api/signaling.api.md
+++ b/review/api/signaling.api.md
@@ -4,9 +4,6 @@
 
 ```ts
 
-import { AttachedProperty } from '@lumino/properties';
-import { PromiseDelegate } from '@lumino/coreutils';
-
 // @public
 export interface ISignal<T, U> {
     block(fn: () => void): void;
@@ -49,8 +46,6 @@ export type Slot<T, U> = (sender: T, args: U) => void;
 export class Stream<T, U> extends Signal<T, U> implements IStream<T, U> {
     [Symbol.asyncIterator](): AsyncIterableIterator<U>;
     emit(args: U): void;
-    // Warning: (ae-forgotten-export) The symbol "Private" needs to be exported by the entry point index.d.ts
-    protected pending: Private.Pending<U>;
     stop(): void;
 }
 

--- a/review/api/signaling.api.md
+++ b/review/api/signaling.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import { PromiseDelegate } from '@lumino/coreutils';
+
 // @public
 export interface ISignal<T, U> {
     block(fn: () => void): void;
@@ -15,6 +17,7 @@ export interface ISignal<T, U> {
 export class Signal<T, U> implements ISignal<T, U> {
     constructor(sender: T);
     block(fn: () => void): void;
+    protected blocked: number;
     connect(slot: Slot<T, U>, thisArg?: unknown): boolean;
     disconnect(slot: Slot<T, U>, thisArg?: unknown): boolean;
     emit(args: U): void;
@@ -36,6 +39,14 @@ export namespace Signal {
 
 // @public
 export type Slot<T, U> = (sender: T, args: U) => void;
+
+// @public
+export class Stream<T, U> extends Signal<T, U> implements AsyncIterableIterator<U> {
+    [Symbol.asyncIterator](): AsyncIterableIterator<U>;
+    emit(args: U): void;
+    next(): Promise<IteratorResult<U>>;
+    protected pending: PromiseDelegate<U>;
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/review/api/signaling.api.md
+++ b/review/api/signaling.api.md
@@ -51,6 +51,7 @@ export class Stream<T, U> extends Signal<T, U> implements IStream<T, U> {
     emit(args: U): void;
     // Warning: (ae-forgotten-export) The symbol "Private" needs to be exported by the entry point index.d.ts
     protected pending: Private.Pending<U>;
+    stop(): void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/review/api/signaling.api.md
+++ b/review/api/signaling.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AttachedProperty } from '@lumino/properties';
 import { PromiseDelegate } from '@lumino/coreutils';
 
 // @public
@@ -14,7 +15,7 @@ export interface ISignal<T, U> {
 }
 
 // @public
-export interface IStream<T, U> extends ISignal<T, U>, AsyncIterableIterator<U> {
+export interface IStream<T, U> extends ISignal<T, U>, AsyncIterable<U> {
 }
 
 // @public
@@ -48,8 +49,8 @@ export type Slot<T, U> = (sender: T, args: U) => void;
 export class Stream<T, U> extends Signal<T, U> implements IStream<T, U> {
     [Symbol.asyncIterator](): AsyncIterableIterator<U>;
     emit(args: U): void;
-    next(): Promise<IteratorResult<U>>;
-    protected pending: PromiseDelegate<U>;
+    // Warning: (ae-forgotten-export) The symbol "Private" needs to be exported by the entry point index.d.ts
+    protected pending: Private.Pending<U>;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/review/api/signaling.api.md
+++ b/review/api/signaling.api.md
@@ -14,6 +14,10 @@ export interface ISignal<T, U> {
 }
 
 // @public
+export interface IStream<T, U> extends ISignal<T, U>, AsyncIterableIterator<U> {
+}
+
+// @public
 export class Signal<T, U> implements ISignal<T, U> {
     constructor(sender: T);
     block(fn: () => void): void;
@@ -41,7 +45,7 @@ export namespace Signal {
 export type Slot<T, U> = (sender: T, args: U) => void;
 
 // @public
-export class Stream<T, U> extends Signal<T, U> implements AsyncIterableIterator<U> {
+export class Stream<T, U> extends Signal<T, U> implements IStream<T, U> {
     [Symbol.asyncIterator](): AsyncIterableIterator<U>;
     emit(args: U): void;
     next(): Promise<IteratorResult<U>>;


### PR DESCRIPTION
This PR adds a `Stream` class that `extends Signal` and implements `IStream`, which means that in addition to being a signal, it is also an async iterable. It can be used as a drop-in replacement for any `Signal` (or `ISignal`) in an application if the author wishes to expose an async iterable API to complement signal connection/disconnection.

This PR also exposes a `protected blocked: number` property of a `Signal` so that sub-classes can implement correct blocking behavior.

## Examples

### Subscribe to a stream via `connect`/`disconnect`:
```ts
// Instantiate a stream.
const stream = new Stream<unknown, string>({});

// Connect a handler to the stream.
const handler = (_, args) => console.log(`emission is: ${args}`);
stream.connect(handler);

stream.emit('foo');
// [OUTPUT] emission is: foo

stream.emit('bar');
// [OUTPUT] emission is: bar

stream.emit('baz');
// [OUTPUT] emission is: baz

// Disconnect the stream handler.
stream.disconnect(handler);
```

### Subscribe to a stream as an async iterable:
```ts
// Instantiate a stream.
const stream = new Stream<unknown, string>({});

// Iterate over stream as an iterable.
void (async () => {
  for await (const emission of stream) {
    console.log(`emission is: ${emission}`);
  }
  console.log('stream stopped');
})();

stream.emit('foo');
// [OUTPUT] emission is: foo

stream.emit('bar');
// [OUTPUT] emission is: bar

stream.emit('baz');
// [OUTPUT] emission is: baz

stream.stop();
// [OUTPUT] stream stopped
```

### Generate an async iterator over the stream.
```ts
// Instantiate a stream.
const stream = new Stream<unknown, string>({});

// Loop through the stream iterator.
void (async () => {
  const it = stream[Symbol.asyncIterator]();
  let emission: IteratorResult<string, any>;
  while (!(emission = await it.next()).done) {
    console.log(`emission is: ${emission.value}`);
  }
  console.log('stream stopped');
})();

stream.emit('foo');
// [OUTPUT] emission is: foo

stream.emit('bar');
// [OUTPUT] emission is: bar

stream.emit('baz');
// [OUTPUT] emission is: baz

stream.stop();
// [OUTPUT] stream stopped
```