### PR TITLE
Custom context menu for notebook tab

### DIFF
--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -2002,7 +2002,6 @@ namespace Private {
     let node = document.createElement('div');
     let content = document.createElement('ul');
     content.setAttribute('role', 'tablist');
-    content.setAttribute('tabindex', '-1');
     content.className = 'lm-TabBar-content';
     node.appendChild(content);
 

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -615,6 +615,7 @@ export class TabBar<T> extends Widget {
           : this._evtKeyDown(event as KeyboardEvent);
         break;
       case 'contextmenu':
+        this._evtKeyDown(event as KeyboardEvent);
         event.preventDefault();
         event.stopPropagation();
         break;
@@ -2001,6 +2002,7 @@ namespace Private {
     let node = document.createElement('div');
     let content = document.createElement('ul');
     content.setAttribute('role', 'tablist');
+    content.setAttribute('tabindex', '-1');
     content.className = 'lm-TabBar-content';
     node.appendChild(content);
 


### PR DESCRIPTION
Updated code in order to allow the usage of menu button in order to open up custom context menu when on the notebook tab:

How to replicate:

- open a new notebook
- Tab until in notebook
- press esc to get out of typing in notebook
- press down arrow 
- press tab and you should be on notebook tab, press menu button and this open up the custom context menu via keyboard. 
