### PR TITLE
Use Actual Return character for Mac shortcuts.

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -1461,8 +1461,7 @@ namespace Private {
   const MAC_DISPLAY: { [key: string]: string } = {
     Backspace: '⌫',
     Tab: '⇥',
-    // U+FE0E prevents the "enter" character from rendering in color as an emoji
-    Enter: '↩\uFE0E',
+    Enter: '⏎',
     Shift: '⇧',
     Ctrl: '⌃',
     Alt: '⌥',


### PR DESCRIPTION
The current character is "Leftwards Arrow with Hook" U+21A9 https://www.compart.com/en/unicode/U+21A9  from the "Arrows" block which often is rendered as colored emoji (CF code where U+FE0F Variation Selector-16) was added.

Replace with "Return Symbol" U+23CE from the "Miscellaneous Technical", which is more consistent as many of the other characters in this list are also from the "Miscellaneous Technical" section (Backspace, Alt, Shift..)

This should not need the Variation Selector and will have a similar look to Shift/Maj... in most fonts.