### PR TITLE
Improve performance of drag & drop, esp. in Chrome

### DIFF
--- a/packages/dragdrop/style/index.css
+++ b/packages/dragdrop/style/index.css
@@ -12,6 +12,16 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-body.lm-mod-override-cursor * {
-  cursor: inherit !important;
+.lm-cursor-backdrop {
+  position: fixed;
+  width: 200px;
+  height: 200px;
+  margin-top: -100px;
+  margin-left: -100px;
+  will-change: transform;
+  z-index: 100;
+}
+
+.lm-mod-drag-image {
+  will-change: transform;
 }


### PR DESCRIPTION
Fixes #450:

- improves performance of the drag image by moving its positioning to compositor (`transform: translate`, `will-change`)
- works around Chromium [Issue 664066](https://bugs.chromium.org/p/chromium/issues/detail?id=664066) by using a custom backdrop node which is dynamically positioned behind the cursor and hidden with high-performance z-index change for hit testing.

Results having `gh-9757-reproducer.ipynb` (n=50000) open on the side and:

#### a) dragging a launcher from the other split panel

| Before | After |
|---|---|
| ![Screenshot from 2022-12-26 04-28-08](https://user-images.githubusercontent.com/5832902/209500227-bb4ad89c-3599-47bc-9755-f08557235074.png) | ![Screenshot from 2022-12-26 04-30-20](https://user-images.githubusercontent.com/5832902/209500192-7f79176e-c86c-49d3-889b-8ae183941e89.png) |

#### b) clicking on lumino data grid

| Before | After |
|---|---|
| ![Screenshot from 2022-12-26 04-27-38](https://user-images.githubusercontent.com/5832902/209500207-71800f96-4f4f-42b7-8c9e-9f9720f25ef2.png) | ![Screenshot from 2022-12-26 04-30-41](https://user-images.githubusercontent.com/5832902/209500116-aa95bcaf-1c61-4a64-ad41-10b022b235ed.png) |

(for ease of testing I was clicking on the header of the table view of debugger in sidebar).

### Breaking changes

When `Drag.overrideCursor` is active, local pointer events (=anything not listening on document) are no longer triggered. This largely does not change the behaviour when this method is used with the `Drag` class as it was already capturing (and preventing) many events that could interfere with drag experience.