### PR TITLE
Automated Changelog Entry for 2023.1.3-alpha.7 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,81 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2023.1.3-alpha.7
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/algorithm@2.0.0-alpha.6...408b5b339ac5ec1d6f856bc1625dd975e0227b69))
+
+### Enhancements made
+
+- Add contain strict for elements with fully managed layout [#506](https://github.com/jupyterlab/lumino/pull/506) ([@krassowski](https://github.com/krassowski))
+- Add content-visibility hide mode [#497](https://github.com/jupyterlab/lumino/pull/497) ([@krassowski](https://github.com/krassowski))
+- Improve the menubar accessibility [#465](https://github.com/jupyterlab/lumino/pull/465) ([@scmmmh](https://github.com/scmmmh))
+- Add async iterable `Stream` class that inherits from `Signal` [#462](https://github.com/jupyterlab/lumino/pull/462) ([@afshin](https://github.com/afshin))
+- Disable text eliding by default [#451](https://github.com/jupyterlab/lumino/pull/451) ([@ibdafna](https://github.com/ibdafna))
+- Add blocking signal feature [#443](https://github.com/jupyterlab/lumino/pull/443) ([@fcollonval](https://github.com/fcollonval))
+- Add support for list of keystrokes [#433](https://github.com/jupyterlab/lumino/pull/433) ([@fcollonval](https://github.com/fcollonval))
+- Add plugin description [#419](https://github.com/jupyterlab/lumino/pull/419) ([@fcollonval](https://github.com/fcollonval))
+- Handle deferred processing when `document` is hidden [#402](https://github.com/jupyterlab/lumino/pull/402) ([@afshin](https://github.com/afshin))
+- Improve datagrid performance [#394](https://github.com/jupyterlab/lumino/pull/394) ([@martinRenou](https://github.com/martinRenou))
+
+### Bugs fixed
+
+- Accessibility: role attributes [#507](https://github.com/jupyterlab/lumino/pull/507) ([@brichet](https://github.com/brichet))
+- Improve performance of drag & drop, esp. in Chrome [#502](https://github.com/jupyterlab/lumino/pull/502) ([@krassowski](https://github.com/krassowski))
+- Fix finding dependents for deactivation [#490](https://github.com/jupyterlab/lumino/pull/490) ([@fcollonval](https://github.com/fcollonval))
+- Fix drag-and-drop of nested dock panel [#473](https://github.com/jupyterlab/lumino/pull/473) ([@drcd1](https://github.com/drcd1))
+- When rejecting the internal promise in a `Stream`, catch failures [#464](https://github.com/jupyterlab/lumino/pull/464) ([@afshin](https://github.com/afshin))
+- Datagrid: Do not prevent page scroll if we are not actually scrolling the grid [#446](https://github.com/jupyterlab/lumino/pull/446) ([@martinRenou](https://github.com/martinRenou))
+- Avoid menu layout trashing by moving DOM queries [#432](https://github.com/jupyterlab/lumino/pull/432) ([@krassowski](https://github.com/krassowski))
+- Handle deferred processing when `document` is hidden [#402](https://github.com/jupyterlab/lumino/pull/402) ([@afshin](https://github.com/afshin))
+
+### Maintenance and upkeep improvements
+
+- Bump to 2.0.0-alpha.7 [#509](https://github.com/jupyterlab/lumino/pull/509) ([@fcollonval](https://github.com/fcollonval))
+- Bump tj-actions/changed-files from 35.1.1 to 35.2.1 [#508](https://github.com/jupyterlab/lumino/pull/508) ([@dependabot](https://github.com/dependabot))
+- Bump tj-actions/changed-files from 34.5.3 to 35.1.1 [#503](https://github.com/jupyterlab/lumino/pull/503) ([@dependabot](https://github.com/dependabot))
+- Bump tj-actions/changed-files from 34.4.0 to 34.5.3 [#493](https://github.com/jupyterlab/lumino/pull/493) ([@dependabot](https://github.com/dependabot))
+- Bump dessant/lock-threads from 3 to 4 [#492](https://github.com/jupyterlab/lumino/pull/492) ([@dependabot](https://github.com/dependabot))
+- Bump decode-uri-component from 0.2.0 to 0.2.2 [#483](https://github.com/jupyterlab/lumino/pull/483) ([@dependabot](https://github.com/dependabot))
+- Use Firefox from playwright [#481](https://github.com/jupyterlab/lumino/pull/481) ([@fcollonval](https://github.com/fcollonval))
+- Set up jupyter releaser [#474](https://github.com/jupyterlab/lumino/pull/474) ([@blink1073](https://github.com/blink1073))
+- Bump engine.io from 6.2.0 to 6.2.1 [#469](https://github.com/jupyterlab/lumino/pull/469) ([@dependabot](https://github.com/dependabot))
+- Fix license header CI [#468](https://github.com/jupyterlab/lumino/pull/468) ([@fcollonval](https://github.com/fcollonval))
+- Bump loader-utils from 3.2.0 to 3.2.1 [#467](https://github.com/jupyterlab/lumino/pull/467) ([@dependabot](https://github.com/dependabot))
+- Bump tj-actions/changed-files from 34.3.2 to 34.4.0 [#466](https://github.com/jupyterlab/lumino/pull/466) ([@dependabot](https://github.com/dependabot))
+- Bump tj-actions/changed-files from 34.0.2 to 34.3.2 [#461](https://github.com/jupyterlab/lumino/pull/461) ([@dependabot](https://github.com/dependabot))
+- Bump actions/checkout from 2 to 3 [#460](https://github.com/jupyterlab/lumino/pull/460) ([@dependabot](https://github.com/dependabot))
+- Fix check release step [#459](https://github.com/jupyterlab/lumino/pull/459) ([@fcollonval](https://github.com/fcollonval))
+- Audit `DataGrid` public API in preparation for 0.x => 2.0 [#458](https://github.com/jupyterlab/lumino/pull/458) ([@afshin](https://github.com/afshin))
+- Bump tj-actions/changed-files from 32.1.2 to 34.0.2 [#454](https://github.com/jupyterlab/lumino/pull/454) ([@dependabot](https://github.com/dependabot))
+- Bump tj-actions/changed-files from 32.0.0 to 32.1.2 [#445](https://github.com/jupyterlab/lumino/pull/445) ([@dependabot](https://github.com/dependabot))
+- Clean up test workflow [#437](https://github.com/jupyterlab/lumino/pull/437) ([@blink1073](https://github.com/blink1073))
+- Bump tj-actions/changed-files from 31.0.3 to 32.0.0 [#435](https://github.com/jupyterlab/lumino/pull/435) ([@dependabot](https://github.com/dependabot))
+- Fix minor code scan warnings [#431](https://github.com/jupyterlab/lumino/pull/431) ([@fcollonval](https://github.com/fcollonval))
+- Bump lerna [#429](https://github.com/jupyterlab/lumino/pull/429) ([@fcollonval](https://github.com/fcollonval))
+- Bump tj-actions/changed-files from 31.0.1 to 31.0.3 [#424](https://github.com/jupyterlab/lumino/pull/424) ([@dependabot](https://github.com/dependabot))
+- Bump tj-actions/changed-files from 29.0.7 to 31.0.1 [#423](https://github.com/jupyterlab/lumino/pull/423) ([@dependabot](https://github.com/dependabot))
+- Add DockLayout tests [#421](https://github.com/jupyterlab/lumino/pull/421) ([@3coins](https://github.com/3coins))
+- Bump tj-actions/changed-files from 29.0.4 to 29.0.7 [#417](https://github.com/jupyterlab/lumino/pull/417) ([@dependabot](https://github.com/dependabot))
+- Remove Internet Explorer from tests, add Webkit [#416](https://github.com/jupyterlab/lumino/pull/416) ([@gabalafou](https://github.com/gabalafou))
+- Follow on to #411 addressing `yield*` [#415](https://github.com/jupyterlab/lumino/pull/415) ([@afshin](https://github.com/afshin))
+
+### Documentation improvements
+
+- Update documentation for Stream class [#484](https://github.com/jupyterlab/lumino/pull/484) ([@afshin](https://github.com/afshin))
+- Backport changelog for stable 1.x [#455](https://github.com/jupyterlab/lumino/pull/455) ([@fcollonval](https://github.com/fcollonval))
+- Switch to pydata sphinx theme [#422](https://github.com/jupyterlab/lumino/pull/422) ([@blink1073](https://github.com/blink1073))
+- Add section to README: Learning Resources [#420](https://github.com/jupyterlab/lumino/pull/420) ([@gabalafou](https://github.com/gabalafou))
+- Follow on to #411 addressing `yield*` [#415](https://github.com/jupyterlab/lumino/pull/415) ([@afshin](https://github.com/afshin))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-09-15&to=2023-01-03&type=c))
+
+[@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3A3coins+updated%3A2022-09-15..2023-01-03&type=Issues) | [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-09-15..2023-01-03&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ablink1073+updated%3A2022-09-15..2023-01-03&type=Issues) | [@brichet](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Abrichet+updated%3A2022-09-15..2023-01-03&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2022-09-15..2023-01-03&type=Issues) | [@drcd1](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adrcd1+updated%3A2022-09-15..2023-01-03&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-09-15..2023-01-03&type=Issues) | [@gabalafou](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Agabalafou+updated%3A2022-09-15..2023-01-03&type=Issues) | [@ibdafna](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aibdafna+updated%3A2022-09-15..2023-01-03&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Akrassowski+updated%3A2022-09-15..2023-01-03&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3AmartinRenou+updated%3A2022-09-15..2023-01-03&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ameeseeksdev+updated%3A2022-09-15..2023-01-03&type=Issues) | [@scmmmh](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Ascmmmh+updated%3A2022-09-15..2023-01-03&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Avidartf+updated%3A2022-09-15..2023-01-03&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2022-09-15..2023-01-03&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2022.9.15-alpha.6
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/algorithm@2.0.0-alpha.5...14aed9f818ef3d6dac4693eb3d7722dc27820664))
@@ -31,8 +106,6 @@ github_url: 'https://github.com/jupyterlab/lumino/blob/main/CHANGELOG.md'
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-09-09&to=2022-09-15&type=c))
 
 [@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2022-09-09..2022-09-15&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Adependabot+updated%3A2022-09-09..2022-09-15&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-09-09..2022-09-15&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Avidartf+updated%3A2022-09-09..2022-09-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2022.9.9-alpha.5
 


### PR DESCRIPTION
Automated Changelog Entry for 2023.1.3-alpha.7 on main
```
npm workspace versions:
@lumino/example-accordionpanel: 2.0.0-alpha.7
@lumino/example-datagrid: 2.0.0-alpha.7
@lumino/example-dockpanel: 2.0.0-alpha.7
@lumino/example-dockpanel-amd: 2.0.0-alpha.7
@lumino/example-dockpanel-iife: 2.0.0-alpha.7
@lumino/example-menubar: 0.1.0-alpha.7
@lumino/example-nested-dockpanel-amd: 2.0.0-alpha.7
@lumino/algorithm: 2.0.0-alpha.7
@lumino/application: 2.0.0-alpha.7
@lumino/collections: 2.0.0-alpha.7
@lumino/commands: 2.0.0-alpha.7
@lumino/coreutils: 2.0.0-alpha.7
@lumino/datagrid: 2.0.0-alpha.7
@lumino/default-theme: 2.0.0-alpha.7
@lumino/disposable: 2.0.0-alpha.7
@lumino/domutils: 2.0.0-alpha.7
@lumino/dragdrop: 2.0.0-alpha.7
@lumino/keyboard: 2.0.0-alpha.7
@lumino/messaging: 2.0.0-alpha.7
@lumino/polling: 2.0.0-alpha.7
@lumino/properties: 2.0.0-alpha.7
@lumino/signaling: 2.0.0-alpha.7
@lumino/virtualdom: 2.0.0-alpha.7
@lumino/widgets: 2.0.0-alpha.7
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/lumino/releases/tag/untagged-e31ef4e5d92b9416e78f  |
| Since | @lumino/algorithm@2.0.0-alpha.6 |