### PR TITLE
Enable creating widgets in shadow DOM

### DIFF
--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -89,6 +89,15 @@ while (!(it = it.next()).done) {
 }
 ```
 
+### Replace `widget.node` with `widget.attachmentNode`
+
+Lumino 2 distinguishes between the contents node (`node`) and attachment node
+(`attachmentNode`) of widgets to enable attaching widgets via shadow DOM root.
+By default attachment and contents node are the same, but for widgets with
+shadow DOM enabled, they differ. Downstream layouts need to update methods
+attaching and detaching widgets to use attachment node if they want to support
+moving the widgets to shadow DOM.
+
 ## Public API changes
 
 ### `@lumino/algorithm`

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -533,7 +533,7 @@ export class DockLayout extends Layout {
    */
   protected attachWidget(widget: Widget): void {
     // Do nothing if the widget is already attached.
-    if (this.parent!.node === widget.node.parentNode) {
+    if (this.parent!.node === widget.attachmentNode.parentNode) {
       return;
     }
 
@@ -546,7 +546,7 @@ export class DockLayout extends Layout {
     }
 
     // Add the widget's node to the parent.
-    this.parent!.node.appendChild(widget.node);
+    this.parent!.node.appendChild(widget.attachmentNode);
 
     // Send an `'after-attach'` message if the parent is attached.
     if (this.parent!.isAttached) {
@@ -564,7 +564,7 @@ export class DockLayout extends Layout {
    */
   protected detachWidget(widget: Widget): void {
     // Do nothing if the widget is not attached.
-    if (this.parent!.node !== widget.node.parentNode) {
+    if (this.parent!.node !== widget.attachmentNode.parentNode) {
       return;
     }
 
@@ -574,7 +574,7 @@ export class DockLayout extends Layout {
     }
 
     // Remove the widget's node from the parent.
-    this.parent!.node.removeChild(widget.node);
+    this.parent!.node.removeChild(widget.attachmentNode);
 
     // Send an `'after-detach'` message if the parent is attached.
     if (this.parent!.isAttached) {

--- a/packages/widgets/src/panellayout.ts
+++ b/packages/widgets/src/panellayout.ts
@@ -212,7 +212,7 @@ export class PanelLayout extends Layout {
     }
 
     // Insert the widget's node before the sibling.
-    this.parent!.node.insertBefore(widget.node, ref);
+    this.parent!.node.insertBefore(widget.attachmentNode, ref);
 
     // Send an `'after-attach'` message if the parent is attached.
     if (this.parent!.isAttached) {
@@ -251,7 +251,7 @@ export class PanelLayout extends Layout {
     }
 
     // Remove the widget's node from the parent.
-    this.parent!.node.removeChild(widget.node);
+    this.parent!.node.removeChild(widget.attachmentNode);
 
     // Send an `'after-detach'` and  message if the parent is attached.
     if (this.parent!.isAttached) {
@@ -267,7 +267,7 @@ export class PanelLayout extends Layout {
     }
 
     // Insert the widget's node before the sibling.
-    this.parent!.node.insertBefore(widget.node, ref);
+    this.parent!.node.insertBefore(widget.attachmentNode, ref);
 
     // Send an `'after-attach'` message if the parent is attached.
     if (this.parent!.isAttached) {
@@ -300,7 +300,7 @@ export class PanelLayout extends Layout {
     }
 
     // Remove the widget's node from the parent.
-    this.parent!.node.removeChild(widget.node);
+    this.parent!.node.removeChild(widget.attachmentNode);
 
     // Send an `'after-detach'` message if the parent is attached.
     if (this.parent!.isAttached) {

--- a/packages/widgets/tests/src/widget.spec.ts
+++ b/packages/widgets/tests/src/widget.spec.ts
@@ -122,6 +122,16 @@ describe('@lumino/widgets', () => {
         let widget = new Widget();
         expect(widget.hasClass('lm-Widget')).to.equal(true);
       });
+
+      it('should optionally proxy node via shadow DOM', () => {
+        let widget = new Widget({ shadowDOM: true });
+        expect(widget.node).to.not.equal(widget.attachmentNode);
+        expect(widget.attachmentNode.shadowRoot).to.not.equal(null);
+
+        widget = new Widget({ shadowDOM: false });
+        expect(widget.node).to.equal(widget.attachmentNode);
+        expect(widget.attachmentNode.shadowRoot).to.equal(null);
+      });
     });
 
     describe('#dispose()', () => {
@@ -554,6 +564,51 @@ describe('@lumino/widgets', () => {
         widget.node.classList.add('foo');
         expect(widget.toggleClass('foo')).to.equal(false);
         expect(widget.toggleClass('foo', false)).to.equal(false);
+      });
+    });
+
+    describe('#adoptStyleSheet()', () => {
+      it('should adopt style sheets for widgets with shadow DOM', () => {
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync('* { color: red; }');
+
+        let widget = new Widget({ shadowDOM: true });
+        Widget.attach(widget, document.body);
+
+        let div = document.createElement('div');
+        widget.node.appendChild(div);
+
+        expect(window.getComputedStyle(div).color).to.equal('rgb(0, 0, 0)');
+
+        let wasAdopted = widget.adoptStyleSheet(sheet);
+        expect(wasAdopted).to.equal(true);
+        expect(window.getComputedStyle(div).color).to.equal('rgb(255, 0, 0)');
+
+        wasAdopted = widget.adoptStyleSheet(sheet);
+        expect(wasAdopted).to.equal(false);
+      });
+    });
+
+    describe('#removeAdoptedStyleSheet()', () => {
+      it('should adopt style sheets for widgets with shadow DOM', () => {
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync('* { color: red; }');
+
+        let widget = new Widget({ shadowDOM: true });
+        Widget.attach(widget, document.body);
+
+        let div = document.createElement('div');
+        widget.node.appendChild(div);
+
+        widget.adoptStyleSheet(sheet);
+        expect(window.getComputedStyle(div).color).to.equal('rgb(255, 0, 0)');
+
+        let wasRemoved = widget.removeAdoptedStyleSheet(sheet);
+        expect(wasRemoved).to.equal(true);
+        expect(window.getComputedStyle(div).color).to.equal('rgb(0, 0, 0)');
+
+        wasRemoved = widget.removeAdoptedStyleSheet(sheet);
+        expect(wasRemoved).to.equal(false);
       });
     });
 

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -1258,6 +1258,8 @@ export class Widget implements IMessageHandler, IObservableDisposable {
     constructor(options?: Widget.IOptions);
     activate(): void;
     addClass(name: string): void;
+    adoptStyleSheet(sheet: CSSStyleSheet): boolean;
+    readonly attachmentNode: HTMLElement;
     children(): IterableIterator<Widget>;
     clearFlag(flag: Widget.Flag): void;
     close(): void;
@@ -1298,6 +1300,7 @@ export class Widget implements IMessageHandler, IObservableDisposable {
     get parent(): Widget | null;
     set parent(value: Widget | null);
     processMessage(msg: Message): void;
+    removeAdoptedStyleSheet(sheet: CSSStyleSheet): boolean;
     removeClass(name: string): void;
     setFlag(flag: Widget.Flag): void;
     setHidden(hidden: boolean): void;
@@ -1330,6 +1333,7 @@ export namespace Widget {
     }
     export interface IOptions {
         node?: HTMLElement;
+        shadowDOM?: boolean;
         tag?: keyof HTMLElementTagNameMap;
     }
     export namespace Msg {


### PR DESCRIPTION
Fixes #434.

Introduces a distinction between `attachmentNode` and a content `node`.

Adds new methods:
- `adoptStyleSheet()`
- `removeAdoptedStyleSheet()`
