### PR TITLE
Make `Token.description` optional for backward compatibility

### DIFF
--- a/packages/coreutils/src/token.ts
+++ b/packages/coreutils/src/token.ts
@@ -31,7 +31,7 @@ export class Token<T> {
   /**
    * Token purpose description.
    */
-  readonly description: string;
+  readonly description?: string; // FIXME remove `?` for the next major version
 
   /**
    * The human readable name for the token.

--- a/review/api/coreutils.api.md
+++ b/review/api/coreutils.api.md
@@ -76,7 +76,8 @@ export class PromiseDelegate<T> {
 
 // @public
 export namespace Random {
-    const getRandomValues: (buffer: Uint8Array) => void;
+    const // Warning: (ae-forgotten-export) The symbol "fallbackRandomValues" needs to be exported by the entry point index.d.ts
+    getRandomValues: typeof fallbackRandomValues;
 }
 
 // @public
@@ -108,7 +109,7 @@ export type ReadonlyPartialJSONValue = JSONPrimitive | ReadonlyPartialJSONObject
 // @public
 export class Token<T> {
     constructor(name: string, description?: string);
-    readonly description: string;
+    readonly description?: string;
     readonly name: string;
 }
 

--- a/review/api/coreutils.api.md
+++ b/review/api/coreutils.api.md
@@ -76,8 +76,7 @@ export class PromiseDelegate<T> {
 
 // @public
 export namespace Random {
-    const // Warning: (ae-forgotten-export) The symbol "fallbackRandomValues" needs to be exported by the entry point index.d.ts
-    getRandomValues: typeof fallbackRandomValues;
+    const getRandomValues: (buffer: Uint8Array) => void;
 }
 
 // @public


### PR DESCRIPTION
In #572, `Token.description` was added but not as a optional attribute. This broke backward compatibility with 2.0.0.

This fixes it by making the description optional.