### PR TITLE
Resize column to fit text on double click

### DIFF
--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -108,11 +108,11 @@ class MergedCellModel extends DataModel {
 
 class LargeDataModel extends DataModel {
   rowCount(region: DataModel.RowRegion): number {
-    return region === 'body' ? 1000000000000 : 2;
+    return region === 'body' ? 1_000_000_000_000 : 2;
   }
 
   columnCount(region: DataModel.ColumnRegion): number {
-    return region === 'body' ? 1000000000000 : 3;
+    return region === 'body' ? 1_000_000_000_000 : 3;
   }
 
   data(region: DataModel.CellRegion, row: number, column: number): any {

--- a/packages/datagrid/src/basicmousehandler.ts
+++ b/packages/datagrid/src/basicmousehandler.ts
@@ -621,6 +621,31 @@ export class BasicMouseHandler implements DataGrid.IMouseHandler {
       return;
     }
 
+    if (region === 'column-header' || region === 'corner-header') {
+      // Convert the hit test into a part.
+      const handle = Private.resizeHandleForHitTest(hit);
+
+      if (handle === 'left' || handle === 'right') {
+        let colIndex = handle === 'left' ? column - 1 : column;
+
+        let colRegion: DataModel.ColumnRegion =
+          region === 'column-header' ? 'body' : 'row-header';
+
+        if (colIndex < 0) {
+          if (region === 'column-header') {
+            // If the column is -1, it means we are in the corner header
+            colIndex = grid.dataModel.columnCount('row-header') - 1;
+            colRegion = 'row-header';
+          } else {
+            // If we are on the left edge of the row header, do nothing
+            return;
+          }
+        }
+
+        grid.resizeColumn(colRegion, colIndex, null);
+      }
+    }
+
     if (region === 'body') {
       if (grid.editable) {
         const cell: CellEditor.CellConfig = {

--- a/packages/datagrid/src/hyperlinkrenderer.ts
+++ b/packages/datagrid/src/hyperlinkrenderer.ts
@@ -42,6 +42,24 @@ export class HyperlinkRenderer extends TextRenderer {
   readonly urlName: CellRenderer.ConfigOption<string> | undefined;
 
   /**
+   * Get the full text to be rendered by the cell.
+   */
+  getText(config: CellRenderer.CellConfig): string {
+    let urlName = CellRenderer.resolveOption(this.urlName, config);
+
+    // If we have a friendly URL name, use that.
+    if (urlName) {
+      return this.format({
+        ...config,
+        value: urlName
+      } as CellRenderer.CellConfig);
+    }
+
+    // Otherwise use the raw value attribute.
+    return this.format(config);
+  }
+
+  /**
    * Draw the text for the cell.
    *
    * @param gc - The graphics context to use for drawing.
@@ -57,9 +75,6 @@ export class HyperlinkRenderer extends TextRenderer {
       return;
     }
 
-    // Resolve for the friendly URL name.
-    let urlName = CellRenderer.resolveOption(this.urlName, config);
-
     // Resolve the text color for the cell.
     let color = CellRenderer.resolveOption(this.textColor, config);
 
@@ -68,19 +83,7 @@ export class HyperlinkRenderer extends TextRenderer {
       return;
     }
 
-    const format = this.format;
-    let text;
-
-    // If we have a friendly URL name, use that.
-    if (urlName) {
-      text = format({
-        ...config,
-        value: urlName
-      } as CellRenderer.CellConfig);
-    } else {
-      // Otherwise use the raw value attribute.
-      text = format(config);
-    }
+    let text = this.getText(config);
 
     // Bail if there is no text to draw.
     if (!text) {

--- a/packages/datagrid/src/textrenderer.ts
+++ b/packages/datagrid/src/textrenderer.ts
@@ -27,6 +27,7 @@ export class TextRenderer extends CellRenderer {
     this.backgroundColor = options.backgroundColor || '';
     this.verticalAlignment = options.verticalAlignment || 'center';
     this.horizontalAlignment = options.horizontalAlignment || 'left';
+    this.horizontalPadding = options.horizontalPadding || 8;
     this.format = options.format || TextRenderer.formatGeneric();
     this.elideDirection = options.elideDirection || 'none';
     this.wrapText = options.wrapText || false;
@@ -56,6 +57,11 @@ export class TextRenderer extends CellRenderer {
    * The horizontal alignment for the cell text.
    */
   readonly horizontalAlignment: CellRenderer.ConfigOption<TextRenderer.HorizontalAlignment>;
+
+  /**
+   * The horizontal alignment for the cell text.
+   */
+  readonly horizontalPadding: number;
 
   /**
    * The format function for the cell value.
@@ -106,6 +112,13 @@ export class TextRenderer extends CellRenderer {
   }
 
   /**
+   * Get the full text to be rendered by the cell.
+   */
+  getText(config: CellRenderer.CellConfig): string {
+    return this.format(config);
+  }
+
+  /**
    * Draw the text for the cell.
    *
    * @param gc - The graphics context to use for drawing.
@@ -130,8 +143,7 @@ export class TextRenderer extends CellRenderer {
     }
 
     // Format the cell value to text.
-    let format = this.format;
-    let text = format(config);
+    let text = this.getText(config);
 
     // Bail if there is no text to draw.
     if (!text) {
@@ -185,7 +197,7 @@ export class TextRenderer extends CellRenderer {
     // Compute the X position for the text.
     switch (hAlign) {
       case 'left':
-        textX = config.x + 8;
+        textX = config.x + this.horizontalPadding;
         boxWidth = config.width - 14;
         break;
       case 'center':
@@ -193,7 +205,7 @@ export class TextRenderer extends CellRenderer {
         boxWidth = config.width;
         break;
       case 'right':
-        textX = config.x + config.width - 8;
+        textX = config.x + config.width - this.horizontalPadding;
         boxWidth = config.width - 14;
         break;
       default:
@@ -395,6 +407,13 @@ export namespace TextRenderer {
      * The default is `'left'`.
      */
     horizontalAlignment?: CellRenderer.ConfigOption<HorizontalAlignment>;
+
+    /**
+     * The horizontal padding for the cell text in pixels.
+     *
+     * The default is `8`.
+     */
+    horizontalPadding?: number;
 
     /**
      * The format function for the renderer.

--- a/review/api/datagrid.api.md
+++ b/review/api/datagrid.api.md
@@ -258,7 +258,7 @@ export class DataGrid extends Widget {
     protected repaintRegion(region: DataModel.CellRegion, r1: number, c1: number, r2: number, c2: number): void;
     resetColumns(region: DataModel.ColumnRegion | 'all'): void;
     resetRows(region: DataModel.RowRegion | 'all'): void;
-    resizeColumn(region: DataModel.ColumnRegion, index: number, size: number): void;
+    resizeColumn(region: DataModel.ColumnRegion, index: number, size: number | null): void;
     resizeRow(region: DataModel.RowRegion, index: number, size: number): void;
     rowAt(region: DataModel.RowRegion, offset: number): number;
     rowCount(region: DataModel.RowRegion): number;
@@ -613,6 +613,7 @@ export class GraphicsContext implements IDisposable {
 export class HyperlinkRenderer extends TextRenderer {
     constructor(options?: HyperlinkRenderer.IOptions);
     drawText(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
+    getText(config: CellRenderer.CellConfig): string;
     readonly url: CellRenderer.ConfigOption<string> | undefined;
     readonly urlName: CellRenderer.ConfigOption<string> | undefined;
 }
@@ -919,7 +920,9 @@ export class TextRenderer extends CellRenderer {
     readonly elideDirection: CellRenderer.ConfigOption<TextRenderer.ElideDirection>;
     readonly font: CellRenderer.ConfigOption<string>;
     readonly format: TextRenderer.FormatFunc;
+    getText(config: CellRenderer.CellConfig): string;
     readonly horizontalAlignment: CellRenderer.ConfigOption<TextRenderer.HorizontalAlignment>;
+    readonly horizontalPadding: number;
     paint(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
     readonly textColor: CellRenderer.ConfigOption<string>;
     readonly verticalAlignment: CellRenderer.ConfigOption<TextRenderer.VerticalAlignment>;
@@ -1004,6 +1007,7 @@ export namespace TextRenderer {
         font?: CellRenderer.ConfigOption<string>;
         format?: FormatFunc;
         horizontalAlignment?: CellRenderer.ConfigOption<HorizontalAlignment>;
+        horizontalPadding?: number;
         textColor?: CellRenderer.ConfigOption<string>;
         verticalAlignment?: CellRenderer.ConfigOption<VerticalAlignment>;
         wrapText?: CellRenderer.ConfigOption<boolean>;


### PR DESCRIPTION
Implements: https://github.com/jupyterlab/lumino/issues/535 and https://github.com/bloomberg/ipydatagrid/issues/302

Automatically resizes the width of columns by double clicking on the barriers between column headers.