### PR TITLE
Automated Changelog Entry for 2023.1.23 on 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2023.1.23
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.31.2...58081c0313e536ac9dbb86ee0a602a1fa8445130))
+
+### Bugs fixed
+
+- Add deprecation warning on Signal blocking feature [#521](https://github.com/jupyterlab/lumino/pull/521) ([@fcollonval](https://github.com/fcollonval))
+
+### Maintenance and upkeep improvements
+
+- Bump versions [#523](https://github.com/jupyterlab/lumino/pull/523) ([@fcollonval](https://github.com/fcollonval))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2023-01-19&to=2023-01-23&type=c))
+
+[@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2023-01-19..2023-01-23&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2023.1.19
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.31.1...2485c99523f14772f9520c0879c4404328ae1d7d))
@@ -19,8 +39,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2022-12-13&to=2023-01-19&type=c))
 
 [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2022-12-13..2023-01-19&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Akrassowski+updated%3A2022-12-13..2023-01-19&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2022-12-13..2023-01-19&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2022.12.13
 


### PR DESCRIPTION
Automated Changelog Entry for 2023.1.23 on 1.x
```
npm workspace versions:
@lumino/example-accordionpanel: 0.8.8
@lumino/example-datagrid: 0.32.8
@lumino/example-datastore: 0.21.8
@lumino/example-dockpanel: 0.21.8
@lumino/example-dockpanel-amd: 0.4.0
@lumino/example-dockpanel-iife: 0.4.0
@lumino/example-menubar: 0.1.3
@lumino/example-nested-dockpanel-amd: 0.4.1
@lumino/algorithm: 1.9.2
@lumino/application: 1.31.3
@lumino/collections: 1.9.3
@lumino/commands: 1.21.1
@lumino/coreutils: 1.12.1
@lumino/datagrid: 0.36.8
@lumino/datastore: 0.18.4
@lumino/default-theme: 0.22.8
@lumino/disposable: 1.10.4
@lumino/domutils: 1.8.2
@lumino/dragdrop: 1.14.4
@lumino/keyboard: 1.8.2
@lumino/messaging: 1.10.3
@lumino/polling: 1.11.4
@lumino/properties: 1.8.2
@lumino/signaling: 1.11.1
@lumino/virtualdom: 1.14.3
@lumino/widgets: 1.37.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/lumino/releases/tag/untagged-982787d96780d608a304  |
| Since | @lumino/application@1.31.2 |