### PR TITLE
Automated Changelog Entry for 2022.12.5 on 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2022.12.5
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/example-menubar@0.1.0-alpha.0...1c0765d67ca74988319b4567ed6c2951a45b97f3))
+
+### Enhancements made
+
+- Dynamic extensions reloading [#377](https://github.com/jupyterlab/lumino/pull/377) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Bump version [#486](https://github.com/jupyterlab/lumino/pull/486) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-11-29&to=2022-12-05&type=c))
+
+[@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-11-29..2022-12-05&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2022.10.31
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.29.4...8362e3daa3afac6b2e832b5bd225b662bdbd6593))
@@ -27,8 +47,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-10-05&to=2022-10-31&type=c))
 
 [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-10-05..2022-10-31&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Akrassowski+updated%3A2022-10-05..2022-10-31&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ameeseeksdev+updated%3A2022-10-05..2022-10-31&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ameeseeksmachine+updated%3A2022-10-05..2022-10-31&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Avidartf+updated%3A2022-10-05..2022-10-31&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2022-10-05..2022-10-31&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2022.10.5
 


### PR DESCRIPTION
Automated Changelog Entry for 2022.12.5 on 1.x
```
npm workspace versions:
@lumino/example-accordionpanel: 0.8.6
@lumino/example-datagrid: 0.32.6
@lumino/example-datastore: 0.21.6
@lumino/example-dockpanel: 0.21.6
@lumino/example-dockpanel-amd: 0.4.0
@lumino/example-dockpanel-iife: 0.4.0
@lumino/example-menubar: 0.1.1
@lumino/example-nested-dockpanel-amd: 0.4.1
@lumino/algorithm: 1.9.2
@lumino/application: 1.31.0
@lumino/collections: 1.9.3
@lumino/commands: 1.21.0
@lumino/coreutils: 1.12.1
@lumino/datagrid: 0.36.6
@lumino/datastore: 0.18.3
@lumino/default-theme: 0.22.6
@lumino/disposable: 1.10.3
@lumino/domutils: 1.8.2
@lumino/dragdrop: 1.14.3
@lumino/keyboard: 1.8.2
@lumino/messaging: 1.10.3
@lumino/polling: 1.11.3
@lumino/properties: 1.8.2
@lumino/signaling: 1.11.0
@lumino/virtualdom: 1.14.3
@lumino/widgets: 1.36.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/lumino/releases/tag/untagged-49a9942893cdbd760e4f  |
| Since | @lumino/example-menubar@0.1.0-alpha.0 |