### PR TITLE
Add contain strict for elements with fully managed layout

### DIFF
--- a/packages/widgets/src/accordionlayout.ts
+++ b/packages/widgets/src/accordionlayout.ts
@@ -241,6 +241,7 @@ namespace Private {
   ): HTMLElement {
     const title = renderer.createSectionTitle(data);
     title.style.position = 'absolute';
+    title.style.contain = 'strict';
     title.setAttribute('aria-label', `${data.label} Section`);
     title.setAttribute('aria-expanded', expanded ? 'true' : 'false');
     title.setAttribute('aria-controls', data.owner.id);

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -1119,6 +1119,7 @@ export class DockLayout extends Layout {
     // Initialize the handle layout behavior.
     let style = handle.style;
     style.position = 'absolute';
+    style.contain = 'strict';
     style.top = '0';
     style.left = '0';
     style.width = '0';

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -1281,6 +1281,7 @@ export namespace DockPanel {
       this.node.classList.add('lm-DockPanel-overlay');
       this.node.classList.add('lm-mod-hidden');
       this.node.style.position = 'absolute';
+      this.node.style.contain = 'strict';
     }
 
     /**

--- a/packages/widgets/src/layout.ts
+++ b/packages/widgets/src/layout.ts
@@ -619,10 +619,12 @@ export class LayoutItem implements IDisposable {
    *
    * #### Notes
    * The widget will be set to absolute positioning.
+   * The widget will use strict CSS containment.
    */
   constructor(widget: Widget) {
     this.widget = widget;
     this.widget.node.style.position = 'absolute';
+    this.widget.node.style.contain = 'strict';
   }
 
   /**
@@ -647,6 +649,7 @@ export class LayoutItem implements IDisposable {
     style.left = '';
     style.width = '';
     style.height = '';
+    style.contain = '';
   }
 
   /**

--- a/packages/widgets/src/splitlayout.ts
+++ b/packages/widgets/src/splitlayout.ts
@@ -829,6 +829,7 @@ namespace Private {
   ): HTMLDivElement {
     let handle = renderer.createHandle();
     handle.style.position = 'absolute';
+    handle.style.contain = 'strict';
     return handle;
   }
 


### PR DESCRIPTION
Closes https://github.com/jupyterlab/lumino/issues/504

Uses strict CSS containment on elements with fully managed layout (absolutely positioned elements that specify all coordinates and dimensions, e.g. top + left + width + height, or top + left + bottom + right) to reduce layout cost (improves performance for resizing certain elements and other actions).

This requires that nothing within the widgets paints outside of it. Some modest changes may be needed downstream to remove painting outside of the widget box, as in https://github.com/jupyterlab/jupyterlab/pull/13671.

The added contain can be overridden in sub-classes of `LayoutItem`.

I would suggest that we merge this, cut a release, pull it in JupyterLab and run full test suite (once https://github.com/jupyterlab/jupyterlab/pull/13671 is in) to see if it causes any side-effects (I did not notice any in manual testing).

I would suggest that we do not backport this to 1.x and instead include a tailored solution in JupyterLab (I will prepare a PR).