### PR TITLE
Add content-visibility hide mode

### DIFF
--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -839,18 +839,21 @@ export class DockLayout extends Layout {
 
     // Using transform create an additional layer in the pixel pipeline
     // to limit the number of layer, it is set only if there is more than one widget.
-    if (
-      this._hiddenMode === Widget.HiddenMode.Scale &&
-      refNode.tabBar.titles.length > 0
-    ) {
-      if (refNode.tabBar.titles.length == 1) {
+    if (this._hiddenMode === Widget.HiddenMode.Scale) {
+      if (refNode.tabBar.titles.length === 0) {
+        // Singular tab should use display mode to limit number of layers.
+        widget.hiddenMode = Widget.HiddenMode.Display;
+      } else if (refNode.tabBar.titles.length == 1) {
+        // If we are adding a second tab, switch the existing tab back to scale.
         const existingWidget = refNode.tabBar.titles[0].owner;
         existingWidget.hiddenMode = Widget.HiddenMode.Scale;
+      } else {
+        // For the third and subsequent tabs no special action is needed.
+        widget.hiddenMode = Widget.HiddenMode.Scale;
       }
-
-      widget.hiddenMode = Widget.HiddenMode.Scale;
     } else {
-      widget.hiddenMode = Widget.HiddenMode.Display;
+      // For all other modes just propagate the current mode.
+      widget.hiddenMode = this._hiddenMode;
     }
 
     // Insert the widget's tab relative to the target index.

--- a/packages/widgets/tests/src/widget.spec.ts
+++ b/packages/widgets/tests/src/widget.spec.ts
@@ -739,10 +739,38 @@ describe('@lumino/widgets', () => {
         widget.dispose();
       });
 
-      it('should add class when switching from scale to display', () => {
+      for (const fromMode of [
+        Widget.HiddenMode.Scale,
+        Widget.HiddenMode.ContentVisibility
+      ]) {
+        it(`should add class when switching from ${fromMode} to display`, () => {
+          let widget = new Widget();
+          Widget.attach(widget, document.body);
+          widget.hiddenMode = fromMode;
+          widget.hide();
+          widget.hiddenMode = Widget.HiddenMode.Display;
+          expect(widget.hasClass('lm-mod-hidden')).to.equal(true);
+          expect(widget.node.style.transform).to.equal('');
+          expect(widget.node.style.willChange).to.equal('auto');
+          widget.dispose();
+        });
+      }
+
+      it('should use content-visibility in relevant mode', () => {
         let widget = new Widget();
         Widget.attach(widget, document.body);
-        widget.hiddenMode = Widget.HiddenMode.Scale;
+        widget.hiddenMode = Widget.HiddenMode.ContentVisibility;
+        widget.hide();
+        expect(widget.hasClass('lm-mod-hidden')).to.equal(false);
+        expect(widget.node.style.contentVisibility).to.equal('hidden');
+        expect(widget.node.style.willChange).to.equal('auto');
+        widget.dispose();
+      });
+
+      it('should add class when switching from content-visibility to display', () => {
+        let widget = new Widget();
+        Widget.attach(widget, document.body);
+        widget.hiddenMode = Widget.HiddenMode.ContentVisibility;
         widget.hide();
         widget.hiddenMode = Widget.HiddenMode.Display;
         expect(widget.hasClass('lm-mod-hidden')).to.equal(true);

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -1324,6 +1324,7 @@ export namespace Widget {
         IsVisible = 8
     }
     export enum HiddenMode {
+        ContentVisibility = 2,
         Display = 0,
         Scale = 1
     }


### PR DESCRIPTION
See https://github.com/jupyterlab/lumino/issues/496#issuecomment-1363431726.

Once support for content-visibility is better across browsers we should make it the default as we have exactly the use case that it was intended for (see point two in [specification](https://www.w3.org/TR/css-contain-2/#using-cv-hidden)).

Performance-wise, I re-run the benchmark for three tabs (as in the issue: two test notebooks and launcher) after full integration and it works as expected:

Google Chrome 108

| hidden mode |IQM [Q1 - Q3] | mean | min |
|----|---|---|---|
| display | 3043.3 [2944.3 – 3193.1] ms | 3051.3 ms | 2390.9 ms
| content-visibility | 631.6 [606.4 – 694.6] ms | 687.7 ms | 566.5 ms
| scale | 548.6 [531 – 561.3] ms | 566.2 ms | 506.6 ms |

but differently to `scale`, it does not cause unintended issues in Chromium browsers where performance issues in presence of big notebooks are most pronounced, nor does it degrade in performance once there are too many tabs open.

Note: the benchmarks above were run with latest dev versions of JupyterLab (4.0alpha) and lumino from this PR, so these account for any potential changes to due windowed notebooks feature (full windowing mode).

Notes on current state in Firefox below. TLDR, we are good to merge IMO.

<details>

For anyone trying this out in Firefox: it may appear that it already "works" in Firefox 108 but it does not support `content-visibility` yet (although some basic support was already [merged](https://bugzilla.mozilla.org/show_bug.cgi?id=1758490) in 3 months ago, possibly pending bug fixes [like this one](https://bugzilla.mozilla.org/show_bug.cgi?id=1804761)). It "works" because in absence of `content-visibility` support it reduces to leaving the tab visible but hidden under the others due to z-index change. It means that we can confidently ship because it is in a way safer than existing _scale_ mode (if user chooses to enable it in a browser which does not support `content-visibility`, their workspace will still work; scale breaks things in Chromium browsers). The performance in this case is fine for few tabs (the three test notebooks scenario):

| hidden mode |IQM [Q1 - Q3] | mean | min |
|----|---|---|---|
| display | 1288.7 [1222.8 – 1351.8] ms | 1304.6 ms | 1132.1 ms |
| z-index | 960.6 [928.8 – 1004.9] ms | 1019.5 ms | 871.2 ms |
| scale | 925 [896.3 – 947.9] ms | 933.2 ms | 811.2 ms |

But it is worse when there are many notebooks (each 20 code cells):

| hidden mode | 10 notebooks | 30 notebooks |
|---|---|---|
| display | 1982.4 [1833.4 – 2145.6] |12061.3 [11591.2 – 12455.9] |
| z-index | 2517.6 [2435.2 – 2603.1] |21574.9 [21158.4 – 22010.4] |
| scale | 2007.3 [1912 – 2113.4] |17439.5 [16916 – 18083.8] |

Interestingly, scale in Firefox is only better for heavy notebooks, not for many small notebooks.

</details>