### PR TITLE
Invalid unicode characters removed from datagrid (#456)

### DIFF
--- a/.github/workflows/check-api-changes.yml
+++ b/.github/workflows/check-api-changes.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Get API changes
         id: api-changed
-        uses: tj-actions/changed-files@v35.8.0
+        uses: tj-actions/changed-files@v35.9.0
         with:
           base_sha: 'HEAD~1'
           sha: 'HEAD'

--- a/packages/datagrid/src/textrenderer.ts
+++ b/packages/datagrid/src/textrenderer.ts
@@ -325,6 +325,10 @@ export class TextRenderer extends CellRenderer {
           // Otherwise incrementally remove the last character
           text = elide + text.substring(2);
         }
+
+        // Remove invalid unicode characters if any
+        text = text.replace(/[\u{D800}-\u{DFFF}]/gu, "");
+
         textWidth = gc.measureText(text).width;
       }
     }

--- a/packages/datagrid/src/textrenderer.ts
+++ b/packages/datagrid/src/textrenderer.ts
@@ -306,28 +306,31 @@ export class TextRenderer extends CellRenderer {
 
     // Compute elided text
     if (elideDirection === 'right') {
-      while (textWidth > boxWidth && text.length > 1) {
-        if (text.length > 4 && textWidth >= 2 * boxWidth) {
+      while (textWidth > boxWidth && [...text].length > 1) {
+        // Create array to deal with astral symbols 
+        let textArr = [...text]
+
+        if (textArr.length > 4 && textWidth >= 2 * boxWidth) {
           // If text width is substantially bigger, take half the string
-          text = text.substring(0, text.length / 2 + 1) + elide;
+          text = textArr.slice(0, Math.floor(textArr.length / 2 + 1)).join('') + elide;
         } else {
           // Otherwise incrementally remove the last character
-          text = text.substring(0, text.length - 2) + elide;
+          text = textArr.slice(0, textArr.length - 2).join('') + elide;
         }
         textWidth = gc.measureText(text).width;
       }
     } else {
-      while (textWidth > boxWidth && text.length > 1) {
-        if (text.length > 4 && textWidth >= 2 * boxWidth) {
+      while (textWidth > boxWidth && [...text].length > 1) {
+        // Create array to deal with astral symbols 
+        let textArr = [...text]
+
+        if (textArr.length > 4 && textWidth >= 2 * boxWidth) {
           // If text width is substantially bigger, take half the string
-          text = elide + text.substring(text.length / 2);
+          text = elide + textArr.slice(Math.floor(textArr.length / 2)).join('');
         } else {
           // Otherwise incrementally remove the last character
-          text = elide + text.substring(2);
+          text = elide + textArr.slice(2).join('');
         }
-
-        // Remove invalid unicode characters if any
-        text = text.replace(/[\u{D800}-\u{DFFF}]/gu, "");
 
         textWidth = gc.measureText(text).width;
       }

--- a/packages/datagrid/src/textrenderer.ts
+++ b/packages/datagrid/src/textrenderer.ts
@@ -312,7 +312,9 @@ export class TextRenderer extends CellRenderer {
       if (elideDirection === 'right') {
         // If text width is substantially bigger, take half the string
         if (textArr.length > 4 && textWidth >= 2 * boxWidth) {
-          text = textArr.slice(0, Math.floor(textArr.length / 2 + 1)).join('') + elide;
+          text =
+            textArr.slice(0, Math.floor(textArr.length / 2 + 1)).join('') +
+            elide;
         } else {
           // Otherwise incrementally remove the last character
           text = textArr.slice(0, textArr.length - 2).join('') + elide;

--- a/packages/datagrid/src/textrenderer.ts
+++ b/packages/datagrid/src/textrenderer.ts
@@ -302,38 +302,33 @@ export class TextRenderer extends CellRenderer {
     }
 
     // Elide text that is too long
-    let elide = '\u2026';
+    const elide = '\u2026';
 
-    // Compute elided text
-    if (elideDirection === 'right') {
-      while (textWidth > boxWidth && [...text].length > 1) {
-        // Create array to deal with astral symbols 
-        let textArr = [...text]
+    // Loop until text width fits box or only one character remains
+    while (textWidth > boxWidth && text.length > 1) {
+      // Convert text string to array for dealing with astral symbols
+      const textArr = [...text];
 
+      if (elideDirection === 'right') {
+        // If text width is substantially bigger, take half the string
         if (textArr.length > 4 && textWidth >= 2 * boxWidth) {
-          // If text width is substantially bigger, take half the string
           text = textArr.slice(0, Math.floor(textArr.length / 2 + 1)).join('') + elide;
         } else {
           // Otherwise incrementally remove the last character
           text = textArr.slice(0, textArr.length - 2).join('') + elide;
         }
-        textWidth = gc.measureText(text).width;
-      }
-    } else {
-      while (textWidth > boxWidth && [...text].length > 1) {
-        // Create array to deal with astral symbols 
-        let textArr = [...text]
-
+      } else {
+        // If text width is substantially bigger, take half the string
         if (textArr.length > 4 && textWidth >= 2 * boxWidth) {
-          // If text width is substantially bigger, take half the string
           text = elide + textArr.slice(Math.floor(textArr.length / 2)).join('');
         } else {
           // Otherwise incrementally remove the last character
           text = elide + textArr.slice(2).join('');
         }
-
-        textWidth = gc.measureText(text).width;
       }
+
+      // Measure new text width
+      textWidth = gc.measureText(text).width;
     }
 
     // Draw the text for the cell.


### PR DESCRIPTION
Fixes #456

When dealing with astral symbols and ellipsing, datagrid generates invalid Unicode characters because of the use of `substring()`.

![before](https://user-images.githubusercontent.com/21252660/234622795-ee8e85ad-9db8-491d-8fd7-855998fd65a0.gif)

With the regular expression `/[\u{D800}-\u{DFFF}]/gu` we match any character falling within the range of surrogate code points. This includes both high surrogates (0xD800 to 0xDBFF) and low surrogates (0xDC00 to 0xDFFF). So any invalid Unicode character resulting from splitting a surrogate pair is removed with `replace()`.

![after](https://user-images.githubusercontent.com/21252660/234624646-bfbd8681-d27a-4fdf-b5b0-19e5bc720054.gif)