### PR TITLE
Automated Changelog Entry for 2022.12.5 on 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Enhancements made
 
 - Dynamic extensions reloading [#377](https://github.com/jupyterlab/lumino/pull/377) ([@fcollonval](https://github.com/fcollonval))
-- Backport #465 on branch 1.x (Improve the menubar accessibility) [#476](https://github.com/jupyterlab/lumino/pull/476) ([@fcollonval](https://github.com/fcollonval))
+- Improve the menubar accessibility [#476](https://github.com/jupyterlab/lumino/pull/476) ([@fcollonval](https://github.com/fcollonval))
 
 ### Bugs fixed
 


### PR DESCRIPTION
Automated Changelog Entry for 2022.12.5 on 1.x
```
npm workspace versions:
@lumino/example-accordionpanel: 0.8.6
@lumino/example-datagrid: 0.32.6
@lumino/example-datastore: 0.21.6
@lumino/example-dockpanel: 0.21.6
@lumino/example-dockpanel-amd: 0.4.0
@lumino/example-dockpanel-iife: 0.4.0
@lumino/example-menubar: 0.1.1
@lumino/example-nested-dockpanel-amd: 0.4.1
@lumino/algorithm: 1.9.2
@lumino/application: 1.31.0
@lumino/collections: 1.9.3
@lumino/commands: 1.21.0
@lumino/coreutils: 1.12.1
@lumino/datagrid: 0.36.6
@lumino/datastore: 0.18.3
@lumino/default-theme: 0.22.6
@lumino/disposable: 1.10.3
@lumino/domutils: 1.8.2
@lumino/dragdrop: 1.14.3
@lumino/keyboard: 1.8.2
@lumino/messaging: 1.10.3
@lumino/polling: 1.11.3
@lumino/properties: 1.8.2
@lumino/signaling: 1.11.0
@lumino/virtualdom: 1.14.3
@lumino/widgets: 1.36.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/lumino/releases/tag/untagged-f9cd7a448d20d6643b9d  |
| Since | v2022.10.31 |