### PR TITLE
Add deprecation warning on Signal blocking feature

### DIFF
--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -38,9 +38,11 @@ export interface ISignal<T, U> {
    * ### Notes
    * The callback function must be synchronous.
    *
+   * @deprecated This feature will be removed in Lumino 2.
+   *
    * @param fn The callback during which the signal is blocked
    */
-  block(fn: () => void): void;
+  block?(fn: () => void): void;
 
   /**
    * Connect a slot to the signal.
@@ -153,6 +155,8 @@ export class Signal<T, U> implements ISignal<T, U> {
    *
    * ### Notes
    * The callback function must be synchronous.
+   *
+   * @deprecated This feature will be removed in Lumino 2.
    *
    * @param fn The callback during which the signal is blocked
    */

--- a/packages/signaling/src/index.ts
+++ b/packages/signaling/src/index.ts
@@ -227,6 +227,8 @@ export namespace Signal {
    * ### Notes
    * The callback function must be synchronous.
    *
+   * @deprecated This feature will be removed in Lumino 2.
+   *
    * @param sender The signals sender
    * @param fn The callback during which all signals are blocked
    */


### PR DESCRIPTION
## Reference

https://github.com/jupyterlab/lumino/pull/444#issuecomment-1400395192

## Code changes

Add deprecation warning on `[I]Signal.block` and `Signal.blockAll`
Make `ISignal.block` optional

