### PR TITLE
Use Firefox from playwright

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         browser: [chrome-headless, firefox-headless, webkit-headless]
+        exclude:
+          # Playwright webkit binary is not compatible with ubuntu
+          - os: ubuntu-latest
+            browser: webkit-headless
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        browser: [chrome-headless, firefox-headless]
-        exclude:
-          # macos and firefox-headless seems to consistently fail.
-          - os: macos-latest
-            browser: firefox-headless
+        browser: [chrome-headless, firefox-headless, webkit-headless]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/packages/algorithm/tests/karma.conf.js
+++ b/packages/algorithm/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/application/tests/karma.conf.js
+++ b/packages/application/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/collections/tests/karma.conf.js
+++ b/packages/collections/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/commands/tests/karma.conf.js
+++ b/packages/commands/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/coreutils/tests/karma.conf.js
+++ b/packages/coreutils/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/disposable/tests/karma.conf.js
+++ b/packages/disposable/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/domutils/tests/karma.conf.js
+++ b/packages/domutils/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/dragdrop/tests/karma.conf.js
+++ b/packages/dragdrop/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/keyboard/tests/karma.conf.js
+++ b/packages/keyboard/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/messaging/tests/karma.conf.js
+++ b/packages/messaging/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/polling/tests/karma.conf.js
+++ b/packages/polling/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/properties/tests/karma.conf.js
+++ b/packages/properties/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/signaling/tests/karma.conf.js
+++ b/packages/signaling/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/virtualdom/tests/karma.conf.js
+++ b/packages/virtualdom/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 

--- a/packages/widgets/tests/karma.conf.js
+++ b/packages/widgets/tests/karma.conf.js
@@ -3,6 +3,8 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+process.env.FIREFOX_BIN = require('playwright').firefox.executablePath();
+process.env.FIREFOX_HEADLESS_BIN = process.env.FIREFOX_BIN;
 process.env.WEBKIT_BIN = require('playwright').webkit.executablePath();
 process.env.WEBKIT_HEADLESS_BIN = process.env.WEBKIT_BIN;
 


### PR DESCRIPTION
This fixes the CI failure of Firefox not found on Ubuntu

I also added the tests against webkit on Windows and mac - unfortunately the Playwright webkit binary is not directly compatible with the ubuntu image. So I'm skipping it for now.