### PR TITLE
Add a 'defer' option to the autoStart argument

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -537,9 +537,9 @@ export class Application<T extends Widget = Widget> {
    * The list of all the deferred plugins.
    */
   get deferredPlugins(): string[] {
-    return Array.from(this._plugins.keys()).filter(
-      id => this._plugins.get(id)!.deferred
-    );
+    return Array.from(this._plugins).filter(
+      ([id, plugin]) => plugin.deferred
+    ).map(([id, plugin]) => id);
   }
 
   /**

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -534,11 +534,9 @@ export class Application<T extends Widget = Widget> {
   }
 
   /**
-   * Collect the deferred plugins.
-   *
-   * @returns The list of all the deferred plugins.
+   * The list of all the deferred plugins.
    */
-  deferredPlugins(): string[] {
+  get deferredPlugins(): string[] {
     return Array.from(this._plugins.keys()).filter(
       id => this._plugins.get(id)!.deferred
     );

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -539,16 +539,16 @@ export class Application<T extends Widget = Widget> {
   /**
    * Activate all the deferred plugins.
    *
-   * @returns A promises which will  resolve when each plugin is activated
-   * or rejects with an error one cannot be activated.
+   * @returns A promise which will resolve when each plugin is activated
+   * or rejects with an error if one cannot be activated.
    */
-  activateDeferredPlugins(): Promise<void[]> {
+  async activateDeferredPlugins(): Promise<void> {
     const promises = this.deferredPlugins
       .filter(pluginId => this._plugins.get(pluginId)!.autoStart)
       .map(pluginId => {
         return this.activatePlugin(pluginId);
       });
-    return Promise.all(promises);
+    await Promise.all(promises);
   }
 
   /**
@@ -926,20 +926,20 @@ namespace Private {
     plugins: Map<string, IPluginData>,
     options: Application.IStartOptions
   ): string[] {
-    // Create a map to hold the plugin IDs.
-    const collection = new Map<string, boolean>();
+    // Create a set to hold the plugin IDs.
+    const collection = new Set<string>();
 
     // Collect the auto-start (non deferred) plugins.
     for (const id of plugins.keys()) {
       if (plugins.get(id)!.autoStart === true) {
-        collection.set(id, true);
+        collection.add(id);
       }
     }
 
     // Add the startup plugins.
     if (options.startPlugins) {
       for (const id of options.startPlugins) {
-        collection.set(id, true);
+        collection.add(id);
       }
     }
 
@@ -951,6 +951,6 @@ namespace Private {
     }
 
     // Return the collected startup plugins.
-    return Array.from(collection.keys());
+    return Array.from(collection);
   }
 }

--- a/packages/application/tests/src/index.spec.ts
+++ b/packages/application/tests/src/index.spec.ts
@@ -135,6 +135,53 @@ describe('@lumino/application', () => {
         expect(app.isPluginActivated(id)).to.be.false;
       });
 
+      it('should be false for deferred plugin', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id = 'plugin1';
+        app.registerPlugin({
+          id,
+          activate: () => {
+            // no-op
+          },
+          autoStart: true,
+          deferred: true
+        });
+        await app.start();
+        expect(app.isPluginActivated(id)).to.be.false;
+      });
+
+      it('should be true for deferred and autoStart plugins only', async () => {
+        const app = new Application({ shell: new Widget() });
+        const id1 = 'plugin1';
+        app.registerPlugin({
+          id: id1,
+          activate: () => {
+            // no-op
+          },
+          autoStart: true,
+          deferred: true
+        });
+        const id2 = 'plugin2';
+        app.registerPlugin({
+          id: id2,
+          activate: () => {
+            // no-op
+          }
+        });
+        const id3 = 'plugin3';
+        app.registerPlugin({
+          id: id3,
+          activate: () => {
+            // no-op
+          },
+          deferred: true
+        });
+        await Promise.all(app.activateDeferredPlugins());
+        expect(app.isPluginActivated(id1)).to.be.true;
+        expect(app.isPluginActivated(id2)).to.be.false;
+        expect(app.isPluginActivated(id3)).to.be.false;
+      });
+
       it('should be false for unregistered plugin', async () => {
         const app = new Application({ shell: new Widget() });
         const id = 'plugin1';

--- a/packages/application/tests/src/index.spec.ts
+++ b/packages/application/tests/src/index.spec.ts
@@ -135,7 +135,7 @@ describe('@lumino/application', () => {
         expect(app.isPluginActivated(id)).to.be.false;
       });
 
-      it('should be false for deferred plugin', async () => {
+      it('should be false for deferred plugin when application start', async () => {
         const app = new Application({ shell: new Widget() });
         const id = 'plugin1';
         app.registerPlugin({
@@ -143,43 +143,12 @@ describe('@lumino/application', () => {
           activate: () => {
             // no-op
           },
-          autoStart: true,
-          deferred: true
+          autoStart: 'defer'
         });
         await app.start();
         expect(app.isPluginActivated(id)).to.be.false;
-      });
-
-      it('should be true for deferred and autoStart plugins only', async () => {
-        const app = new Application({ shell: new Widget() });
-        const id1 = 'plugin1';
-        app.registerPlugin({
-          id: id1,
-          activate: () => {
-            // no-op
-          },
-          autoStart: true,
-          deferred: true
-        });
-        const id2 = 'plugin2';
-        app.registerPlugin({
-          id: id2,
-          activate: () => {
-            // no-op
-          }
-        });
-        const id3 = 'plugin3';
-        app.registerPlugin({
-          id: id3,
-          activate: () => {
-            // no-op
-          },
-          deferred: true
-        });
-        await Promise.all(app.activateDeferredPlugins());
-        expect(app.isPluginActivated(id1)).to.be.true;
-        expect(app.isPluginActivated(id2)).to.be.false;
-        expect(app.isPluginActivated(id3)).to.be.false;
+        await app.activateDeferredPlugins();
+        expect(app.isPluginActivated(id)).to.be.true;
       });
 
       it('should be false for unregistered plugin', async () => {

--- a/review/api/application.api.md
+++ b/review/api/application.api.md
@@ -13,12 +13,14 @@ import { Widget } from '@lumino/widgets';
 // @public
 export class Application<T extends Widget = Widget> {
     constructor(options: Application.IOptions<T>);
+    activateDeferredPlugins(): Promise<void>;
     activatePlugin(id: string): Promise<void>;
     protected addEventListeners(): void;
     protected attachShell(id: string): void;
     readonly commands: CommandRegistry;
     readonly contextMenu: ContextMenu;
     deactivatePlugin(id: string): Promise<string[]>;
+    get deferredPlugins(): string[];
     deregisterPlugin(id: string, force?: boolean): void;
     protected evtContextMenu(event: PointerEvent): void;
     protected evtKeydown(event: KeyboardEvent): void;
@@ -53,7 +55,7 @@ export namespace Application {
 // @public
 export interface IPlugin<T extends Application, U> {
     activate: (app: T, ...args: any[]) => U | Promise<U>;
-    autoStart?: boolean;
+    autoStart?: boolean | 'defer';
     deactivate?: ((app: T, ...args: any[]) => void | Promise<void>) | null;
     description?: string;
     id: string;


### PR DESCRIPTION
~~This PR adds an optional `deferred` flag to the plugin options.~~
**EDIT** This PR allows to set the value 'defer' to the `autoStart` argument of a plugin.

This is related to https://github.com/jupyterlab/jupyterlab/issues/14576.

It also adds a function for activating all deferred plugins, preferably after application startup.

It does not modify the behavior of `autoStart`, which means that if `autoStart: false`, the plugin will not be activated using the dedicated function.
