### PR TITLE
Improve the menubar accessibility

### DIFF
--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -41,7 +41,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v34.3.2
         with:
-          base_sha: 'HEAD~1'
+          since_last_remote_commit: "true"
           sha: 'HEAD'
 
       - name: Push fixes

--- a/examples/example-menubar/index.html
+++ b/examples/example-menubar/index.html
@@ -9,7 +9,7 @@
   <meta charset="UTF-8">
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
   <script type="text/javascript" src="build/bundle.example.js"></script>
-  <title>Menubar Example</title>
+  <title>MenuBar Example</title>
 </head>
 <body>
 </body>

--- a/examples/example-menubar/index.html
+++ b/examples/example-menubar/index.html
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright (c) Jupyter Development Team.
+  ~ Distributed under the terms of the Modified BSD License.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+  <script type="text/javascript" src="build/bundle.example.js"></script>
+  <title>Menubar Example</title>
+</head>
+<body>
+</body>
+</html>

--- a/examples/example-menubar/package.json
+++ b/examples/example-menubar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/example-menubar",
-  "version": "0.9.0-alpha.6",
+  "version": "0.1.0-alpha.6",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",

--- a/examples/example-menubar/package.json
+++ b/examples/example-menubar/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@lumino/example-menubar",
+  "version": "0.9.0-alpha.6",
+  "private": true,
+  "scripts": {
+    "build": "tsc && rollup -c",
+    "clean": "rimraf build"
+  },
+  "dependencies": {
+    "@lumino/default-theme": "^1.0.0-alpha.6",
+    "@lumino/messaging": "^2.0.0-alpha.6",
+    "@lumino/widgets": "^2.0.0-alpha.6"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^13.3.0",
+    "rimraf": "^3.0.2",
+    "rollup": "^2.77.3",
+    "rollup-plugin-styles": "^4.0.0",
+    "typescript": "~4.7.3"
+  }
+}

--- a/examples/example-menubar/rollup.config.js
+++ b/examples/example-menubar/rollup.config.js
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { createRollupConfig } from '../../rollup.examples.config';
+const rollupConfig = createRollupConfig();
+export default rollupConfig;

--- a/examples/example-menubar/src/index.ts
+++ b/examples/example-menubar/src/index.ts
@@ -1,0 +1,104 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { CommandRegistry } from '@lumino/commands';
+import { Menu, MenuBar, PanelLayout, Widget } from '@lumino/widgets';
+
+import '../style/index.css';
+
+class Application extends Widget {
+  constructor() {
+    super({ tag: 'main' });
+  }
+}
+
+class SkipLink extends Widget {
+  static createNode(): HTMLElement {
+    const node = document.createElement('a');
+    node.setAttribute('href', '#content');
+    node.innerHTML = 'Skip to the main content';
+    node.classList.add('lm-example-skip-link');
+    return node;
+  }
+
+  constructor() {
+    super({ node: SkipLink.createNode() });
+  }
+}
+
+class Article extends Widget {
+  static createNode(): HTMLElement {
+    const node = document.createElement('div');
+    node.setAttribute('id', 'content');
+    node.setAttribute('tabindex', '-1');
+    const h1 = document.createElement('h1');
+    h1.innerHTML = 'Menubar Example';
+    node.appendChild(h1);
+    const label = document.createElement('label');
+    label.appendChild(
+      document.createTextNode('A textarea to demonstrate the tab handling.')
+    );
+    const textarea = document.createElement('textarea');
+    textarea.setAttribute('autocomplete', 'off');
+    label.appendChild(textarea);
+    node.appendChild(label);
+    return node;
+  }
+
+  constructor() {
+    super({ node: Article.createNode() });
+  }
+}
+
+function addMenuItem(
+  commands: CommandRegistry,
+  menu: Menu,
+  command: string,
+  label: string,
+  log: string
+): void {
+  commands.addCommand(command, {
+    label: label,
+    execute: () => {
+      console.log(log);
+    }
+  });
+  menu.addItem({
+    type: 'command',
+    command: command
+  });
+}
+
+function main(): void {
+  const app = new Application();
+  const appLayout = new PanelLayout();
+  app.layout = appLayout;
+
+  const skipLink = new SkipLink();
+  appLayout.addWidget(skipLink);
+
+  const menubar = new MenuBar();
+  const commands = new CommandRegistry();
+
+  const fileMenu = new Menu({ commands: commands });
+  fileMenu.title.label = 'File';
+  addMenuItem(commands, fileMenu, 'new', 'New', 'File > New');
+  addMenuItem(commands, fileMenu, 'open', 'Open', 'File > Open');
+  addMenuItem(commands, fileMenu, 'save', 'Save', 'File > Save');
+  menubar.addMenu(fileMenu);
+
+  const editMenu = new Menu({ commands: commands });
+  editMenu.title.label = 'Edit';
+  addMenuItem(commands, editMenu, 'cut', 'Cut', 'Edit > Cut');
+  addMenuItem(commands, editMenu, 'copy', 'Copy', 'Edit > Copy');
+  addMenuItem(commands, editMenu, 'paste', 'Paste', 'Edit > Paste');
+  menubar.addMenu(editMenu);
+  appLayout.addWidget(menubar);
+
+  const article = new Article();
+  appLayout.addWidget(article);
+
+  Widget.attach(app, document.body);
+}
+
+window.onload = main;

