### PR TITLE
Fix finding dependents for deactivation

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -881,9 +881,7 @@ namespace Private {
       oldSize = previousSize;
     }
 
-    console.log(newEdges);
     const sorted = topologicSort(newEdges);
-    console.log(sorted);
     const index = sorted.findIndex(candidate => candidate === id);
 
     if (index === -1) {

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -860,7 +860,30 @@ namespace Private {
       add(id);
     }
 
-    const sorted = topologicSort(edges);
+    // Filter edges
+    // - Get all packages that dependent on the package to be deactivated
+    const newEdges = edges.filter(edge => edge[1] === id);
+    let oldSize = 0;
+    while (newEdges.length > oldSize) {
+      const previousSize = newEdges.length;
+      // Get all packages that dependent on packages that will be deactivated
+      const packagesOfInterest = new Set(newEdges.map(edge => edge[0]));
+      for (const poi of packagesOfInterest) {
+        edges
+          .filter(edge => edge[1] === poi)
+          .forEach(edge => {
+            // We check it is not already included to deal with circular dependencies
+            if (!newEdges.includes(edge)) {
+              newEdges.push(edge);
+            }
+          });
+      }
+      oldSize = previousSize;
+    }
+
+    console.log(newEdges);
+    const sorted = topologicSort(newEdges);
+    console.log(sorted);
     const index = sorted.findIndex(candidate => candidate === id);
 
     if (index === -1) {


### PR DESCRIPTION
When trying to use it in `jupyterlab-plugin-playground` with JupyterLab 3.6.0-alpha.5. I realized the number of packages brings errors when linearizing the package dependency graph.

This filters the list of dependency relationship to the minimal graph related to the plugin to be deactivated.