### PR TITLE
Automated Changelog Entry for 2022.11.29 on 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements made
 
-- Backport #465 on branch 1.x (Improve the menubar accessibility) [#476](https://github.com/jupyterlab/lumino/pull/476) ([@fcollonval](https://github.com/fcollonval))
+- Improve the menubar accessibility [#476](https://github.com/jupyterlab/lumino/pull/476) ([@fcollonval](https://github.com/fcollonval))
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2022.11.29
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.30.0...047d42205a32de8ec502f0d57d70fb161f1d1f41))
+
+### Enhancements made
+
+- Backport #465 on branch 1.x (Improve the menubar accessibility) [#476](https://github.com/jupyterlab/lumino/pull/476) ([@fcollonval](https://github.com/fcollonval))
+
+### Bugs fixed
+
+- Fix drag-and-drop of nested dock panel [#473](https://github.com/jupyterlab/lumino/pull/473) ([@drcd1](https://github.com/drcd1))
+
+### Maintenance and upkeep improvements
+
+- Correct example version for 1.x [#479](https://github.com/jupyterlab/lumino/pull/479) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-10-31&to=2022-11-29&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-10-31..2022-11-29&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2022-10-31..2022-11-29&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-10-31..2022-11-29&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ameeseeksmachine+updated%3A2022-10-31..2022-11-29&type=Issues) | [@scmmmh](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ascmmmh+updated%3A2022-10-31..2022-11-29&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Avidartf+updated%3A2022-10-31..2022-11-29&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2022-10-31..2022-11-29&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2022.10.31
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.29.4...8362e3daa3afac6b2e832b5bd225b662bdbd6593))
@@ -27,8 +51,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-10-05&to=2022-10-31&type=c))
 
 [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-10-05..2022-10-31&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Akrassowski+updated%3A2022-10-05..2022-10-31&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ameeseeksdev+updated%3A2022-10-05..2022-10-31&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ameeseeksmachine+updated%3A2022-10-05..2022-10-31&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Avidartf+updated%3A2022-10-05..2022-10-31&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2022-10-05..2022-10-31&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2022.10.5
 


### PR DESCRIPTION
Automated Changelog Entry for 2022.11.29 on 1.x
```
npm workspace versions:
@lumino/example-accordionpanel: 0.8.5
@lumino/example-datagrid: 0.32.5
@lumino/example-datastore: 0.21.5
@lumino/example-dockpanel: 0.21.5
@lumino/example-dockpanel-amd: 0.4.0
@lumino/example-dockpanel-iife: 0.4.0
@lumino/example-menubar: 0.1.0-alpha.0
@lumino/example-nested-dockpanel-amd: 0.4.0
@lumino/algorithm: 1.9.2
@lumino/application: 1.30.0
@lumino/collections: 1.9.3
@lumino/commands: 1.21.0
@lumino/coreutils: 1.12.1
@lumino/datagrid: 0.36.5
@lumino/datastore: 0.18.3
@lumino/default-theme: 0.22.5
@lumino/disposable: 1.10.3
@lumino/domutils: 1.8.2
@lumino/dragdrop: 1.14.3
@lumino/keyboard: 1.8.2
@lumino/messaging: 1.10.3
@lumino/polling: 1.11.3
@lumino/properties: 1.8.2
@lumino/signaling: 1.11.0
@lumino/virtualdom: 1.14.3
@lumino/widgets: 1.35.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/lumino/releases/tag/untagged-931c45ed5cbe5f4791c1  |
| Since | @lumino/application@1.30.0 |