### PR TITLE
added guards for browser globals

### DIFF
--- a/packages/domutils/src/clipboard.ts
+++ b/packages/domutils/src/clipboard.ts
@@ -18,6 +18,7 @@ export namespace ClipboardExt {
    * @param text - The text to copy to the clipboard.
    */
   export function copyText(text: string): void {
+    if (typeof document === 'undefined') return;
     // Fetch the document body.
     const body = document.body;
 

--- a/packages/domutils/src/platform.ts
+++ b/packages/domutils/src/platform.ts
@@ -15,22 +15,26 @@ export namespace Platform {
   /**
    * A flag indicating whether the platform is Mac.
    */
-  export const IS_MAC = !!navigator.platform.match(/Mac/i);
+  export const IS_MAC =
+    typeof navigator !== 'undefined' && !!navigator.platform.match(/Mac/i);
 
   /**
    * A flag indicating whether the platform is Windows.
    */
-  export const IS_WIN = !!navigator.platform.match(/Win/i);
+  export const IS_WIN =
+    typeof navigator !== 'undefined' && !!navigator.platform.match(/Win/i);
 
   /**
    * A flag indicating whether the browser is IE.
    */
-  export const IS_IE = /Trident/.test(navigator.userAgent);
+  export const IS_IE =
+    typeof navigator !== 'undefined' && /Trident/.test(navigator.userAgent);
 
   /**
    * A flag indicating whether the browser is Edge.
    */
-  export const IS_EDGE = /Edge/.test(navigator.userAgent);
+  export const IS_EDGE =
+    typeof navigator !== 'undefined' && /Edge/.test(navigator.userAgent);
 
   /**
    * Test whether the `accel` key is pressed.

--- a/packages/domutils/src/selector.ts
+++ b/packages/domutils/src/selector.ts
@@ -109,13 +109,17 @@ namespace Private {
   /**
    * An empty element for testing selector validity.
    */
-  export const testElem = document.createElement('div');
+  export const testElem =
+    typeof document !== 'undefined'
+      ? document.createElement('div')
+      : ({} as any);
 
   /**
    * A cross-browser CSS selector matching prototype function.
    */
   export const protoMatchFunc = (() => {
-    let proto = Element.prototype as any;
+    let proto =
+      typeof Element === 'undefined' ? ({} as any) : Element.prototype;
     return (
       proto.matches ||
       proto.matchesSelector ||


### PR DESCRIPTION
This draft PR illustrates the changes needed to allow `jupyterlab` to be statically included in `remix.run` application and bundled within server code.

The changes here obviously may not leave the application in a functional state or apply good defaults, but they enable bundling / building and subsequent use in client-only parts of a remix / next.js based web application.

Hopefully these are useful as a guide in how to update / change intiialisaiton of some parts of lumino so there there is no dependency on browser globals at import time.

Note: these changes were determined from a specific use case, where `domutils` was pulled in as a dependency, there may be other similar issues in other lumino packages that need to be considered.