--- a/examples/example-menubar/src/index.ts
+++ b/examples/example-menubar/src/index.ts
@@ -49,14 +49,9 @@ class Article extends Widget {
     const h1 = document.createElement('h1');
     h1.innerHTML = 'MenuBar Example';
     node.appendChild(h1);
-    const label = document.createElement('label');
-    label.appendChild(
-      document.createTextNode('A textarea to demonstrate the tab handling.')
-    );
-    const textarea = document.createElement('textarea');
-    textarea.setAttribute('autocomplete', 'off');
-    label.appendChild(textarea);
-    node.appendChild(label);
+    const button = document.createElement('button');
+    button.innerHTML = 'A button you can tab to out of the menubar';
+    node.appendChild(button);
     return node;
   }
 
@@ -96,7 +91,6 @@ function main(): void {
   app.layout = appLayout;
 
   const skipLink = new SkipLink();
-  appLayout.addWidget(skipLink);
 
   const menubar = new MenuBar();
   const commands = new CommandRegistry();
@@ -114,9 +108,11 @@ function main(): void {
   addMenuItem(commands, editMenu, 'copy', 'Copy', 'Edit > Copy');
   addMenuItem(commands, editMenu, 'paste', 'Paste', 'Edit > Paste');
   menubar.addMenu(editMenu);
-  appLayout.addWidget(menubar);
 
   const article = new Article();
+
+  appLayout.addWidget(skipLink);
+  appLayout.addWidget(menubar);
   appLayout.addWidget(article);
 
   Widget.attach(app, document.body);

--- a/examples/example-menubar/src/index.ts
+++ b/examples/example-menubar/src/index.ts
@@ -6,13 +6,22 @@ import { Menu, MenuBar, PanelLayout, Widget } from '@lumino/widgets';
 
 import '../style/index.css';
 
+/**
+ * Wrapper widget containing the example application.
+ */
 class Application extends Widget {
   constructor() {
     super({ tag: 'main' });
   }
 }
 
+/**
+ * Skip link to jump to the main content.
+ */
 class SkipLink extends Widget {
+  /**
+   * Create a HTMLElement that statically links to "#content".
+   */
   static createNode(): HTMLElement {
     const node = document.createElement('a');
     node.setAttribute('href', '#content');
@@ -26,13 +35,19 @@ class SkipLink extends Widget {
   }
 }
 
+/**
+ * A Widget containing some content to provide context example.
+ */
 class Article extends Widget {
+  /**
+   * Create the content structure.
+   */
   static createNode(): HTMLElement {
     const node = document.createElement('div');
     node.setAttribute('id', 'content');
     node.setAttribute('tabindex', '-1');
     const h1 = document.createElement('h1');
-    h1.innerHTML = 'Menubar Example';
+    h1.innerHTML = 'MenuBar Example';
     node.appendChild(h1);
     const label = document.createElement('label');
     label.appendChild(
@@ -50,6 +65,9 @@ class Article extends Widget {
   }
 }
 
+/**
+ * Helper Function to add menu items.
+ */
 function addMenuItem(
   commands: CommandRegistry,
   menu: Menu,
@@ -69,6 +87,9 @@ function addMenuItem(
   });
 }
 
+/**
+ * Create the MenuBar example application.
+ */
 function main(): void {
   const app = new Application();
   const appLayout = new PanelLayout();

--- a/examples/example-menubar/style/content.css
+++ b/examples/example-menubar/style/content.css
@@ -1,0 +1,26 @@
+/*
+ Copyright (c) Jupyter Development Team.
+ Distributed under the terms of the Modified BSD License.
+*/
+
+.lm-example-skip-link {
+  position: absolute;
+  left: -1000px;
+  top: -1000px;
+}
+
+.lm-example-skip-link:focus {
+  position: fixed;
+  left: 50%;
+  top: 0;
+  z-index: 10;
+  padding: 0.5rem 1rem;
+  box-shadow: 0 0 5px #000;
+  border-bottom-left-radius: 0.2rem;
+  border-bottom-right-radius: 0.2rem;
+  background: #fff;
+}
+
+textarea {
+  display: block;
+}

--- a/examples/example-menubar/style/content.css
+++ b/examples/example-menubar/style/content.css
@@ -24,3 +24,7 @@
 textarea {
   display: block;
 }
+
+#content {
+  padding: 0 1rem;
+}

--- a/examples/example-menubar/style/index.css
+++ b/examples/example-menubar/style/index.css
@@ -1,0 +1,28 @@
+/*
+ Copyright (c) Jupyter Development Team.
+ Distributed under the terms of the Modified BSD License.
+*/
+@import '@lumino/default-theme/style/index.css';
+@import './content.css';
+
+body {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+#main {
+  flex: 1 1 auto;
+}
+
+#accordion {
+  flex: 1 1 auto;
+  padding: 4px;
+}

--- a/examples/example-menubar/style/index.css
+++ b/examples/example-menubar/style/index.css
@@ -17,12 +17,3 @@ body {
   padding: 0;
   overflow: hidden;
 }
-
-#main {
-  flex: 1 1 auto;
-}
-
-#accordion {
-  flex: 1 1 auto;
-  padding: 4px;
-}

--- a/examples/example-menubar/tsconfig.json
+++ b/examples/example-menubar/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "declaration": false,
+    "noImplicitAny": true,
+    "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "strictNullChecks": true,
+    "sourceMap": true,
+    "module": "ES6",
+    "moduleResolution": "node",
+    "target": "ES2018",
+    "outDir": "./build",
+    "lib": ["DOM", "ES2018"],
+    "types": []
+  },
+  "include": ["src/*"]
+}

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -383,7 +383,7 @@ export class MenuBar extends Widget {
    */
   protected onActivateRequest(msg: Message): void {
     if (this.isAttached) {
-      this.node.focus();
+      this.contentNode.focus();
     }
   }
 

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -136,7 +136,7 @@ export class MenuBar extends Widget {
 
     // Update the focus index.
     if (value !== -1) {
-      this._focusIndex = value;
+      this._tabFocusIndex = value;
     }
 
     // Update focus to new active index
@@ -394,9 +394,9 @@ export class MenuBar extends Widget {
     let menus = this._menus;
     let renderer = this.renderer;
     let activeIndex = this._activeIndex;
-    let focusIndex =
-      this._focusIndex >= 0 && this._focusIndex < menus.length
-        ? this._focusIndex
+    let tabFocusIndex =
+      this._tabFocusIndex >= 0 && this._tabFocusIndex < menus.length
+        ? this._tabFocusIndex
         : 0;
     let content = new Array<VirtualElement>(menus.length);
     for (let i = 0, n = menus.length; i < n; ++i) {
@@ -408,7 +408,7 @@ export class MenuBar extends Widget {
       content[i] = renderer.renderItem({
         title,
         active,
-        focusable: i === focusIndex,
+        tabbable: i === tabFocusIndex,
         onfocus: () => {
           this.activeIndex = i;
         }
@@ -737,7 +737,8 @@ export class MenuBar extends Widget {
   }
 
   private _activeIndex = -1;
-  private _focusIndex = 0;
+  // Track which item can be focused using the TAB key
+  private _tabFocusIndex = 0;
   private _forceItemsPosition: Menu.IOpenOptions;
   private _menus: Menu[] = [];
   private _childMenu: Menu | null = null;
@@ -784,9 +785,9 @@ export namespace MenuBar {
     readonly active: boolean;
 
     /**
-     * The index of the item in the list of items.
+     * Whether the user can tab to the item.
      */
-    readonly focusable: boolean;
+    readonly tabbable: boolean;
 
     readonly onfocus?: (event: FocusEvent) => void;
   }
@@ -827,7 +828,7 @@ export namespace MenuBar {
         {
           className,
           dataset,
-          tabindex: data.focusable ? '0' : '-1',
+          tabindex: data.tabbable ? '0' : '-1',
           onfocus: data.onfocus,
           ...aria
         },

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -359,7 +359,6 @@ export class MenuBar extends Widget {
     this.node.addEventListener('mousemove', this);
     this.node.addEventListener('mouseleave', this);
     this.node.addEventListener('contextmenu', this);
-    this.contentNode.addEventListener('focus', this);
   }
 
   /**
@@ -371,7 +370,6 @@ export class MenuBar extends Widget {
     this.node.removeEventListener('mousemove', this);
     this.node.removeEventListener('mouseleave', this);
     this.node.removeEventListener('contextmenu', this);
-    this.contentNode.removeEventListener('focus', this);
     this._closeChildMenu();
   }
 

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -134,6 +134,11 @@ export class MenuBar extends Widget {
     // Update the active index.
     this._activeIndex = value;
 
+    // Update the focus index.
+    if (value !== -1) {
+      this._focusIndex = value;
+    }
+
     // Update focus to new active index
     if (
       this._activeIndex >= 0 &&
@@ -389,6 +394,10 @@ export class MenuBar extends Widget {
     let menus = this._menus;
     let renderer = this.renderer;
     let activeIndex = this._activeIndex;
+    let focusIndex =
+      this._focusIndex >= 0 && this._focusIndex < menus.length
+        ? this._focusIndex
+        : 0;
     let content = new Array<VirtualElement>(menus.length);
     for (let i = 0, n = menus.length; i < n; ++i) {
       let title = menus[i].title;
@@ -399,7 +408,7 @@ export class MenuBar extends Widget {
       content[i] = renderer.renderItem({
         title,
         active,
-        index: i,
+        focusable: i === focusIndex,
         onfocus: () => {
           this.activeIndex = i;
         }
@@ -728,6 +737,7 @@ export class MenuBar extends Widget {
   }
 
   private _activeIndex = -1;
+  private _focusIndex = 0;
   private _forceItemsPosition: Menu.IOpenOptions;
   private _menus: Menu[] = [];
   private _childMenu: Menu | null = null;
@@ -776,7 +786,7 @@ export namespace MenuBar {
     /**
      * The index of the item in the list of items.
      */
-    readonly index: number;
+    readonly focusable: boolean;
 
     readonly onfocus?: (event: FocusEvent) => void;
   }
@@ -817,7 +827,7 @@ export namespace MenuBar {
         {
           className,
           dataset,
-          tabindex: data.index === 0 ? '0' : '-1',
+          tabindex: data.focusable ? '0' : '-1',
           onfocus: data.onfocus,
           ...aria
         },

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -347,9 +347,6 @@ export class MenuBar extends Widget {
         event.preventDefault();
         event.stopPropagation();
         break;
-      case 'focus':
-        this._evtFocus(event as FocusEvent);
-        break;
     }
   }
 
@@ -423,11 +420,9 @@ export class MenuBar extends Widget {
     // Fetch the key code for the event.
     let kc = event.keyCode;
 
-    // Reset the active index on tab (but not reverse tab), but do not trap the tab key.
+    // Reset the active index on tab, but do not trap the tab key.
     if (kc === 9) {
-      if (!event.shiftKey) {
-        this.activeIndex = -1;
-      }
+      this.activeIndex = -1;
       return;
     }
 
@@ -596,17 +591,6 @@ export class MenuBar extends Widget {
   private _evtMouseLeave(event: MouseEvent): void {
     // Reset the active index if there is no open menu.
     if (!this._childMenu) {
-      this.activeIndex = -1;
-    }
-  }
-
-  /**
-   * Handle the `'focus'` event for the menu bar.
-   */
-  private _evtFocus(event: FocusEvent): void {
-    if (this.activeIndex === -1) {
-      this.activeIndex = 0;
-    } else {
       this.activeIndex = -1;
     }
   }
@@ -971,7 +955,6 @@ namespace Private {
     content.className = 'lm-MenuBar-content';
     node.appendChild(content);
     content.setAttribute('role', 'menubar');
-    content.tabIndex = 0;
     return node;
   }
 

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -971,7 +971,6 @@ namespace Private {
     content.className = 'lm-MenuBar-content';
     node.appendChild(content);
     content.setAttribute('role', 'menubar');
-    //node.tabIndex = 0;
     content.tabIndex = 0;
     return node;
   }

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -380,7 +380,7 @@ export class MenuBar extends Widget {
    */
   protected onActivateRequest(msg: Message): void {
     if (this.isAttached) {
-      this.contentNode.focus();
+      this.activeIndex = 0;
     }
   }
 

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -736,8 +736,9 @@ export class MenuBar extends Widget {
     this.update();
   }
 
+  // Track the index of the item that is currently focused. -1 means nothing focused.
   private _activeIndex = -1;
-  // Track which item can be focused using the TAB key
+  // Track which item can be focused using the TAB key. Unlike _activeIndex will always point to a menuitem.
   private _tabFocusIndex = 0;
   private _forceItemsPosition: Menu.IOpenOptions;
   private _menus: Menu[] = [];

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -885,7 +885,8 @@ describe('@lumino/widgets', () => {
         widget.title.closable = true;
         data = {
           title: widget.title,
-          active: true
+          active: true,
+          index: 0
         };
       });
 

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -760,6 +760,35 @@ describe('@lumino/widgets', () => {
           expect(cancelled).to.equal(true);
         });
       });
+
+      context('focus', () => {
+        it('should focus the first menu item on keyboard focus', () => {
+          let bar = createMenuBar();
+          bar.contentNode.focus();
+          console.log(document.activeElement);
+          expect(
+            bar.contentNode.contains(document.activeElement) &&
+              bar.contentNode !== document.activeElement
+          ).to.equal(true);
+          bar.dispose();
+        });
+
+        it('should loose focus on tab key', () => {
+          let bar = createMenuBar();
+          bar.contentNode.focus();
+          expect(
+            bar.contentNode.contains(document.activeElement) &&
+              bar.contentNode !== document.activeElement
+          ).to.equal(true);
+          let event = new KeyboardEvent('keydown', { keyCode: 9 });
+          bar.node.dispatchEvent(event);
+          expect(
+            bar.contentNode.contains(document.activeElement) &&
+              bar.contentNode !== document.activeElement
+          ).to.equal(false);
+          bar.dispose();
+        });
+      });
     });
 
     describe('#onBeforeAttach()', () => {
@@ -808,14 +837,19 @@ describe('@lumino/widgets', () => {
         let bar = createMenuBar();
         Widget.detach(bar);
         MessageLoop.sendMessage(bar, Widget.Msg.ActivateRequest);
-        expect(bar.node.contains(document.activeElement)).to.equal(false);
+        expect(bar.contentNode.contains(document.activeElement)).to.equal(
+          false
+        );
         bar.dispose();
       });
 
       it('should focus the node if attached', () => {
         let bar = createMenuBar();
         MessageLoop.sendMessage(bar, Widget.Msg.ActivateRequest);
-        expect(bar.node.contains(document.activeElement)).to.equal(true);
+        expect(
+          bar.contentNode.contains(document.activeElement) &&
+            bar.contentNode !== document.activeElement
+        ).to.equal(true);
         bar.dispose();
       });
     });

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -781,49 +781,30 @@ describe('@lumino/widgets', () => {
           bar.dispose();
         });
 
-        it('should loose focus on tab key', done => {
+        it('should loose focus on tab key', () => {
           let bar = createUnfocusedMenuBar();
           bar.contentNode.focus();
           expect(
             bar.contentNode.contains(document.activeElement) &&
               bar.contentNode !== document.activeElement
           ).to.equal(true);
-          let event = new KeyboardEvent('keydown', {
-            keyCode: 9,
-            bubbles: true,
-            cancelable: true,
-            composed: true
-          });
-          console.log(bar.activeIndex);
+          let event = new KeyboardEvent('keydown', { keyCode: 9, bubbles });
           bar.contentNode.dispatchEvent(event);
-          console.log(bar.activeIndex);
-          console.log(document.activeElement);
-          expect(
-            bar.contentNode.contains(document.activeElement) &&
-              bar.contentNode !== document.activeElement
-          ).to.equal(false);
+          expect(bar.activeIndex).to.equal(-1);
           bar.dispose();
         });
 
-        it('should loose focus on shift-tab key', done => {
+        it('should loose focus on shift-tab key', () => {
           let bar = createUnfocusedMenuBar();
           bar.contentNode.focus();
           expect(
             bar.contentNode.contains(document.activeElement) &&
               bar.contentNode !== document.activeElement
           ).to.equal(true);
-          let event = new KeyboardEvent('keydown', {
-            keyCode: 9,
-            shiftKey: true,
-            bubbles: true,
-            cancelable: true,
-            composed: true
-          });
-          console.log(bar.activeIndex);
+          let event = new KeyboardEvent('keydown', { keyCode: 9 });
           bar.contentNode.dispatchEvent(event);
-          console.log(bar.activeIndex);
-          console.log(document.activeElement);
-          expect(bar.contentNode === document.activeElement).to.equal(true);
+          bar.contentNode.focus();
+          expect(bar.activeIndex).to.equal(-1);
           bar.dispose();
         });
       });

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -941,7 +941,7 @@ describe('@lumino/widgets', () => {
         data = {
           title: widget.title,
           active: true,
-          index: 0
+          focusable: true
         };
       });
 

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -785,10 +785,9 @@ describe('@lumino/widgets', () => {
         it('should lose focus on tab key', () => {
           let bar = createUnfocusedMenuBar();
           bar.activeIndex = 0;
-          expect(
-            bar.contentNode.contains(document.activeElement) &&
-              bar.contentNode !== document.activeElement
-          ).to.equal(true);
+          expect(bar.contentNode.contains(document.activeElement)).to.equal(
+            true
+          );
           let event = new KeyboardEvent('keydown', { keyCode: 9, bubbles });
           bar.contentNode.dispatchEvent(event);
           expect(bar.activeIndex).to.equal(-1);
@@ -798,10 +797,9 @@ describe('@lumino/widgets', () => {
         it('should lose focus on shift-tab key', () => {
           let bar = createUnfocusedMenuBar();
           bar.activeIndex = 0;
-          expect(
-            bar.contentNode.contains(document.activeElement) &&
-              bar.contentNode !== document.activeElement
-          ).to.equal(true);
+          expect(bar.contentNode.contains(document.activeElement)).to.equal(
+            true
+          );
           let event = new KeyboardEvent('keydown', {
             keyCode: 9,
             shiftKey: true,

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -941,7 +941,7 @@ describe('@lumino/widgets', () => {
         data = {
           title: widget.title,
           active: true,
-          focusable: true
+          tabbable: true
         };
       });
 

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -798,7 +798,6 @@ describe('@lumino/widgets', () => {
         it('should lose focus on shift-tab key', () => {
           let bar = createUnfocusedMenuBar();
           bar.activeIndex = 0;
-          console.log(document.activeElement);
           expect(
             bar.contentNode.contains(document.activeElement) &&
               bar.contentNode !== document.activeElement

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -782,19 +782,9 @@ describe('@lumino/widgets', () => {
       });
 
       context('focus', () => {
-        it('should focus the first menu item on keyboard focus', () => {
+        it('should lose focus on tab key', () => {
           let bar = createUnfocusedMenuBar();
-          bar.contentNode.focus();
-          expect(
-            bar.contentNode.contains(document.activeElement) &&
-              bar.contentNode !== document.activeElement
-          ).to.equal(true);
-          bar.dispose();
-        });
-
-        it('should loose focus on tab key', () => {
-          let bar = createUnfocusedMenuBar();
-          bar.contentNode.focus();
+          bar.activeIndex = 0;
           expect(
             bar.contentNode.contains(document.activeElement) &&
               bar.contentNode !== document.activeElement
@@ -805,16 +795,20 @@ describe('@lumino/widgets', () => {
           bar.dispose();
         });
 
-        it('should loose focus on shift-tab key', () => {
+        it('should lose focus on shift-tab key', () => {
           let bar = createUnfocusedMenuBar();
-          bar.contentNode.focus();
+          bar.activeIndex = 0;
+          console.log(document.activeElement);
           expect(
             bar.contentNode.contains(document.activeElement) &&
               bar.contentNode !== document.activeElement
           ).to.equal(true);
-          let event = new KeyboardEvent('keydown', { keyCode: 9 });
+          let event = new KeyboardEvent('keydown', {
+            keyCode: 9,
+            shiftKey: true,
+            bubbles
+          });
           bar.contentNode.dispatchEvent(event);
-          bar.contentNode.focus();
           expect(bar.activeIndex).to.equal(-1);
           bar.dispose();
         });

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -74,6 +74,15 @@ describe('@lumino/widgets', () => {
     return bar;
   }
 
+  /**
+   * Create a MenuBar that has no active menu item.
+   */
+  function createUnfocusedMenuBar(): MenuBar {
+    const bar = createMenuBar();
+    bar.activeIndex = -1;
+    return bar;
+  }
+
   before(() => {
     commands = new CommandRegistry();
     const iconRenderer = {
@@ -763,9 +772,8 @@ describe('@lumino/widgets', () => {
 
       context('focus', () => {
         it('should focus the first menu item on keyboard focus', () => {
-          let bar = createMenuBar();
+          let bar = createUnfocusedMenuBar();
           bar.contentNode.focus();
-          console.log(document.activeElement);
           expect(
             bar.contentNode.contains(document.activeElement) &&
               bar.contentNode !== document.activeElement
@@ -773,19 +781,49 @@ describe('@lumino/widgets', () => {
           bar.dispose();
         });
 
-        it('should loose focus on tab key', () => {
-          let bar = createMenuBar();
+        it('should loose focus on tab key', done => {
+          let bar = createUnfocusedMenuBar();
           bar.contentNode.focus();
           expect(
             bar.contentNode.contains(document.activeElement) &&
               bar.contentNode !== document.activeElement
           ).to.equal(true);
-          let event = new KeyboardEvent('keydown', { keyCode: 9 });
-          bar.node.dispatchEvent(event);
+          let event = new KeyboardEvent('keydown', {
+            keyCode: 9,
+            bubbles: true,
+            cancelable: true,
+            composed: true
+          });
+          console.log(bar.activeIndex);
+          bar.contentNode.dispatchEvent(event);
+          console.log(bar.activeIndex);
+          console.log(document.activeElement);
           expect(
             bar.contentNode.contains(document.activeElement) &&
               bar.contentNode !== document.activeElement
           ).to.equal(false);
+          bar.dispose();
+        });
+
+        it('should loose focus on shift-tab key', done => {
+          let bar = createUnfocusedMenuBar();
+          bar.contentNode.focus();
+          expect(
+            bar.contentNode.contains(document.activeElement) &&
+              bar.contentNode !== document.activeElement
+          ).to.equal(true);
+          let event = new KeyboardEvent('keydown', {
+            keyCode: 9,
+            shiftKey: true,
+            bubbles: true,
+            cancelable: true,
+            composed: true
+          });
+          console.log(bar.activeIndex);
+          bar.contentNode.dispatchEvent(event);
+          console.log(bar.activeIndex);
+          console.log(document.activeElement);
+          expect(bar.contentNode === document.activeElement).to.equal(true);
           bar.dispose();
         });
       });
@@ -844,7 +882,7 @@ describe('@lumino/widgets', () => {
       });
 
       it('should focus the node if attached', () => {
-        let bar = createMenuBar();
+        let bar = createUnfocusedMenuBar();
         MessageLoop.sendMessage(bar, Widget.Msg.ActivateRequest);
         expect(
           bar.contentNode.contains(document.activeElement) &&

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -495,6 +495,17 @@ describe('@lumino/widgets', () => {
           expect(menu.isAttached).to.equal(true);
         });
 
+        it('should open the active menu on Space', () => {
+          let menu = bar.activeMenu!;
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              bubbles,
+              keyCode: 32
+            })
+          );
+          expect(menu.isAttached).to.equal(true);
+        });
+
         it('should open the active menu on Up Arrow', () => {
           let menu = bar.activeMenu!;
           bar.node.dispatchEvent(

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -777,6 +777,7 @@ export namespace MenuBar {
         readonly active: boolean;
         // (undocumented)
         readonly onfocus?: (event: FocusEvent) => void;
+        readonly tabbable: boolean;
         readonly title: Title<Widget>;
     }
     export interface IRenderer {


### PR DESCRIPTION
This PR will improve accessibility issues with the menubar component, bringing it closer to being WCAG2.1 compliant. In particular it will
* Set the tabindex properties as specified;
* Handle the focus setting as specified, both when focus first moves into the menubar and also when focus moves out of it;

This is my first bit of work with the lumino codebase, so all comments, particularly around architecture are much appreciated.

I haven't added any tests yet, that is the next step.