### PR TITLE
Added "tabindex=0" for sidebar accessibility

### DIFF
--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -175,7 +175,8 @@ export type ARIAAttrNames =
   | 'aria-valuemin'
   | 'aria-valuenow'
   | 'aria-valuetext'
-  | 'role';
+  | 'role'
+  | 'tabIndex';
 
 /**
  * The names of the supported HTML5 CSS property names.

--- a/packages/virtualdom/src/index.ts
+++ b/packages/virtualdom/src/index.ts
@@ -175,8 +175,7 @@ export type ARIAAttrNames =
   | 'aria-valuemin'
   | 'aria-valuenow'
   | 'aria-valuetext'
-  | 'role'
-  | 'tabIndex';
+  | 'role';
 
 /**
  * The names of the supported HTML5 CSS property names.

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1667,7 +1667,11 @@ export namespace TabBar {
      * @returns The ARIA attributes for the tab.
      */
     createTabARIA(data: IRenderData<any>): ElementARIAAttrs {
-      return { role: 'tab', 'aria-selected': data.current.toString() };
+      return {
+        role: 'tab',
+        'aria-selected': data.current.toString(),
+        tabIndex: '0'
+      };
     }
 
     /**

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -21,6 +21,7 @@ import { ISignal, Signal } from '@lumino/signaling';
 
 import {
   ElementARIAAttrs,
+  ElementBaseAttrs,
   ElementDataset,
   ElementInlineStyle,
   h,
@@ -1666,11 +1667,11 @@ export namespace TabBar {
      *
      * @returns The ARIA attributes for the tab.
      */
-    createTabARIA(data: IRenderData<any>): ElementARIAAttrs {
+    createTabARIA(data: IRenderData<any>): ElementARIAAttrs | ElementBaseAttrs {
       return {
         role: 'tab',
         'aria-selected': data.current.toString(),
-        tabIndex: '0'
+        tabindex: '0'
       };
     }
 

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -7,6 +7,7 @@
 import { CommandRegistry } from '@lumino/commands';
 import { ConflatableMessage } from '@lumino/messaging';
 import { ElementARIAAttrs } from '@lumino/virtualdom';
+import { ElementBaseAttrs } from '@lumino/virtualdom';
 import { ElementDataset } from '@lumino/virtualdom';
 import { ElementInlineStyle } from '@lumino/virtualdom';
 import { h } from '@lumino/virtualdom';
@@ -1151,7 +1152,7 @@ export namespace TabBar {
         constructor();
         readonly closeIconSelector = ".lm-TabBar-tabCloseIcon";
         createIconClass(data: IRenderData<any>): string;
-        createTabARIA(data: IRenderData<any>): ElementARIAAttrs;
+        createTabARIA(data: IRenderData<any>): ElementARIAAttrs | ElementBaseAttrs;
         createTabClass(data: IRenderData<any>): string;
         createTabDataset(data: IRenderData<any>): ElementDataset;
         createTabKey(data: IRenderData<any>): string;


### PR DESCRIPTION
References
[#9686 ](https://github.com/jupyterlab/jupyterlab/issues/9686) and [#1440](https://github.com/jupyterlab/jupyterlab/pull/14400)

Code changes
Easy part of #9686: added labels and tabindex="0" for sidebar elements so screen-readers can access them.

@krassowski Please review and comment to see if these are the right changes needed. 
