### PR TITLE
Check for hidden items before re-rendering

### DIFF
--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -287,64 +287,65 @@ export class CommandPalette extends Widget {
    * A message handler invoked on an `'update-request'` message.
    */
   protected onUpdateRequest(msg: Message): void {
-    if (!this.isHidden) {
-        // Fetch the current query text and content node.
-        let query = this.inputNode.value;
-        let contentNode = this.contentNode;
+    if (this.isHidden) {
+      return;
+    }
+    // Fetch the current query text and content node.
+    let query = this.inputNode.value;
+    let contentNode = this.contentNode;
 
-        // Ensure the search results are generated.
-        let results = this._results;
-        if (!results) {
-        // Generate and store the new search results.
-        results = this._results = Private.search(this._items, query);
+    // Ensure the search results are generated.
+    let results = this._results;
+    if (!results) {
+      // Generate and store the new search results.
+      results = this._results = Private.search(this._items, query);
 
-        // Reset the active index.
-        this._activeIndex = query
-            ? ArrayExt.findFirstIndex(results, Private.canActivate)
-            : -1;
-        }
+    // Reset the active index.
+    this._activeIndex = query
+        ? ArrayExt.findFirstIndex(results, Private.canActivate)
+        : -1;
+    }
 
-        // If there is no query and no results, clear the content.
-        if (!query && results.length === 0) {
-        VirtualDOM.render(null, contentNode);
-        return;
-        }
+    // If there is no query and no results, clear the content.
+    if (!query && results.length === 0) {
+      VirtualDOM.render(null, contentNode);
+      return;
+    }
 
-        // If the is a query but no results, render the empty message.
-        if (query && results.length === 0) {
-        let content = this.renderer.renderEmptyMessage({ query });
-        VirtualDOM.render(content, contentNode);
-        return;
-        }
+    // If the is a query but no results, render the empty message.
+    if (query && results.length === 0) {
+      let content = this.renderer.renderEmptyMessage({ query });
+      VirtualDOM.render(content, contentNode);
+      return;
+    }
 
-        // Create the render content for the search results.
-        let renderer = this.renderer;
-        let activeIndex = this._activeIndex;
-        let content = new Array<VirtualElement>(results.length);
-        for (let i = 0, n = results.length; i < n; ++i) {
-        let result = results[i];
-        if (result.type === 'header') {
-            let indices = result.indices;
-            let category = result.category;
-            content[i] = renderer.renderHeader({ category, indices });
-        } else {
-            let item = result.item;
-            let indices = result.indices;
-            let active = i === activeIndex;
-            content[i] = renderer.renderItem({ item, indices, active });
-        }
-        }
+    // Create the render content for the search results.
+    let renderer = this.renderer;
+    let activeIndex = this._activeIndex;
+    let content = new Array<VirtualElement>(results.length);
+    for (let i = 0, n = results.length; i < n; ++i) {
+      let result = results[i];
+      if (result.type === 'header') {
+          let indices = result.indices;
+          let category = result.category;
+          content[i] = renderer.renderHeader({ category, indices });
+      } else {
+          let item = result.item;
+          let indices = result.indices;
+          let active = i === activeIndex;
+          content[i] = renderer.renderItem({ item, indices, active });
+      }
+    }
 
-        // Render the search result content.
-        VirtualDOM.render(content, contentNode);
+    // Render the search result content.
+    VirtualDOM.render(content, contentNode);
 
-        // Adjust the scroll position as needed.
-        if (activeIndex < 0 || activeIndex >= results.length) {
-            contentNode.scrollTop = 0;
-        } else {
-            let element = contentNode.children[activeIndex];
-            ElementExt.scrollIntoViewIfNeeded(contentNode, element);
-        }
+    // Adjust the scroll position as needed.
+    if (activeIndex < 0 || activeIndex >= results.length) {
+        contentNode.scrollTop = 0;
+    } else {
+        let element = contentNode.children[activeIndex];
+        ElementExt.scrollIntoViewIfNeeded(contentNode, element);
     }
   }
 

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -287,9 +287,10 @@ export class CommandPalette extends Widget {
    * A message handler invoked on an `'update-request'` message.
    */
   protected onUpdateRequest(msg: Message): void {
-    if (this.isHidden) {
+    if (this.isHidden()) {
       return;
     }
+
     // Fetch the current query text and content node.
     let query = this.inputNode.value;
     let contentNode = this.contentNode;
@@ -300,8 +301,8 @@ export class CommandPalette extends Widget {
       // Generate and store the new search results.
       results = this._results = Private.search(this._items, query);
 
-    // Reset the active index.
-    this._activeIndex = query
+      // Reset the active index.
+      this._activeIndex = query
         ? ArrayExt.findFirstIndex(results, Private.canActivate)
         : -1;
     }
@@ -326,14 +327,14 @@ export class CommandPalette extends Widget {
     for (let i = 0, n = results.length; i < n; ++i) {
       let result = results[i];
       if (result.type === 'header') {
-          let indices = result.indices;
-          let category = result.category;
-          content[i] = renderer.renderHeader({ category, indices });
+        let indices = result.indices;
+        let category = result.category;
+        content[i] = renderer.renderHeader({ category, indices });
       } else {
-          let item = result.item;
-          let indices = result.indices;
-          let active = i === activeIndex;
-          content[i] = renderer.renderItem({ item, indices, active });
+        let item = result.item;
+        let indices = result.indices;
+        let active = i === activeIndex;
+        content[i] = renderer.renderItem({ item, indices, active });
       }
     }
 
@@ -342,10 +343,10 @@ export class CommandPalette extends Widget {
 
     // Adjust the scroll position as needed.
     if (activeIndex < 0 || activeIndex >= results.length) {
-        contentNode.scrollTop = 0;
+      contentNode.scrollTop = 0;
     } else {
-        let element = contentNode.children[activeIndex];
-        ElementExt.scrollIntoViewIfNeeded(contentNode, element);
+      let element = contentNode.children[activeIndex];
+      ElementExt.scrollIntoViewIfNeeded(contentNode, element);
     }
   }
 

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -273,6 +273,14 @@ export class CommandPalette extends Widget {
   }
 
   /**
+   * A message handler invoked on an `'after-show'` message.
+   */
+  protected onAfterShow(msg: Message): void {
+    this.update();
+    super.onAfterShow(msg);
+  }
+  
+  /**
    * A message handler invoked on an `'activate-request'` message.
    */
   protected onActivateRequest(msg: Message): void {

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -287,62 +287,64 @@ export class CommandPalette extends Widget {
    * A message handler invoked on an `'update-request'` message.
    */
   protected onUpdateRequest(msg: Message): void {
-    // Fetch the current query text and content node.
-    let query = this.inputNode.value;
-    let contentNode = this.contentNode;
+    if (!this.isHidden) {
+        // Fetch the current query text and content node.
+        let query = this.inputNode.value;
+        let contentNode = this.contentNode;
 
-    // Ensure the search results are generated.
-    let results = this._results;
-    if (!results) {
-      // Generate and store the new search results.
-      results = this._results = Private.search(this._items, query);
+        // Ensure the search results are generated.
+        let results = this._results;
+        if (!results) {
+        // Generate and store the new search results.
+        results = this._results = Private.search(this._items, query);
 
-      // Reset the active index.
-      this._activeIndex = query
-        ? ArrayExt.findFirstIndex(results, Private.canActivate)
-        : -1;
-    }
+        // Reset the active index.
+        this._activeIndex = query
+            ? ArrayExt.findFirstIndex(results, Private.canActivate)
+            : -1;
+        }
 
-    // If there is no query and no results, clear the content.
-    if (!query && results.length === 0) {
-      VirtualDOM.render(null, contentNode);
-      return;
-    }
+        // If there is no query and no results, clear the content.
+        if (!query && results.length === 0) {
+        VirtualDOM.render(null, contentNode);
+        return;
+        }
 
-    // If the is a query but no results, render the empty message.
-    if (query && results.length === 0) {
-      let content = this.renderer.renderEmptyMessage({ query });
-      VirtualDOM.render(content, contentNode);
-      return;
-    }
+        // If the is a query but no results, render the empty message.
+        if (query && results.length === 0) {
+        let content = this.renderer.renderEmptyMessage({ query });
+        VirtualDOM.render(content, contentNode);
+        return;
+        }
 
-    // Create the render content for the search results.
-    let renderer = this.renderer;
-    let activeIndex = this._activeIndex;
-    let content = new Array<VirtualElement>(results.length);
-    for (let i = 0, n = results.length; i < n; ++i) {
-      let result = results[i];
-      if (result.type === 'header') {
-        let indices = result.indices;
-        let category = result.category;
-        content[i] = renderer.renderHeader({ category, indices });
-      } else {
-        let item = result.item;
-        let indices = result.indices;
-        let active = i === activeIndex;
-        content[i] = renderer.renderItem({ item, indices, active });
-      }
-    }
+        // Create the render content for the search results.
+        let renderer = this.renderer;
+        let activeIndex = this._activeIndex;
+        let content = new Array<VirtualElement>(results.length);
+        for (let i = 0, n = results.length; i < n; ++i) {
+        let result = results[i];
+        if (result.type === 'header') {
+            let indices = result.indices;
+            let category = result.category;
+            content[i] = renderer.renderHeader({ category, indices });
+        } else {
+            let item = result.item;
+            let indices = result.indices;
+            let active = i === activeIndex;
+            content[i] = renderer.renderItem({ item, indices, active });
+        }
+        }
 
-    // Render the search result content.
-    VirtualDOM.render(content, contentNode);
+        // Render the search result content.
+        VirtualDOM.render(content, contentNode);
 
-    // Adjust the scroll position as needed.
-    if (activeIndex < 0 || activeIndex >= results.length) {
-      contentNode.scrollTop = 0;
-    } else {
-      let element = contentNode.children[activeIndex];
-      ElementExt.scrollIntoViewIfNeeded(contentNode, element);
+        // Adjust the scroll position as needed.
+        if (activeIndex < 0 || activeIndex >= results.length) {
+            contentNode.scrollTop = 0;
+        } else {
+            let element = contentNode.children[activeIndex];
+            ElementExt.scrollIntoViewIfNeeded(contentNode, element);
+        }
     }
   }
 

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -279,7 +279,7 @@ export class CommandPalette extends Widget {
     this.update();
     super.onAfterShow(msg);
   }
-  
+
   /**
    * A message handler invoked on an `'activate-request'` message.
    */

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -287,7 +287,7 @@ export class CommandPalette extends Widget {
    * A message handler invoked on an `'update-request'` message.
    */
   protected onUpdateRequest(msg: Message): void {
-    if (this.isHidden()) {
+    if (this.isHidden) {
       return;
     }
 

--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -667,7 +667,10 @@ export class Widget implements IMessageHandler, IObservableDisposable {
    * #### Notes
    * The default implementation of this handler is a no-op.
    */
-  protected onAfterShow(msg: Message): void {}
+  protected onAfterShow(msg: Message): void {
+    this.update();
+    super.onAfterShow(msg);
+  }
 
   /**
    * A message handler invoked on a `'before-hide'` message.

--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -667,10 +667,7 @@ export class Widget implements IMessageHandler, IObservableDisposable {
    * #### Notes
    * The default implementation of this handler is a no-op.
    */
-  protected onAfterShow(msg: Message): void {
-    this.update();
-    super.onAfterShow(msg);
-  }
+  protected onAfterShow(msg: Message): void {}
 
   /**
    * A message handler invoked on a `'before-hide'` message.

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -179,6 +179,7 @@ export class CommandPalette extends Widget {
     get items(): ReadonlyArray<CommandPalette.IItem>;
     protected onActivateRequest(msg: Message): void;
     protected onAfterDetach(msg: Message): void;
+    protected onAfterShow(msg: Message): void;
     protected onBeforeAttach(msg: Message): void;
     protected onUpdateRequest(msg: Message): void;
     refresh(): void;


### PR DESCRIPTION
This PR fixes issue [#13677](https://github.com/jupyterlab/jupyterlab/issues/13677) from jupyterlab.

### Issue
Hidden items are still being re-rendered, despite the fact that they shouldn't be. 

### Solution
Added a check to [```onUpdateRequest```](https://github.com/jupyterlab/lumino/blob/fa048e1680cce138af24ee1aa964f2f02b5e61f6/packages/widgets/src/commandpalette.ts#L289) to determine if an item is hidden, before re-rendering it. This will prevent hidden items from being re-rendered, thus solving the issue.