### PR TITLE
Remove `IDragEvent` deprecated tag

### DIFF
--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -38,6 +38,8 @@ export type SupportedActions =
  * events, a drop target must cancel the `'lm-dragenter'` event by
  * calling the event's `preventDefault()` method.
  *
+ * This interface will be deprecated in @lumino/dragdrop@^2.0.0 in favor of
+ * `Drag.Event`.
  */
 export interface IDragEvent extends MouseEvent {
   /**

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -38,8 +38,6 @@ export type SupportedActions =
  * events, a drop target must cancel the `'lm-dragenter'` event by
  * calling the event's `preventDefault()` method.
  *
- * @deprecated This interface will be deprecated in @lumino/dragdrop@^2.0.0 in favor
- * of ``Drag.Event``.
  */
 export interface IDragEvent extends MouseEvent {
   /**


### PR DESCRIPTION
This PR removes a `@deprecated` warning because it is actually a warning about *future* deprecation.

Fixes #559.