### PR TITLE
Add optional `description` to `Token`

### DIFF
--- a/packages/coreutils/src/token.ts
+++ b/packages/coreutils/src/token.ts
@@ -20,11 +20,18 @@ export class Token<T> {
    * Construct a new token.
    *
    * @param name - A human readable name for the token.
+   * @param description - Token purpose description for documentation.
    */
-  constructor(name: string) {
+  constructor(name: string, description?: string) {
     this.name = name;
+    this.description = description ?? '';
     this._tokenStructuralPropertyT = null!;
   }
+
+  /**
+   * Token purpose description.
+   */
+  readonly description: string;
 
   /**
    * The human readable name for the token.

--- a/packages/polling/tsconfig.json
+++ b/packages/polling/tsconfig.json
@@ -4,8 +4,7 @@
     "declarationDir": "types",
     "lib": ["DOM", "ES2018"],
     "outDir": "lib",
-    "rootDir": "src",
-    "types": ["@types/node"]
+    "rootDir": "src"
   },
   "include": ["src/*"],
   "references": [

--- a/review/api/coreutils.api.md
+++ b/review/api/coreutils.api.md
@@ -76,8 +76,7 @@ export class PromiseDelegate<T> {
 
 // @public
 export namespace Random {
-    const // Warning: (ae-forgotten-export) The symbol "fallbackRandomValues" needs to be exported by the entry point index.d.ts
-    getRandomValues: typeof fallbackRandomValues;
+    const getRandomValues: (buffer: Uint8Array) => void;
 }
 
 // @public
@@ -108,7 +107,8 @@ export type ReadonlyPartialJSONValue = JSONPrimitive | ReadonlyPartialJSONObject
 
 // @public
 export class Token<T> {
-    constructor(name: string);
+    constructor(name: string, description?: string);
+    readonly description: string;
     readonly name: string;
 }
 

--- a/review/api/coreutils.api.md
+++ b/review/api/coreutils.api.md
@@ -76,7 +76,8 @@ export class PromiseDelegate<T> {
 
 // @public
 export namespace Random {
-    const getRandomValues: (buffer: Uint8Array) => void;
+    const // Warning: (ae-forgotten-export) The symbol "fallbackRandomValues" needs to be exported by the entry point index.d.ts
+    getRandomValues: typeof fallbackRandomValues;
 }
 
 // @public


### PR DESCRIPTION
The goal of this attribute is to improve token documentation.