### PR TITLE
Splits with merge option for dock panels

### DIFF
--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -64,7 +64,6 @@ function createMenu(): Menu {
 }
 
 class ContentWidget extends Widget {
-
   static menuFocus: ContentWidget | null;
 
   static createNode(): HTMLElement {
@@ -485,7 +484,11 @@ function main(): void {
   contextSub1.addItem({ command: 'example:merge-right' });
   contextSub1.addItem({ command: 'example:merge-top' });
   contextSub1.addItem({ command: 'example:merge-bottom' });
-  contextMenu.addItem({ type: 'submenu', submenu: contextSub1, selector: '.content' });
+  contextMenu.addItem({
+    type: 'submenu',
+    submenu: contextSub1,
+    selector: '.content'
+  });
 
   commands.addCommand('save-dock-layout', {
     label: 'Save Layout',

--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -64,6 +64,9 @@ function createMenu(): Menu {
 }
 
 class ContentWidget extends Widget {
+
+  static menuFocus: ContentWidget | null;
+
   static createNode(): HTMLElement {
     let node = document.createElement('div');
     let content = document.createElement('div');
@@ -82,6 +85,10 @@ class ContentWidget extends Widget {
     this.title.label = name;
     this.title.closable = true;
     this.title.caption = `Long description for: ${name}`;
+    let widget = this;
+    this.node.addEventListener('contextmenu', (event: MouseEvent) => {
+      ContentWidget.menuFocus = widget;
+    });
   }
 
   get inputNode(): HTMLInputElement {
@@ -91,6 +98,12 @@ class ContentWidget extends Widget {
   protected onActivateRequest(msg: Message): void {
     if (this.isAttached) {
       this.inputNode.focus();
+    }
+  }
+
+  protected onBeforeDetach(msg: Message): void {
+    if (ContentWidget.menuFocus === this) {
+      ContentWidget.menuFocus = null;
     }
   }
 }
@@ -322,6 +335,7 @@ function main(): void {
   let contextMenu = new ContextMenu({ commands });
 
   document.addEventListener('contextmenu', (event: MouseEvent) => {
+    if (event.shiftKey) return;
     if (contextMenu.open(event)) {
       event.preventDefault();
     }
@@ -397,6 +411,56 @@ function main(): void {
     sender.addWidget(w, { ref: arg.titles[0].owner });
   });
 
+  let doSplit = (mode: DockPanel.InsertMode) => {
+    let ref = ContentWidget.menuFocus;
+    if (ref) {
+      let name = ref.title.label;
+      let widget = new ContentWidget(name);
+      widget.inputNode.value = `${name} ${mode}`;
+      dock.addWidget(widget, { mode: mode, ref: ref });
+    }
+  };
+
+  commands.addCommand('example:split-left', {
+    label: 'Split left',
+    execute: () => doSplit('split-left')
+  });
+
+  commands.addCommand('example:split-right', {
+    label: 'Split right',
+    execute: () => doSplit('split-right')
+  });
+
+  commands.addCommand('example:split-top', {
+    label: 'Split top',
+    execute: () => doSplit('split-top')
+  });
+
+  commands.addCommand('example:split-bottom', {
+    label: 'Split bottom',
+    execute: () => doSplit('split-bottom')
+  });
+
+  commands.addCommand('example:merge-left', {
+    label: 'Merge left',
+    execute: () => doSplit('merge-left')
+  });
+
+  commands.addCommand('example:merge-right', {
+    label: 'Merge right',
+    execute: () => doSplit('merge-right')
+  });
+
+  commands.addCommand('example:merge-top', {
+    label: 'Merge top',
+    execute: () => doSplit('merge-top')
+  });
+
+  commands.addCommand('example:merge-bottom', {
+    label: 'Merge bottom',
+    execute: () => doSplit('merge-bottom')
+  });
+
   let savedLayouts: DockPanel.ILayoutConfig[] = [];
 
   commands.addCommand('example:add-button', {
@@ -408,7 +472,20 @@ function main(): void {
       console.log('Toggle add button');
     }
   });
+
   contextMenu.addItem({ command: 'example:add-button', selector: '.content' });
+  let contextSub1 = new Menu({ commands });
+  contextSub1.title.label = 'Splitting';
+  contextSub1.addItem({ command: 'example:split-left' });
+  contextSub1.addItem({ command: 'example:split-right' });
+  contextSub1.addItem({ command: 'example:split-top' });
+  contextSub1.addItem({ command: 'example:split-bottom' });
+  contextSub1.addItem({ type: 'separator' });
+  contextSub1.addItem({ command: 'example:merge-left' });
+  contextSub1.addItem({ command: 'example:merge-right' });
+  contextSub1.addItem({ command: 'example:merge-top' });
+  contextSub1.addItem({ command: 'example:merge-bottom' });
+  contextMenu.addItem({ type: 'submenu', submenu: contextSub1, selector: '.content' });
 
   commands.addCommand('save-dock-layout', {
     label: 'Save Layout',

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -409,6 +409,18 @@ export class DockLayout extends Layout {
       case 'split-bottom':
         this._insertSplit(widget, ref, refNode, 'vertical', true);
         break;
+      case 'merge-top':
+        this._insertSplit(widget, ref, refNode, 'vertical', false, true);
+        break;
+      case 'merge-left':
+        this._insertSplit(widget, ref, refNode, 'horizontal', false, true);
+        break;
+      case 'merge-right':
+        this._insertSplit(widget, ref, refNode, 'horizontal', true, true);
+        break;
+      case 'merge-bottom':
+        this._insertSplit(widget, ref, refNode, 'vertical', true, true);
+        break;
     }
 
     // Do nothing else if there is no parent widget.
@@ -792,6 +804,16 @@ export class DockLayout extends Layout {
   }
 
   /**
+   * Create the tab layout node to hold the widget.
+   */
+  private _createTabNode(widget: Widget): Private.TabLayoutNode {
+    let tabNode = new Private.TabLayoutNode(this._createTabBar());
+    tabNode.tabBar.addTab(widget.title);
+    Private.addAria(widget, tabNode.tabBar);
+    return tabNode;
+  }
+
+  /**
    * Insert a widget next to an existing tab.
    *
    * #### Notes
@@ -872,7 +894,8 @@ export class DockLayout extends Layout {
     ref: Widget | null,
     refNode: Private.TabLayoutNode | null,
     orientation: Private.Orientation,
-    after: boolean
+    after: boolean,
+    merge: boolean = false
   ): void {
     // Do nothing if there is no effective split.
     if (widget === ref && refNode && refNode.tabBar.titles.length === 1) {
@@ -882,14 +905,9 @@ export class DockLayout extends Layout {
     // Ensure the widget is removed from the current layout.
     this._removeWidget(widget);
 
-    // Create the tab layout node to hold the widget.
-    let tabNode = new Private.TabLayoutNode(this._createTabBar());
-    tabNode.tabBar.addTab(widget.title);
-    Private.addAria(widget, tabNode.tabBar);
-
     // Set the root if it does not exist.
     if (!this._root) {
-      this._root = tabNode;
+      this._root = this._createTabNode(widget);
       return;
     }
 
@@ -908,6 +926,7 @@ export class DockLayout extends Layout {
       let sizer = Private.createSizer(refNode ? 1 : Private.GOLDEN_RATIO);
 
       // Insert the tab node sized to the golden ratio.
+      let tabNode = this._createTabNode(widget);
       ArrayExt.insert(root.children, i, tabNode);
       ArrayExt.insert(root.sizers, i, sizer);
       ArrayExt.insert(root.handles, i, this._createHandle());
@@ -930,6 +949,17 @@ export class DockLayout extends Layout {
       // Find the index of the ref node.
       let i = splitNode.children.indexOf(refNode);
 
+      // Conditionally reuse a tab layout found in the wanted position.
+      if (merge) {
+        let j = i + (after ? 1 : -1);
+        let sibling = splitNode.children[j];
+        if (sibling instanceof Private.TabLayoutNode) {
+          this._insertTab(widget, null, sibling, true);
+          ++sibling.tabBar.currentIndex;
+          return;
+        }
+      }
+
       // Normalize the split node.
       splitNode.normalizeSizes();
 
@@ -938,6 +968,7 @@ export class DockLayout extends Layout {
 
       // Insert the tab node sized to the other half.
       let j = i + (after ? 1 : 0);
+      let tabNode = this._createTabNode(widget);
       ArrayExt.insert(splitNode.children, j, tabNode);
       ArrayExt.insert(splitNode.sizers, j, Private.createSizer(s));
       ArrayExt.insert(splitNode.handles, j, this._createHandle());
@@ -963,6 +994,7 @@ export class DockLayout extends Layout {
 
     // Add the tab node sized to the other half.
     let j = after ? 1 : 0;
+    let tabNode = this._createTabNode(widget);
     ArrayExt.insert(childNode.children, j, tabNode);
     ArrayExt.insert(childNode.sizers, j, Private.createSizer(0.5));
     ArrayExt.insert(childNode.handles, j, this._createHandle());
@@ -1243,6 +1275,30 @@ export namespace DockLayout {
      * inserted at the bottom edge of the dock layout.
      */
     | 'split-bottom'
+
+    /**
+     * Like `tab-after` if there is a tab layout above the reference widget,
+     * and like `split-top` otherwise.
+     */
+    | 'merge-top'
+
+    /**
+     * Like `tab-after` if there is a tab layout left of the reference widget,
+     * and like `split-left` otherwise.
+     */
+    | 'merge-left'
+
+    /**
+     * Like `tab-after` if there is a tab layout right of the reference widget,
+     * and like `split-right` otherwise.
+     */
+    | 'merge-right'
+
+    /**
+     * Like `tab-after` if there is a tab layout below the reference widget,
+     * and like `split-bottom` otherwise.
+     */
+    | 'merge-bottom'
 
     /**
      * The tab position before the reference widget.

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -1277,26 +1277,26 @@ export namespace DockLayout {
     | 'split-bottom'
 
     /**
-     * Like `tab-after` if there is a tab layout above the reference widget,
-     * and like `split-top` otherwise.
+     * Like `split-top` but if a tab layout exists above the reference widget,
+     * it behaves like `tab-after` with reference to that instead.
      */
     | 'merge-top'
 
     /**
-     * Like `tab-after` if there is a tab layout left of the reference widget,
-     * and like `split-left` otherwise.
+     * Like `split-left` but if a tab layout exists left of the reference widget,
+     * it behaves like `tab-after` with reference to that instead.
      */
     | 'merge-left'
 
     /**
-     * Like `tab-after` if there is a tab layout right of the reference widget,
-     * and like `split-right` otherwise.
+     * Like `split-right` but if a tab layout exists right of the reference widget,
+     * it behaves like `tab-after` with reference to that instead.
      */
     | 'merge-right'
 
     /**
-     * Like `tab-after` if there is a tab layout below the reference widget,
-     * and like `split-bottom` otherwise.
+     * Like `split-bottom` but if a tab layout exists below the reference widget,
+     * it behaves like `tab-after` with reference to that instead.
      */
     | 'merge-bottom'
 

--- a/packages/widgets/tests/src/docklayout.spec.ts
+++ b/packages/widgets/tests/src/docklayout.spec.ts
@@ -244,7 +244,42 @@ describe('@lumino/widgets', () => {
       it.skip('should have some tests');
     });
     describe('#addWidget()', () => {
-      it.skip('should have some tests');
+      it('should add widgets', () => {
+        const layout = new DockLayout({ renderer });
+        const widget = new Widget();
+        layout.addWidget(widget);
+        expect(layout['_root'].tabBar).to.exist;
+        expect(layout['_root'].tabBar.titles[0].owner).to.equal(widget);
+      });
+      it('should add splits', () => {
+        for (let i = 0, d = ['right', 'left', 'bottom', 'top']; i < 4; ++i) {
+          const layout = new DockLayout({ renderer });
+          const w1 = new Widget();
+          const w2 = new Widget();
+          layout.addWidget(w1);
+          layout.addWidget(w2, { ref: w1, mode: <DockLayout.InsertMode> `split-${d[i]}` });
+          expect(layout['_root'].children).to.exist;
+          expect(layout['_root'].children.length).to.equal(2);
+          expect(layout['_root'].children[0+i%2].tabBar.titles[0].owner).to.equal(w1);
+          expect(layout['_root'].children[1-i%2].tabBar.titles[0].owner).to.equal(w2);
+        }
+      });
+      it('should merge splits', () => {
+        for (let i = 0, d = ['right', 'left', 'bottom', 'top']; i < 4; ++i) {
+          const layout = new DockLayout({ renderer });
+          const w1 = new Widget();
+          const w2 = new Widget();
+          const w3 = new Widget();
+          layout.addWidget(w1);
+          layout.addWidget(w2, { ref: w1, mode: <DockLayout.InsertMode> `merge-${d[i]}` });
+          layout.addWidget(w3, { ref: w1, mode: <DockLayout.InsertMode> `merge-${d[i]}` });
+          expect(layout['_root'].children).to.exist;
+          expect(layout['_root'].children.length).to.equal(2);
+          expect(layout['_root'].children[0+i%2].tabBar.titles[0].owner).to.equal(w1);
+          expect(layout['_root'].children[1-i%2].tabBar.titles[0].owner).to.equal(w2);
+          expect(layout['_root'].children[1-i%2].tabBar.titles[1].owner).to.equal(w3);
+        }
+      });
     });
     describe('#removeWidget()', () => {
       it.skip('should have some tests');

--- a/packages/widgets/tests/src/docklayout.spec.ts
+++ b/packages/widgets/tests/src/docklayout.spec.ts
@@ -244,6 +244,7 @@ describe('@lumino/widgets', () => {
       it.skip('should have some tests');
     });
     describe('#addWidget()', () => {
+      type Mode = DockLayout.InsertMode;
       it('should add widgets', () => {
         const layout = new DockLayout({ renderer });
         const widget = new Widget();
@@ -257,11 +258,15 @@ describe('@lumino/widgets', () => {
           const w1 = new Widget();
           const w2 = new Widget();
           layout.addWidget(w1);
-          layout.addWidget(w2, { ref: w1, mode: <DockLayout.InsertMode> `split-${d[i]}` });
+          layout.addWidget(w2, { ref: w1, mode: <Mode>`split-${d[i]}` });
           expect(layout['_root'].children).to.exist;
           expect(layout['_root'].children.length).to.equal(2);
-          expect(layout['_root'].children[0+i%2].tabBar.titles[0].owner).to.equal(w1);
-          expect(layout['_root'].children[1-i%2].tabBar.titles[0].owner).to.equal(w2);
+          expect(
+            layout['_root'].children[0 + (i % 2)].tabBar.titles[0].owner
+          ).to.equal(w1);
+          expect(
+            layout['_root'].children[1 - (i % 2)].tabBar.titles[0].owner
+          ).to.equal(w2);
         }
       });
       it('should merge splits', () => {
@@ -271,13 +276,19 @@ describe('@lumino/widgets', () => {
           const w2 = new Widget();
           const w3 = new Widget();
           layout.addWidget(w1);
-          layout.addWidget(w2, { ref: w1, mode: <DockLayout.InsertMode> `merge-${d[i]}` });
-          layout.addWidget(w3, { ref: w1, mode: <DockLayout.InsertMode> `merge-${d[i]}` });
+          layout.addWidget(w2, { ref: w1, mode: <Mode>`merge-${d[i]}` });
+          layout.addWidget(w3, { ref: w1, mode: <Mode>`merge-${d[i]}` });
           expect(layout['_root'].children).to.exist;
           expect(layout['_root'].children.length).to.equal(2);
-          expect(layout['_root'].children[0+i%2].tabBar.titles[0].owner).to.equal(w1);
-          expect(layout['_root'].children[1-i%2].tabBar.titles[0].owner).to.equal(w2);
-          expect(layout['_root'].children[1-i%2].tabBar.titles[1].owner).to.equal(w3);
+          expect(
+            layout['_root'].children[0 + (i % 2)].tabBar.titles[0].owner
+          ).to.equal(w1);
+          expect(
+            layout['_root'].children[1 - (i % 2)].tabBar.titles[0].owner
+          ).to.equal(w2);
+          expect(
+            layout['_root'].children[1 - (i % 2)].tabBar.titles[1].owner
+          ).to.equal(w3);
         }
       });
     });

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -359,6 +359,26 @@ export namespace DockLayout {
     */
     | 'split-bottom'
     /**
+    * Like `split-top` but if a tab layout exists above the reference widget,
+    * it behaves like `tab-after` with reference to that instead.
+    */
+    | 'merge-top'
+    /**
+    * Like `split-left` but if a tab layout exists left of the reference widget,
+    * it behaves like `tab-after` with reference to that instead.
+    */
+    | 'merge-left'
+    /**
+    * Like `split-right` but if a tab layout exists right of the reference widget,
+    * it behaves like `tab-after` with reference to that instead.
+    */
+    | 'merge-right'
+    /**
+    * Like `split-bottom` but if a tab layout exists below the reference widget,
+    * it behaves like `tab-after` with reference to that instead.
+    */
+    | 'merge-bottom'
+    /**
     * The tab position before the reference widget.
     *
     * The widget will be added as a tab before the reference widget.


### PR DESCRIPTION
The point of this new feature is to avoid the following situation:
![Screenshot](https://user-images.githubusercontent.com/7685034/236679629-c0b8d4de-adda-49ff-b2f0-3dcf0d253101.png)

I think it's a widely accepted convention to work in a layout of 3 panels: file tree, text editor, and preview. But if launching the preview *always* splits the editor widget, you keep winding up with 2 preview splits and you repeatedly have to drag one of the preview tabs over to the adjacent split.

To solve this I have introduced 4 new insert modes (`merge-left, merge-right, merge-top, merge-bottom`) which function like (`split-left, split-right, split-top, split-bottom`) but any existing splits will be reused. The behavior effectively changes to `tab-after` on the tab layout found to the left/right/top/bottom.

See the dockpanel example which now has a context menu for split and merge operations on the content widgets.