### PR TITLE
Automated Changelog Entry for 2023.3.27-0 on 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2023.3.27-0
+
+([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.31.3...45339b9ad932f305d58cbe3c60a57afcd88aa006))
+
+### Bugs fixed
+
+- Remove `IDragEvent` deprecated tag [#561](https://github.com/jupyterlab/lumino/pull/561) ([@afshin](https://github.com/afshin))
+
+### Maintenance and upkeep improvements
+
+- Update versions [#565](https://github.com/jupyterlab/lumino/pull/565) ([@fcollonval](https://github.com/fcollonval))
+
+### Documentation improvements
+
+- Remove `IDragEvent` deprecated tag [#561](https://github.com/jupyterlab/lumino/pull/561) ([@afshin](https://github.com/afshin))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2023-01-23&to=2023-03-27&type=c))
+
+[@afshin](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aafshin+updated%3A2023-01-23..2023-03-27&type=Issues) | [@andrii-i](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Aandrii-i+updated%3A2023-01-23..2023-03-27&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2023-01-23..2023-03-27&type=Issues) | [@krassowski](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Akrassowski+updated%3A2023-01-23..2023-03-27&type=Issues) | [@steff456](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Asteff456+updated%3A2023-01-23..2023-03-27&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Awelcome+updated%3A2023-01-23..2023-03-27&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2023.1.23
 
 ([Full Changelog](https://github.com/jupyterlab/lumino/compare/@lumino/application@1.31.2...58081c0313e536ac9dbb86ee0a602a1fa8445130))
@@ -19,8 +43,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/lumino/graphs/contributors?from=2023-01-19&to=2023-01-23&type=c))
 
 [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Flumino+involves%3Afcollonval+updated%3A2023-01-19..2023-01-23&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2023.1.19
 


### PR DESCRIPTION
Automated Changelog Entry for 2023.3.27-0 on 1.x
```
npm workspace versions:
@lumino/example-accordionpanel: 0.8.9
@lumino/example-datagrid: 0.32.9
@lumino/example-datastore: 0.21.9
@lumino/example-dockpanel: 0.21.9
@lumino/example-dockpanel-amd: 0.4.0
@lumino/example-dockpanel-iife: 0.4.0
@lumino/example-menubar: 0.1.4
@lumino/example-nested-dockpanel-amd: 0.4.1
@lumino/algorithm: 1.9.2
@lumino/application: 1.31.4
@lumino/collections: 1.9.3
@lumino/commands: 1.21.1
@lumino/coreutils: 1.12.1
@lumino/datagrid: 0.36.9
@lumino/datastore: 0.18.4
@lumino/default-theme: 0.22.9
@lumino/disposable: 1.10.4
@lumino/domutils: 1.8.2
@lumino/dragdrop: 1.14.5
@lumino/keyboard: 1.8.2
@lumino/messaging: 1.10.3
@lumino/polling: 1.11.4
@lumino/properties: 1.8.2
@lumino/signaling: 1.11.1
@lumino/virtualdom: 1.14.3
@lumino/widgets: 1.37.2
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/jupyterlab/lumino/releases/tag/untagged-b36ebf330d6de06b169f  |
| Since | @lumino/application@1.31.3 |