### PR TITLE
When rejecting the internal promise in a `Stream`, catch failures

### DIFF
--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -385,6 +385,7 @@ export class Stream<T, U> extends Signal<T, U> implements IStream<T, U> {
    * Stop the stream's async iteration.
    */
   stop(): void {
+    this._pending.promise.catch(() => undefined);
     this._pending.reject('stop');
   }
 


### PR DESCRIPTION
This is a minor bug that might manifest in testing suites or in circumstances where a `Stream` instance is stopped when nobody is subscribed to its async iterator.