### PR TITLE
Fix requiring position for `MenuBar` undetermined index

### DIFF
--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -699,7 +699,8 @@ export class MenuBar extends Widget {
     }
 
     // Get position for the new menu >before< updating active index.
-    const position = this._positionForMenu(index);
+    const position =
+      index >= 0 && this._childMenu ? this._positionForMenu(index) : null;
 
     // Before any modification, update window data.
     Menu.saveWindowData();
@@ -710,7 +711,7 @@ export class MenuBar extends Widget {
     this.activeIndex = index;
 
     // Open the new menu if a menu is already open.
-    if (this._childMenu) {
+    if (position) {
       this._openChildMenu(position);
     }
   }


### PR DESCRIPTION
In https://github.com/jupyter/notebook/pull/6757, the following error was seen:

![image](https://user-images.githubusercontent.com/8435071/222782911-2dfab4ce-e6ff-4ee0-b29a-91861e3b106b.png)

This error has probably appeared due to the conjunction of trouble with the new overflow menu feature and single item menu bar used in notebook v7.