### PR TITLE
[accessibility] Uses the arrow keys for tab bar navigation

### DIFF
--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -802,7 +802,7 @@ export class TabBar<T> extends Widget {
       if (this.addButtonEnabled) {
         focusable.push(this.addButtonNode);
       }
-      // If the tab bac contains only one element, nothing to do.
+      // If the tab bar contains only one element, nothing to do.
       if (focusable.length <= 1) {
         return;
       }

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -696,7 +696,7 @@ export class TabBar<T> extends Widget {
 
     let tabs = this.contentNode.children;
 
-    // Find the index of the released tab.
+    // Find the index of the targeted tab.
     let index = ArrayExt.findFirstIndex(tabs, tab => {
       return ElementExt.hitTest(tab, event.clientX, event.clientY);
     });

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1807,7 +1807,7 @@ export namespace TabBar {
      * @returns The ARIA attributes for the tab.
      */
     createTabARIA(data: IRenderData<any>): ElementARIAAttrs | ElementBaseAttrs {
-      const ariaAttributes: { [k: string]: string } = {
+      const ariaAttributes: Record<string, string> = {
         role: 'tab',
         'aria-selected': data.current.toString()
       };

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -821,7 +821,7 @@ export class TabBar<T> extends Widget {
         (event.key === 'ArrowRight' && this._orientation === 'horizontal') ||
         (event.key === 'ArrowDown' && this._orientation === 'vertical')
       ) {
-        nextFocused = focusable[focusedIndex + 1] || focusable[0];
+        nextFocused = focusable[focusedIndex + 1] ?? focusable[0];
       } else if (
         (event.key === 'ArrowLeft' && this._orientation === 'horizontal') ||
         (event.key === 'ArrowUp' && this._orientation === 'vertical')

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -716,6 +716,7 @@ export class TabBar<T> extends Widget {
       let onblur = () => {
         input.removeEventListener('blur', onblur);
         label.innerHTML = oldValue;
+        this.node.addEventListener('keydown', this);
       };
 
       input.addEventListener('dblclick', (event: Event) =>
@@ -732,6 +733,7 @@ export class TabBar<T> extends Widget {
           onblur();
         }
       });
+      this.node.removeEventListener('keydown', this);
       input.select();
       input.focus();
 
@@ -850,6 +852,13 @@ export class TabBar<T> extends Widget {
 
     // Do nothing if a drag is in progress.
     if (this._dragData) {
+      return;
+    }
+
+    // Do nothing if a title editable input was clicked.
+    if (
+      (event.target as HTMLElement).classList.contains('lm-TabBar-tabInput')
+    ) {
       return;
     }
 

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -33,7 +33,14 @@ import { Title } from './title';
 
 import { Widget } from './widget';
 
-const ARROW_KEYS = ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown'];
+const ARROW_KEYS = [
+  'ArrowLeft',
+  'ArrowUp',
+  'ArrowRight',
+  'ArrowDown',
+  'Home',
+  'End'
+];
 
 /**
  * A widget which displays titles as a single row or column of tabs.
@@ -830,6 +837,10 @@ export class TabBar<T> extends Widget {
       ) {
         nextFocused =
           focusable[focusedIndex - 1] ?? focusable[focusable.length - 1];
+      } else if (event.key === 'Home') {
+        nextFocused = focusable[0];
+      } else if (event.key === 'End') {
+        nextFocused = focusable[focusable.length - 1];
       }
 
       // Change the focused element and the tabindex value.

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -827,7 +827,7 @@ export class TabBar<T> extends Widget {
         (event.key === 'ArrowUp' && this._orientation === 'vertical')
       ) {
         nextFocused =
-          focusable[focusedIndex - 1] || focusable[focusable.length - 1];
+          focusable[focusedIndex - 1] ?? focusable[focusable.length - 1];
       }
 
       // Change the focused element and the tabindex value.

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -832,7 +832,7 @@ export class TabBar<T> extends Widget {
 
       // Change the focused element and the tabindex value.
       if (nextFocused) {
-        focusable.forEach(element => element.setAttribute('tabindex', '-1'));
+        focusable[focusedIndex]?.setAttribute('tabindex', '-1');
         nextFocused?.setAttribute('tabindex', '0');
         (nextFocused as HTMLElement).focus();
       }
@@ -1807,14 +1807,11 @@ export namespace TabBar {
      * @returns The ARIA attributes for the tab.
      */
     createTabARIA(data: IRenderData<any>): ElementARIAAttrs | ElementBaseAttrs {
-      const ariaAttributes: Record<string, string> = {
+      return {
         role: 'tab',
-        'aria-selected': data.current.toString()
+        'aria-selected': data.current.toString(),
+        tabindex: `${data.tabIndex ?? '-1'}`
       };
-      if (data.tabIndex !== undefined) {
-        ariaAttributes.tabindex = `${data.tabIndex}`;
-      }
-      return ariaAttributes;
     }
 
     /**

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1592,6 +1592,125 @@ describe('@lumino/widgets', () => {
 
           expect(addRequested).to.be.true;
         });
+
+        it('should have the tabindex="0" on the first tab by default', () => {
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          expect(firstTab.getAttribute('tabindex')).to.equal('0');
+          for (let i = 1; i < bar.titles.length; i++) {
+            let tab = bar.contentNode.children[i] as HTMLElement;
+            expect(tab.getAttribute('tabindex')).to.equal('-1');
+          }
+          expect(bar.addButtonNode.getAttribute('tabindex')).to.equal('-1');
+        });
+
+        it('should switch the focus on the second tab on right click', () => {
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          firstTab.focus();
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowRight',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(firstTab.getAttribute('tabindex')).to.equal('-1');
+          const secondTab = bar.contentNode.children[1] as HTMLElement;
+          expect(secondTab.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(secondTab);
+        });
+
+        it('should switch the focus on the last tab on left click', () => {
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          firstTab.focus();
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowLeft',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(firstTab.getAttribute('tabindex')).to.equal('-1');
+          const lastTab = bar.contentNode.lastChild as HTMLElement;
+          expect(lastTab.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(lastTab);
+        });
+
+        it('should switch the focus on the add button on left click', () => {
+          bar.addButtonEnabled = true;
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          firstTab.focus();
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowLeft',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(firstTab.getAttribute('tabindex')).to.equal('-1');
+          expect(bar.addButtonNode.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(bar.addButtonNode);
+        });
+
+        it('should not change the tabindex values on focusing another element', () => {
+          const node = document.createElement('div');
+          node.setAttribute('tabindex', '0');
+          document.body.append(node);
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          firstTab.focus();
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowRight',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          node.focus();
+          const secondTab = bar.contentNode.children[1] as HTMLElement;
+          expect(document.activeElement).not.to.equal(secondTab);
+          expect(secondTab.getAttribute('tabindex')).to.equal('0');
+        });
+
+        /**
+         * This test is skipped as it seems there is no way to trigger a change of focus
+         * when simulating tabulation keydown.
+         *
+         * TODO:
+         * Find a way to trigger the change of focus.
+         */
+        it.skip('should keep focus on the second tab on tabulation', () => {
+          const node = document.createElement('div');
+          node.setAttribute('tabindex', '0');
+          document.body.append(node);
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          firstTab.focus();
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowRight',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'Tab'
+            })
+          );
+          const secondTab = bar.contentNode.children[1] as HTMLElement;
+          expect(document.activeElement).not.to.equal(secondTab);
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'Tab',
+              shiftKey: true
+            })
+          );
+          expect(document.activeElement).to.equal(secondTab);
+        });
       });
 
       context('contextmenu', () => {

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1604,7 +1604,7 @@ describe('@lumino/widgets', () => {
           expect(bar.addButtonNode.getAttribute('tabindex')).to.equal('-1');
         });
 
-        it('should switch the focus on the second tab on right arrow keydown', () => {
+        it('should focus the second tab on right arrow keydown', () => {
           populateBar(bar);
           const firstTab = bar.contentNode.firstChild as HTMLElement;
           firstTab.focus();
@@ -1621,7 +1621,7 @@ describe('@lumino/widgets', () => {
           expect(document.activeElement).to.equal(secondTab);
         });
 
-        it('should switch the focus on the last tab on left arrow keydown', () => {
+        it('should focus the last tab on left arrow keydown', () => {
           populateBar(bar);
           const firstTab = bar.contentNode.firstChild as HTMLElement;
           firstTab.focus();
@@ -1638,7 +1638,7 @@ describe('@lumino/widgets', () => {
           expect(document.activeElement).to.equal(lastTab);
         });
 
-        it('should switch the focus on the add button on left arrow keydown', () => {
+        it('should focus the add button on left arrow keydown', () => {
           bar.addButtonEnabled = true;
           populateBar(bar);
           const firstTab = bar.contentNode.firstChild as HTMLElement;
@@ -1679,7 +1679,7 @@ describe('@lumino/widgets', () => {
           expect(document.activeElement).to.equal(firstTab);
         });
 
-        it('should switch the focus on the second tab on down arrow keydown', () => {
+        it('should focus the second tab on down arrow keydown', () => {
           bar.orientation = 'vertical';
           populateBar(bar);
           const firstTab = bar.contentNode.firstChild as HTMLElement;
@@ -1697,7 +1697,7 @@ describe('@lumino/widgets', () => {
           expect(document.activeElement).to.equal(secondTab);
         });
 
-        it('should switch the focus on the last tab on up arrow keydown', () => {
+        it('should focus the last tab on up arrow keydown', () => {
           bar.orientation = 'vertical';
           populateBar(bar);
           const firstTab = bar.contentNode.firstChild as HTMLElement;
@@ -1738,6 +1738,38 @@ describe('@lumino/widgets', () => {
           );
           expect(firstTab.getAttribute('tabindex')).to.equal('0');
           expect(document.activeElement).to.equal(firstTab);
+        });
+
+        it('should focus the first tab on "Home" keydown', () => {
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          const lastTab = bar.contentNode.lastChild as HTMLElement;
+          firstTab.setAttribute('tabindex', '-1');
+          lastTab.setAttribute('tabindex', '0');
+          lastTab.focus();
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'Home',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(firstTab.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(firstTab);
+        });
+
+        it('should focus the last tab on "End" keydown', () => {
+          populateBar(bar);
+          const lastTab = bar.contentNode.lastChild as HTMLElement;
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'End',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(lastTab.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(lastTab);
         });
 
         it('should not change the tabindex values on focusing another element', () => {

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1604,7 +1604,7 @@ describe('@lumino/widgets', () => {
           expect(bar.addButtonNode.getAttribute('tabindex')).to.equal('-1');
         });
 
-        it('should switch the focus on the second tab on right click', () => {
+        it('should switch the focus on the second tab on right arrow keydown', () => {
           populateBar(bar);
           const firstTab = bar.contentNode.firstChild as HTMLElement;
           firstTab.focus();
@@ -1621,7 +1621,7 @@ describe('@lumino/widgets', () => {
           expect(document.activeElement).to.equal(secondTab);
         });
 
-        it('should switch the focus on the last tab on left click', () => {
+        it('should switch the focus on the last tab on left arrow keydown', () => {
           populateBar(bar);
           const firstTab = bar.contentNode.firstChild as HTMLElement;
           firstTab.focus();
@@ -1638,7 +1638,7 @@ describe('@lumino/widgets', () => {
           expect(document.activeElement).to.equal(lastTab);
         });
 
-        it('should switch the focus on the add button on left click', () => {
+        it('should switch the focus on the add button on left arrow keydown', () => {
           bar.addButtonEnabled = true;
           populateBar(bar);
           const firstTab = bar.contentNode.firstChild as HTMLElement;
@@ -1653,6 +1653,91 @@ describe('@lumino/widgets', () => {
           expect(firstTab.getAttribute('tabindex')).to.equal('-1');
           expect(bar.addButtonNode.getAttribute('tabindex')).to.equal('0');
           expect(document.activeElement).to.equal(bar.addButtonNode);
+        });
+
+        it('should be no-op on up and down arrow keydown', () => {
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          firstTab.focus();
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowUp',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(firstTab.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(firstTab);
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowDown',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(firstTab.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(firstTab);
+        });
+
+        it('should switch the focus on the second tab on down arrow keydown', () => {
+          bar.orientation = 'vertical';
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          firstTab.focus();
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowDown',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(firstTab.getAttribute('tabindex')).to.equal('-1');
+          const secondTab = bar.contentNode.children[1] as HTMLElement;
+          expect(secondTab.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(secondTab);
+        });
+
+        it('should switch the focus on the last tab on up arrow keydown', () => {
+          bar.orientation = 'vertical';
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          firstTab.focus();
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowUp',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(firstTab.getAttribute('tabindex')).to.equal('-1');
+          const lastTab = bar.contentNode.lastChild as HTMLElement;
+          expect(lastTab.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(lastTab);
+        });
+
+        it('should be no-op on left and right arrow keydown', () => {
+          bar.orientation = 'vertical';
+          populateBar(bar);
+          const firstTab = bar.contentNode.firstChild as HTMLElement;
+          firstTab.focus();
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowLeft',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(firstTab.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(firstTab);
+          bar.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'ArrowRight',
+              cancelable: true,
+              bubbles: true
+            })
+          );
+          expect(firstTab.getAttribute('tabindex')).to.equal('0');
+          expect(document.activeElement).to.equal(firstTab);
         });
 
         it('should not change the tabindex values on focusing another element', () => {

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -1115,6 +1115,7 @@ export namespace TabBar {
     }
     export interface IRenderData<T> {
         readonly current: boolean;
+        readonly tabIndex?: number;
         readonly title: Title<T>;
         readonly zIndex: number;
     }


### PR DESCRIPTION
This PR follows https://github.com/jupyterlab/lumino/pull/583 and https://github.com/jupyterlab/lumino/pull/590 to use the arrow keys for tab bar navigation.

After this PR:
By default the tab bar elements have `tabindex="-1"`, except for the current one (or the first one) which has  `tabindex="0"`. 
When a tab is focused, the arrow keys are used to change the focused tab (left/right for horizontal tab bars, up/down for vertical ones).
Pressing the tabulation again moves the focus to an element other than the tab bar. 

---

Closes https://github.com/jupyterlab/lumino/pull/581