### PR TITLE
Added role of button to addButton to make itkeyboard accessible when using screenreader

### DIFF
--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -2007,6 +2007,7 @@ namespace Private {
     let add = document.createElement('div');
     add.className = 'lm-TabBar-addButton lm-mod-hidden';
     add.setAttribute('tabindex', '-1');
+    add.setAttribute('role', 'button');
     node.appendChild(add);
     return node;
   }


### PR DESCRIPTION
Issue number: 14814

https://github.com/jupyterlab/jupyterlab/issues/14814 

In order to make the the addLauncher button keyboard accessible when using screen reader, added the role of button to the div element. 

Tested using windows narrator. The add button is now keyboard accessible with screen reader and without it. In order to launch new launcher via keyboard: use Enter key or Spacebar Key.

