### PR TITLE
Datagrid: Introduce AsyncCellRenderer and ImageRenderer

### DIFF
--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -577,7 +577,7 @@ function main(): void {
   let grid5 = new DataGrid({
     style: greenStripeStyle,
     defaultSizes: {
-      rowHeight: 32,
+      rowHeight: 75,
       columnWidth: 128,
       rowHeaderWidth: 64,
       columnHeaderHeight: 32

--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -592,7 +592,18 @@ function main(): void {
   });
 
   const imageRenderer = new ImageRenderer({
-    sizingMode: 'fit-width'
+    width: '100%',
+    height: '' // Will be computed automatically
+    // Other options:
+    // width: '50px',
+    // height: '50px',
+    //
+    // width: '100%',
+    // height: '50px',
+    //
+    // For keeping the original size:
+    // width: '',
+    // height: '',
   });
   grid5.cellRenderers.update({
     body: (config: CellRenderer.CellConfig) => {

--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -591,7 +591,9 @@ function main(): void {
     selectionMode: 'row'
   });
 
-  const imageRenderer = new ImageRenderer();
+  const imageRenderer = new ImageRenderer({
+    sizingMode: 'fit-width'
+  });
   grid5.cellRenderers.update({
     body: (config: CellRenderer.CellConfig) => {
       if (config.metadata.name === 'Image') {

--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -20,7 +20,8 @@ import {
   ICellEditor,
   JSONModel,
   MutableDataModel,
-  TextRenderer
+  TextRenderer,
+  ImageRenderer
 } from '@lumino/datagrid';
 
 import { DockPanel, StackedPanel, Widget } from '@lumino/widgets';
@@ -590,6 +591,16 @@ function main(): void {
     selectionMode: 'row'
   });
 
+  const imageRenderer = new ImageRenderer();
+  grid5.cellRenderers.update({
+    body: (config: CellRenderer.CellConfig) => {
+      if (config.metadata.name === 'Image') {
+        return imageRenderer;
+      }
+      return undefined;
+    }
+  });
+
   let grid6 = new DataGrid({
     defaultSizes: {
       rowHeight: 32,
@@ -962,6 +973,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 18.0,
         Name: 'chevrolet chevelle malibu',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/1966_Chevrolet_Chevelle_SS_%2832985111206%29.jpg/420px-1966_Chevrolet_Chevelle_SS_%2832985111206%29.jpg',
         index: 0,
         Acceleration: 12.0,
         Year: '1970-01-01',
@@ -974,6 +986,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 15.0,
         Name: 'buick skylark 320',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/1d/1972_Buick_Skylark_Front.jpg/420px-1972_Buick_Skylark_Front.jpg',
         index: 1,
         Acceleration: 11.5,
         Year: '1970-01-01',
@@ -986,6 +999,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 18.0,
         Name: 'plymouth satellite',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/66Sat.jpg/420px-66Sat.jpg',
         index: 2,
         Acceleration: 11.0,
         Year: '1970-01-01',
@@ -998,6 +1012,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 16.0,
         Name: 'amc rebel sst',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg/420px-1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg',
         index: 3,
         Acceleration: 12.0,
         Year: '1970-01-01',
@@ -1010,6 +1025,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 17.0,
         Name: 'ford torino',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/1970_ford_torino_cobra_sportsroof_chiolero.jpg/420px-1970_ford_torino_cobra_sportsroof_chiolero.jpg',
         index: 4,
         Acceleration: 10.5,
         Year: '1970-01-01',
@@ -1022,6 +1038,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 15.0,
         Name: 'ford galaxie 500',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/92/1963_Ford_Galaxie_sedan_2_--_06-05-2010.jpg/420px-1963_Ford_Galaxie_sedan_2_--_06-05-2010.jpg',
         index: 5,
         Acceleration: 10.0,
         Year: '1970-01-01',
@@ -1034,6 +1051,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 14.0,
         Name: 'chevrolet impala',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/1965_Chevrolet_Impala_300_hp_V8_big_Block_Engine.JPG/420px-1965_Chevrolet_Impala_300_hp_V8_big_Block_Engine.JPG',
         index: 6,
         Acceleration: 9.0,
         Year: '1970-01-01',
@@ -1046,6 +1064,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 14.0,
         Name: 'plymouth fury iii',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0e/1959_Plymouth_Sport_Fury_photo-13.JPG/420px-1959_Plymouth_Sport_Fury_photo-13.JPG',
         index: 7,
         Acceleration: 8.5,
         Year: '1970-01-01',
@@ -1058,6 +1077,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 14.0,
         Name: 'pontiac catalina',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Pontiac_Catalina_front.jpg/420px-Pontiac_Catalina_front.jpg',
         index: 8,
         Acceleration: 10.0,
         Year: '1970-01-01',
@@ -1070,6 +1090,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 15.0,
         Name: 'amc ambassador dpl',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/1964_Rambler_Ambassador_990_H_in_black_and_white_with_red_interior_at_2017_AMO_meet_01of16.jpg/420px-1964_Rambler_Ambassador_990_H_in_black_and_white_with_red_interior_at_2017_AMO_meet_01of16.jpg',
         index: 9,
         Acceleration: 8.5,
         Year: '1970-01-01',
@@ -1082,6 +1103,7 @@ namespace Data {
         Origin: 'Europe',
         Miles_per_Gallon: null,
         Name: 'citroen ds-21 pallas',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/58/Festival_automobile_international_2018_-_Citro%C3%ABn_DS_21_-_1965_-_002.jpg/300px-Festival_automobile_international_2018_-_Citro%C3%ABn_DS_21_-_1965_-_002.jpg',
         index: 10,
         Acceleration: 17.5,
         Year: '1970-01-01',
@@ -1094,6 +1116,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: null,
         Name: 'chevrolet chevelle concours (sw)',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/1969_Chevrolet_Chevelle_SS396_2_door_Hardtop_%2825260012813%29.jpg/270px-1969_Chevrolet_Chevelle_SS396_2_door_Hardtop_%2825260012813%29.jpg',
         index: 11,
         Acceleration: 11.5,
         Year: '1970-01-01',
@@ -1106,6 +1129,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: null,
         Name: 'ford torino (sw)',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/1970_ford_torino_cobra_sportsroof_chiolero.jpg/420px-1970_ford_torino_cobra_sportsroof_chiolero.jpg',
         index: 12,
         Acceleration: 11.0,
         Year: '1970-01-01',
@@ -1118,6 +1142,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: null,
         Name: 'plymouth satellite (sw)',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/66Sat.jpg/420px-66Sat.jpg',
         index: 13,
         Acceleration: 10.5,
         Year: '1970-01-01',
@@ -1130,6 +1155,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: null,
         Name: 'amc rebel sst (sw)',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg/420px-1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg',
         index: 14,
         Acceleration: 11.0,
         Year: '1970-01-01',
@@ -1142,6 +1168,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 15.0,
         Name: 'dodge challenger se',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/1970_Dodge_Challenger_RT_440_Magnum_%2813440447413%29.jpg/420px-1970_Dodge_Challenger_RT_440_Magnum_%2813440447413%29.jpg',
         index: 15,
         Acceleration: 10.0,
         Year: '1970-01-01',
@@ -1154,6 +1181,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 14.0,
         Name: "plymouth 'cuda 340",
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/%2770_Plymouth_Barracuda_%28%2711_Auto_classique_VAQ_Mont_St-Hilaire%29.JPG/420px-%2770_Plymouth_Barracuda_%28%2711_Auto_classique_VAQ_Mont_St-Hilaire%29.JPG',
         index: 16,
         Acceleration: 8.0,
         Year: '1970-01-01',
@@ -1166,6 +1194,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: null,
         Name: 'ford mustang boss 302',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/1970_Ford_Mustang_Boss_302_%2815863840731%29.jpg/420px-1970_Ford_Mustang_Boss_302_%2815863840731%29.jpg',
         index: 17,
         Acceleration: 8.0,
         Year: '1970-01-01',
@@ -1178,6 +1207,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 15.0,
         Name: 'chevrolet monte carlo',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Chevrolet_Monte_Carlo_1970_P6170033.jpg/420px-Chevrolet_Monte_Carlo_1970_P6170033.jpg',
         index: 18,
         Acceleration: 9.5,
         Year: '1970-01-01',
@@ -1190,6 +1220,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 14.0,
         Name: 'buick estate wagon (sw)',
+        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/1987_Buick_Electra_Estate_a_station_wagon_at_2019_AACA_Hershey_meet_1of3.jpg/420px-1987_Buick_Electra_Estate_a_station_wagon_at_2019_AACA_Hershey_meet_1of3.jpg',
         index: 19,
         Acceleration: 10.0,
         Year: '1970-01-01',
@@ -1202,6 +1233,7 @@ namespace Data {
         Origin: 'Japan',
         Miles_per_Gallon: 24.0,
         Name: 'toyota corona mark ii',
+        Image: '',
         index: 20,
         Acceleration: 15.0,
         Year: '1970-01-01',
@@ -1214,6 +1246,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 22.0,
         Name: 'plymouth duster',
+        Image: '',
         index: 21,
         Acceleration: 15.5,
         Year: '1970-01-01',
@@ -1226,6 +1259,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 18.0,
         Name: 'amc hornet',
+        Image: '',
         index: 22,
         Acceleration: 15.5,
         Year: '1970-01-01',
@@ -1238,6 +1272,7 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 21.0,
         Name: 'ford maverick',
+        Image: '',
         index: 23,
         Acceleration: 16.0,
         Year: '1970-01-01',
@@ -1250,6 +1285,7 @@ namespace Data {
         Origin: 'Japan',
         Miles_per_Gallon: 27.0,
         Name: 'datsun pl510',
+        Image: '',
         index: 24,
         Acceleration: 14.5,
         Year: '1970-01-01',
@@ -1262,6 +1298,7 @@ namespace Data {
         Origin: 'Europe',
         Miles_per_Gallon: 26.0,
         Name: 'volkswagen 1131 deluxe sedan',
+        Image: '',
         index: 25,
         Acceleration: 20.5,
         Year: '1970-01-01',
@@ -1274,6 +1311,7 @@ namespace Data {
         Origin: 'Europe',
         Miles_per_Gallon: 25.0,
         Name: 'peugeot 504',
+        Image: '',
         index: 26,
         Acceleration: 17.5,
         Year: '1970-01-01',
@@ -1286,6 +1324,7 @@ namespace Data {
         Origin: 'Europe',
         Miles_per_Gallon: 24.0,
         Name: 'audi 100 ls',
+        Image: '',
         index: 27,
         Acceleration: 14.5,
         Year: '1970-01-01',
@@ -1298,6 +1337,7 @@ namespace Data {
         Origin: 'Europe',
         Miles_per_Gallon: 25.0,
         Name: 'saab 99e',
+        Image: '',
         index: 28,
         Acceleration: 17.5,
         Year: '1970-01-01',
@@ -1310,6 +1350,7 @@ namespace Data {
         Origin: 'Europe',
         Miles_per_Gallon: 26.0,
         Name: 'bmw 2002',
+        Image: '',
         index: 29,
         Acceleration: 12.5,
         Year: '1970-01-01',
@@ -1347,6 +1388,10 @@ namespace Data {
         },
         {
           name: 'Name',
+          type: 'string'
+        },
+        {
+          name: 'Image',
           type: 'string'
         },
         {

--- a/examples/example-datagrid/src/index.ts
+++ b/examples/example-datagrid/src/index.ts
@@ -973,7 +973,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 18.0,
         Name: 'chevrolet chevelle malibu',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/1966_Chevrolet_Chevelle_SS_%2832985111206%29.jpg/420px-1966_Chevrolet_Chevelle_SS_%2832985111206%29.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/1966_Chevrolet_Chevelle_SS_%2832985111206%29.jpg/420px-1966_Chevrolet_Chevelle_SS_%2832985111206%29.jpg',
         index: 0,
         Acceleration: 12.0,
         Year: '1970-01-01',
@@ -986,7 +987,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 15.0,
         Name: 'buick skylark 320',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/1d/1972_Buick_Skylark_Front.jpg/420px-1972_Buick_Skylark_Front.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/1/1d/1972_Buick_Skylark_Front.jpg/420px-1972_Buick_Skylark_Front.jpg',
         index: 1,
         Acceleration: 11.5,
         Year: '1970-01-01',
@@ -999,7 +1001,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 18.0,
         Name: 'plymouth satellite',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/66Sat.jpg/420px-66Sat.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/66Sat.jpg/420px-66Sat.jpg',
         index: 2,
         Acceleration: 11.0,
         Year: '1970-01-01',
@@ -1012,7 +1015,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 16.0,
         Name: 'amc rebel sst',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg/420px-1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg/420px-1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg',
         index: 3,
         Acceleration: 12.0,
         Year: '1970-01-01',
@@ -1025,7 +1029,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 17.0,
         Name: 'ford torino',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/1970_ford_torino_cobra_sportsroof_chiolero.jpg/420px-1970_ford_torino_cobra_sportsroof_chiolero.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/1970_ford_torino_cobra_sportsroof_chiolero.jpg/420px-1970_ford_torino_cobra_sportsroof_chiolero.jpg',
         index: 4,
         Acceleration: 10.5,
         Year: '1970-01-01',
@@ -1038,7 +1043,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 15.0,
         Name: 'ford galaxie 500',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/92/1963_Ford_Galaxie_sedan_2_--_06-05-2010.jpg/420px-1963_Ford_Galaxie_sedan_2_--_06-05-2010.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/9/92/1963_Ford_Galaxie_sedan_2_--_06-05-2010.jpg/420px-1963_Ford_Galaxie_sedan_2_--_06-05-2010.jpg',
         index: 5,
         Acceleration: 10.0,
         Year: '1970-01-01',
@@ -1051,7 +1057,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 14.0,
         Name: 'chevrolet impala',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/1965_Chevrolet_Impala_300_hp_V8_big_Block_Engine.JPG/420px-1965_Chevrolet_Impala_300_hp_V8_big_Block_Engine.JPG',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/1965_Chevrolet_Impala_300_hp_V8_big_Block_Engine.JPG/420px-1965_Chevrolet_Impala_300_hp_V8_big_Block_Engine.JPG',
         index: 6,
         Acceleration: 9.0,
         Year: '1970-01-01',
@@ -1064,7 +1071,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 14.0,
         Name: 'plymouth fury iii',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0e/1959_Plymouth_Sport_Fury_photo-13.JPG/420px-1959_Plymouth_Sport_Fury_photo-13.JPG',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0e/1959_Plymouth_Sport_Fury_photo-13.JPG/420px-1959_Plymouth_Sport_Fury_photo-13.JPG',
         index: 7,
         Acceleration: 8.5,
         Year: '1970-01-01',
@@ -1077,7 +1085,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 14.0,
         Name: 'pontiac catalina',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Pontiac_Catalina_front.jpg/420px-Pontiac_Catalina_front.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Pontiac_Catalina_front.jpg/420px-Pontiac_Catalina_front.jpg',
         index: 8,
         Acceleration: 10.0,
         Year: '1970-01-01',
@@ -1090,7 +1099,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 15.0,
         Name: 'amc ambassador dpl',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/1964_Rambler_Ambassador_990_H_in_black_and_white_with_red_interior_at_2017_AMO_meet_01of16.jpg/420px-1964_Rambler_Ambassador_990_H_in_black_and_white_with_red_interior_at_2017_AMO_meet_01of16.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/1964_Rambler_Ambassador_990_H_in_black_and_white_with_red_interior_at_2017_AMO_meet_01of16.jpg/420px-1964_Rambler_Ambassador_990_H_in_black_and_white_with_red_interior_at_2017_AMO_meet_01of16.jpg',
         index: 9,
         Acceleration: 8.5,
         Year: '1970-01-01',
@@ -1103,7 +1113,8 @@ namespace Data {
         Origin: 'Europe',
         Miles_per_Gallon: null,
         Name: 'citroen ds-21 pallas',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/58/Festival_automobile_international_2018_-_Citro%C3%ABn_DS_21_-_1965_-_002.jpg/300px-Festival_automobile_international_2018_-_Citro%C3%ABn_DS_21_-_1965_-_002.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/5/58/Festival_automobile_international_2018_-_Citro%C3%ABn_DS_21_-_1965_-_002.jpg/300px-Festival_automobile_international_2018_-_Citro%C3%ABn_DS_21_-_1965_-_002.jpg',
         index: 10,
         Acceleration: 17.5,
         Year: '1970-01-01',
@@ -1116,7 +1127,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: null,
         Name: 'chevrolet chevelle concours (sw)',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/1969_Chevrolet_Chevelle_SS396_2_door_Hardtop_%2825260012813%29.jpg/270px-1969_Chevrolet_Chevelle_SS396_2_door_Hardtop_%2825260012813%29.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/1969_Chevrolet_Chevelle_SS396_2_door_Hardtop_%2825260012813%29.jpg/270px-1969_Chevrolet_Chevelle_SS396_2_door_Hardtop_%2825260012813%29.jpg',
         index: 11,
         Acceleration: 11.5,
         Year: '1970-01-01',
@@ -1129,7 +1141,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: null,
         Name: 'ford torino (sw)',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/1970_ford_torino_cobra_sportsroof_chiolero.jpg/420px-1970_ford_torino_cobra_sportsroof_chiolero.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/1970_ford_torino_cobra_sportsroof_chiolero.jpg/420px-1970_ford_torino_cobra_sportsroof_chiolero.jpg',
         index: 12,
         Acceleration: 11.0,
         Year: '1970-01-01',
@@ -1142,7 +1155,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: null,
         Name: 'plymouth satellite (sw)',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/66Sat.jpg/420px-66Sat.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f0/66Sat.jpg/420px-66Sat.jpg',
         index: 13,
         Acceleration: 10.5,
         Year: '1970-01-01',
@@ -1155,7 +1169,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: null,
         Name: 'amc rebel sst (sw)',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg/420px-1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg/420px-1968_AMC_Rebel_Station_Wagon-GoldWhite.jpg',
         index: 14,
         Acceleration: 11.0,
         Year: '1970-01-01',
@@ -1168,7 +1183,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 15.0,
         Name: 'dodge challenger se',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/1970_Dodge_Challenger_RT_440_Magnum_%2813440447413%29.jpg/420px-1970_Dodge_Challenger_RT_440_Magnum_%2813440447413%29.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/1970_Dodge_Challenger_RT_440_Magnum_%2813440447413%29.jpg/420px-1970_Dodge_Challenger_RT_440_Magnum_%2813440447413%29.jpg',
         index: 15,
         Acceleration: 10.0,
         Year: '1970-01-01',
@@ -1181,7 +1197,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 14.0,
         Name: "plymouth 'cuda 340",
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/%2770_Plymouth_Barracuda_%28%2711_Auto_classique_VAQ_Mont_St-Hilaire%29.JPG/420px-%2770_Plymouth_Barracuda_%28%2711_Auto_classique_VAQ_Mont_St-Hilaire%29.JPG',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/%2770_Plymouth_Barracuda_%28%2711_Auto_classique_VAQ_Mont_St-Hilaire%29.JPG/420px-%2770_Plymouth_Barracuda_%28%2711_Auto_classique_VAQ_Mont_St-Hilaire%29.JPG',
         index: 16,
         Acceleration: 8.0,
         Year: '1970-01-01',
@@ -1194,7 +1211,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: null,
         Name: 'ford mustang boss 302',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/1970_Ford_Mustang_Boss_302_%2815863840731%29.jpg/420px-1970_Ford_Mustang_Boss_302_%2815863840731%29.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/1970_Ford_Mustang_Boss_302_%2815863840731%29.jpg/420px-1970_Ford_Mustang_Boss_302_%2815863840731%29.jpg',
         index: 17,
         Acceleration: 8.0,
         Year: '1970-01-01',
@@ -1207,7 +1225,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 15.0,
         Name: 'chevrolet monte carlo',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Chevrolet_Monte_Carlo_1970_P6170033.jpg/420px-Chevrolet_Monte_Carlo_1970_P6170033.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Chevrolet_Monte_Carlo_1970_P6170033.jpg/420px-Chevrolet_Monte_Carlo_1970_P6170033.jpg',
         index: 18,
         Acceleration: 9.5,
         Year: '1970-01-01',
@@ -1220,7 +1239,8 @@ namespace Data {
         Origin: 'USA',
         Miles_per_Gallon: 14.0,
         Name: 'buick estate wagon (sw)',
-        Image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/1987_Buick_Electra_Estate_a_station_wagon_at_2019_AACA_Hershey_meet_1of3.jpg/420px-1987_Buick_Electra_Estate_a_station_wagon_at_2019_AACA_Hershey_meet_1of3.jpg',
+        Image:
+          'https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/1987_Buick_Electra_Estate_a_station_wagon_at_2019_AACA_Hershey_meet_1of3.jpg/420px-1987_Buick_Electra_Estate_a_station_wagon_at_2019_AACA_Hershey_meet_1of3.jpg',
         index: 19,
         Acceleration: 10.0,
         Year: '1970-01-01',

--- a/packages/datagrid/src/asynccellrenderer.ts
+++ b/packages/datagrid/src/asynccellrenderer.ts
@@ -8,8 +8,8 @@
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-import { CellRenderer } from "./cellrenderer";
-import { GraphicsContext } from "./graphicscontext";
+import { CellRenderer } from './cellrenderer';
+import { GraphicsContext } from './graphicscontext';
 
 /**
  * An object which renders the cells of a data grid asynchronously.
@@ -21,7 +21,6 @@ import { GraphicsContext } from "./graphicscontext";
  * See `ImageRenderer` for an example of an asynchronous renderer.
  */
 export abstract class AsyncCellRenderer extends CellRenderer {
-
   /**
    * Whether the renderer is ready or not for that specific config.
    * If it's not ready, the datagrid will paint the placeholder using `paintPlaceholder`.
@@ -47,6 +46,8 @@ export abstract class AsyncCellRenderer extends CellRenderer {
    *
    * @param config - The configuration data for the cell.
    */
-  abstract paintPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
-
+  abstract paintPlaceholder(
+    gc: GraphicsContext,
+    config: CellRenderer.CellConfig
+  ): void;
 }

--- a/packages/datagrid/src/asynccellrenderer.ts
+++ b/packages/datagrid/src/asynccellrenderer.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2023, Lumino Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+import { CellRenderer } from "./cellrenderer";
+import { GraphicsContext } from "./graphicscontext";
+
+/**
+ * An object which renders the cells of a data grid asynchronously.
+ *
+ * #### Notes
+ * For performance reason, the datagrid only paints cells synchronously,
+ * though if your cell renderer inherits from AsyncCellRenderer, you will
+ * be able to do some asynchronous work prior to painting the cell.
+ * See `ImageRenderer` for an example of an asynchronous renderer.
+ */
+export abstract class AsyncCellRenderer extends CellRenderer {
+
+  /**
+   * Whether the renderer is ready or not for that specific config.
+   * If it's not ready, the datagrid will paint the placeholder using `paintPlaceholder`.
+   * If it's ready, the datagrid will paint the cell synchronously using `paint`.
+   *
+   * @param config - The configuration data for the cell.
+   *
+   * @returns Whether the renderer is ready for this config or not.
+   */
+  abstract isReady(config: CellRenderer.CellConfig): boolean;
+
+  /**
+   * Do any asynchronous work prior to painting this cell config.
+   *
+   * @param config - The configuration data for the cell.
+   */
+  abstract load(config: CellRenderer.CellConfig): Promise<void>;
+
+  /**
+   * Paint the placeholder for a cell, waiting for the renderer to be ready.
+   *
+   * @param gc - The graphics context to use for drawing.
+   *
+   * @param config - The configuration data for the cell.
+   */
+  abstract paintPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
+
+}

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -20,6 +20,8 @@ import {
 
 import { GridLayout, ScrollBar, Widget } from '@lumino/widgets';
 
+import { AsyncCellRenderer } from './asynccellrenderer';
+
 import { CellRenderer } from './cellrenderer';
 
 import { DataModel, MutableDataModel } from './datamodel';
@@ -40,7 +42,6 @@ import {
 } from './celleditorcontroller';
 
 import { TextRenderer } from './textrenderer';
-import { ImageRenderer } from './imagerenderer';
 
 /**
  * A widget which implements a high-performance tabular data grid.
@@ -5062,7 +5063,7 @@ export class DataGrid extends Widget {
 
         // Paint the cell into the off-screen buffer.
         try {
-          if (renderer instanceof ImageRenderer) {
+          if (renderer instanceof AsyncCellRenderer) {
             if (renderer.isReady(config)) {
               renderer.paint(gc, config);
             } else {

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -5304,7 +5304,25 @@ export class DataGrid extends Widget {
 
       // Paint the cell into the off-screen buffer.
       try {
-        renderer.paint(gc, config);
+        if (renderer instanceof AsyncCellRenderer) {
+          if (renderer.isReady(config)) {
+            renderer.paint(gc, config);
+          } else {
+            renderer.paintPlaceholder(gc, config);
+
+            const r1 = group.r1;
+            const r2 = group.r2;
+
+            const c1 = group.c1;
+            const c2 = group.c2;
+
+            renderer.load(config).then(() => {
+              this.repaintRegion(rgn.region, r1, c1, r2, c2);
+            });
+          }
+        } else {
+          renderer.paint(gc, config);
+        }
       } catch (err) {
         console.error(err);
       }

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -5069,11 +5069,11 @@ export class DataGrid extends Widget {
             } else {
               renderer.paintPlaceholder(gc, config);
               renderer.load(config).then(() => {
-                const r1 = rgn.row;
-                const r2 = rgn.row + rgn.rowSizes.length;
+                const r1 = row;
+                const r2 = row + 1;
 
-                const c1 = rgn.column;
-                const c2 = rgn.column + rgn.columnSizes.length;
+                const c1 = column;
+                const c2 = column + 1;
 
                 this.repaintRegion(rgn.region, r1, c1, r2, c2);
               });

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -40,6 +40,7 @@ import {
 } from './celleditorcontroller';
 
 import { TextRenderer } from './textrenderer';
+import { ImageRenderer } from './imagerenderer';
 
 /**
  * A widget which implements a high-performance tabular data grid.
@@ -5061,7 +5062,24 @@ export class DataGrid extends Widget {
 
         // Paint the cell into the off-screen buffer.
         try {
-          renderer.paint(gc, config);
+          if (renderer instanceof ImageRenderer) {
+            if (renderer.isReady(config)) {
+              renderer.paint(gc, config);
+            } else {
+              renderer.paintPlaceholder(gc, config);
+              renderer.load(config).then(() => {
+                const r1 = rgn.row;
+                const r2 = rgn.row + rgn.rowSizes.length;
+
+                const c1 = rgn.column;
+                const c2 = rgn.column + rgn.columnSizes.length;
+
+                this.repaintRegion(rgn.region, r1, c1, r2, c2);
+              });
+            }
+          } else {
+            renderer.paint(gc, config);
+          }
         } catch (err) {
           console.error(err);
         }

--- a/packages/datagrid/src/imagerenderer.ts
+++ b/packages/datagrid/src/imagerenderer.ts
@@ -37,13 +37,25 @@ export class ImageRenderer extends AsyncCellRenderer {
     super();
 
     this.backgroundColor = options.backgroundColor || '';
+    this.textColor = options.textColor || '#000000';
+    this.placeholder = options.placeholder || '...';
     this.sizingMode = options.sizingMode || 'fit-height';
   }
+
+  /**
+   * The CSS color for drawing the placeholder text.
+   */
+  readonly textColor: CellRenderer.ConfigOption<string>;
 
   /**
    * The CSS color for the cell background.
    */
   readonly backgroundColor: CellRenderer.ConfigOption<string>;
+
+  /**
+   * The placeholder text.
+   */
+  readonly placeholder: CellRenderer.ConfigOption<string>;
 
   /**
    * Sizing mode. Can be 'original', 'fit', or 'fill'.
@@ -83,7 +95,6 @@ export class ImageRenderer extends AsyncCellRenderer {
 
     const img = new Image();
     img.onload = () => {
-      // Load image
       ImageRenderer.dataCache.set(value, img);
 
       loadedPromise.resolve();
@@ -126,7 +137,7 @@ export class ImageRenderer extends AsyncCellRenderer {
    */
   drawBackground(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
     // Resolve the background color for the cell.
-    let color = CellRenderer.resolveOption(this.backgroundColor, config);
+    const color = CellRenderer.resolveOption(this.backgroundColor, config);
 
     // Bail if there is no background color to draw.
     if (!color) {
@@ -146,13 +157,15 @@ export class ImageRenderer extends AsyncCellRenderer {
    * @param config - The configuration data for the cell.
    */
   drawPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
-    // TODO Consider inheriting from/using a TextRenderer for rendering the placeholder
+    const placeholder = CellRenderer.resolveOption(this.placeholder, config);
+    const color = CellRenderer.resolveOption(this.textColor, config);
+
     const textX = config.x + config.width / 2;
     const textY = config.y + config.height / 2;
 
     // Draw the placeholder.
-    gc.fillStyle = 'black'; // TODO Make this part of the cell config
-    gc.fillText('loading...', textX, textY); // TODO Make this "loading..." part of the cell config
+    gc.fillStyle = color;
+    gc.fillText(placeholder, textX, textY);
   }
 
   /**
@@ -210,6 +223,20 @@ export namespace ImageRenderer {
      * The default is `''`.
      */
     backgroundColor?: CellRenderer.ConfigOption<string>;
+
+    /**
+     * The placeholder text while the cell is loading.
+     *
+     * The default is `'...'`.
+     */
+    placeholder?: CellRenderer.ConfigOption<string>;
+
+    /**
+     * The color for the drawing the placeholder text.
+     *
+     * The default `'#000000'`.
+     */
+    textColor?: CellRenderer.ConfigOption<string>;
 
     /**
      * Sizing mode. Can be 'original', 'fit-height', 'fit-width', or 'fill'.

--- a/packages/datagrid/src/imagerenderer.ts
+++ b/packages/datagrid/src/imagerenderer.ts
@@ -13,7 +13,6 @@ import { CellRenderer } from './cellrenderer';
 
 import { GraphicsContext } from './graphicscontext';
 
-
 export type SizingMode = 'fit' | 'fill' | 'original';
 
 /**
@@ -52,7 +51,9 @@ export class ImageRenderer extends AsyncCellRenderer {
    * @returns Whether the renderer is ready for this config or not.
    */
   isReady(config: CellRenderer.CellConfig): boolean {
-    return !config.value || ImageRenderer.dataCache.get(config.value) !== undefined;
+    return (
+      !config.value || ImageRenderer.dataCache.get(config.value) !== undefined
+    );
   }
 
   /**
@@ -141,8 +142,8 @@ export class ImageRenderer extends AsyncCellRenderer {
     const textY = config.y + config.height / 2;
 
     // Draw the placeholder.
-    gc.fillStyle = "black";  // TODO Make this part of the cell config
-    gc.fillText("loading...", textX, textY);  // TODO Make this "loading..." part of the cell config
+    gc.fillStyle = 'black'; // TODO Make this part of the cell config
+    gc.fillText('loading...', textX, textY); // TODO Make this "loading..." part of the cell config
   }
 
   /**
@@ -165,11 +166,10 @@ export class ImageRenderer extends AsyncCellRenderer {
       return this.drawPlaceholder(gc, config);
     }
 
+    const fitHeight = (img.height / img.width) * config.width;
     switch (this.sizingMode) {
       case 'fit':
-        const newHeight = (img.height / img.width) * config.width;
-
-        gc.drawImage(img, config.x, config.y, config.width, newHeight);
+        gc.drawImage(img, config.x, config.y, config.width, fitHeight);
         break;
       case 'fill':
         gc.drawImage(img, config.x, config.y, config.width, config.height);

--- a/packages/datagrid/src/imagerenderer.ts
+++ b/packages/datagrid/src/imagerenderer.ts
@@ -13,7 +13,16 @@ import { CellRenderer } from './cellrenderer';
 
 import { GraphicsContext } from './graphicscontext';
 
-export type SizingMode = 'fit' | 'fill' | 'original';
+/**
+ * Sizing mode. Can be 'original', 'fit-height', 'fit-width', or 'fill'.
+ * 'fit-height' will make the image fit the available height in the cell, respecting the image size ratio.
+ * 'fit-width' will make the image fit the available width in the cell, respecting the image size ratio.
+ * 'fill' will make the image fill the available space in the cell, NOT respecting the image size ratio.
+ * 'original' will make respect the size of the original image.
+ *
+ * The default is 'fit-height'
+ */
+export type SizingMode = 'fit-height' | 'fit-width' | 'fill' | 'original';
 
 /**
  * A cell renderer which renders data values as images.
@@ -28,7 +37,7 @@ export class ImageRenderer extends AsyncCellRenderer {
     super();
 
     this.backgroundColor = options.backgroundColor || '';
-    this.sizingMode = options.sizingMode || 'fit';
+    this.sizingMode = options.sizingMode || 'fit-height';
   }
 
   /**
@@ -166,9 +175,13 @@ export class ImageRenderer extends AsyncCellRenderer {
       return this.drawPlaceholder(gc, config);
     }
 
+    const fitWidth = (img.width / img.height) * config.height;
     const fitHeight = (img.height / img.width) * config.width;
     switch (this.sizingMode) {
-      case 'fit':
+      case 'fit-height':
+        gc.drawImage(img, config.x, config.y, fitWidth, config.height);
+        break;
+      case 'fit-width':
         gc.drawImage(img, config.x, config.y, config.width, fitHeight);
         break;
       case 'fill':
@@ -199,12 +212,13 @@ export namespace ImageRenderer {
     backgroundColor?: CellRenderer.ConfigOption<string>;
 
     /**
-     * Sizing mode. Can be 'original', 'fit', or 'fill'.
-     * 'fit' will make the image fit the available width in the cell, respecting the image size ratio.
-     * 'fill' will make the image fill the available space in the cell, not respecting the image size ratio.
+     * Sizing mode. Can be 'original', 'fit-height', 'fit-width', or 'fill'.
+     * 'fit-height' will make the image fit the available height in the cell, respecting the image size ratio.
+     * 'fit-width' will make the image fit the available width in the cell, respecting the image size ratio.
+     * 'fill' will make the image fill the available space in the cell, NOT respecting the image size ratio.
      * 'original' will make respect the size of the original image.
      *
-     * The default is 'fit'
+     * The default is 'fit-height'
      */
     sizingMode?: CellRenderer.ConfigOption<SizingMode>;
   }

--- a/packages/datagrid/src/imagerenderer.ts
+++ b/packages/datagrid/src/imagerenderer.ts
@@ -12,6 +12,9 @@ import { CellRenderer } from './cellrenderer';
 
 import { GraphicsContext } from './graphicscontext';
 
+
+export type SizingMode = 'fit' | 'fill' | 'original';
+
 // TODO Inherit from AsyncCellRenderer?
 
 /**
@@ -27,12 +30,18 @@ export class ImageRenderer extends CellRenderer {
     super();
 
     this.backgroundColor = options.backgroundColor || '';
+    this.sizingMode = options.sizingMode || 'fit';
   }
 
   /**
    * The CSS color for the cell background.
    */
   readonly backgroundColor: CellRenderer.ConfigOption<string>;
+
+  /**
+   * Sizing mode. Can be 'original', 'fit', or 'fill'.
+   */
+  readonly sizingMode: CellRenderer.ConfigOption<SizingMode>;
 
   /**
    * Whether the renderer is ready or not for that specific config.
@@ -157,7 +166,19 @@ export class ImageRenderer extends CellRenderer {
       return this.drawPlaceholder(gc, config);
     }
 
-    gc.drawImage(img, config.x, config.y, config.width, config.height);
+    switch (this.sizingMode) {
+      case 'fit':
+        const newHeight = (img.height / img.width) * config.width;
+
+        gc.drawImage(img, config.x, config.y, config.width, newHeight);
+        break;
+      case 'fill':
+        gc.drawImage(img, config.x, config.y, config.width, config.height);
+        break;
+      case 'original':
+        gc.drawImage(img, config.x, config.y);
+        break;
+    }
   }
 
   static dataCache = new Map<string, HTMLImageElement | undefined>();
@@ -177,5 +198,15 @@ export namespace ImageRenderer {
      * The default is `''`.
      */
     backgroundColor?: CellRenderer.ConfigOption<string>;
+
+    /**
+     * Sizing mode. Can be 'original', 'fit', or 'fill'.
+     * 'fit' will make the image fit the available width in the cell, respecting the image size ratio.
+     * 'fill' will make the image fill the available space in the cell, not respecting the image size ratio.
+     * 'original' will make respect the size of the original image.
+     *
+     * The default is 'fit'
+     */
+    sizingMode?: CellRenderer.ConfigOption<SizingMode>;
   }
 }

--- a/packages/datagrid/src/imagerenderer.ts
+++ b/packages/datagrid/src/imagerenderer.ts
@@ -1,0 +1,177 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2019, PhosphorJS Contributors
+|
+| Distributed under the terms of the BSD 3-Clause License.
+|
+| The full license is in the file LICENSE, distributed with this software.
+|----------------------------------------------------------------------------*/
+import { PromiseDelegate } from '@lumino/coreutils';
+import { CellRenderer } from './cellrenderer';
+
+import { GraphicsContext } from './graphicscontext';
+
+// TODO Inherit from AsyncCellRenderer?
+
+/**
+ * A cell renderer which renders data values as images.
+ */
+export class ImageRenderer extends CellRenderer {
+  /**
+   * Construct a new text renderer.
+   *
+   * @param options - The options for initializing the renderer.
+   */
+  constructor(options: ImageRenderer.IOptions = {}) {
+    super();
+
+    this.backgroundColor = options.backgroundColor || '';
+  }
+
+  /**
+   * The CSS color for the cell background.
+   */
+  readonly backgroundColor: CellRenderer.ConfigOption<string>;
+
+  /**
+   * Whether the renderer is ready or not for that specific config.
+   * If it's not ready, the datagrid will paint the placeholder.
+   * If it's ready, the datagrid will paint the image synchronously.
+   *
+   * @param config - The configuration data for the cell.
+   *
+   * @returns Whether the renderer is ready for this config or not.
+   */
+  isReady(config: CellRenderer.CellConfig): boolean {
+    return ImageRenderer.dataCache.has(config.value);
+  }
+
+  /**
+   * Load the image asynchronously for a specific config.
+   *
+   * @param config - The configuration data for the cell.
+   */
+  async load(config: CellRenderer.CellConfig): Promise<void> {
+    // Bail early if there is nothing to do
+    if (!config.value) {
+      return;
+    }
+
+    const loadedPromise = new PromiseDelegate<void>();
+
+    const img = new Image();
+    img.onload = () => {
+      ImageRenderer.dataCache.set(config.value, img);
+
+      loadedPromise.resolve();
+    };
+    img.src = config.value;
+
+    return loadedPromise.promise;
+  }
+
+  /**
+   * Paint the placeholder for a cell, waiting for the renderer to be ready.
+   *
+   * @param gc - The graphics context to use for drawing.
+   *
+   * @param config - The configuration data for the cell.
+   */
+  paintPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
+    this.drawBackground(gc, config);
+    this.drawPlaceholder(gc, config);
+  }
+
+  /**
+   * Paint the content for a cell.
+   *
+   * @param gc - The graphics context to use for drawing.
+   *
+   * @param config - The configuration data for the cell.
+   */
+  paint(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
+    this.drawBackground(gc, config);
+    this.drawImage(gc, config);
+  }
+
+  /**
+   * Draw the background for the cell.
+   *
+   * @param gc - The graphics context to use for drawing.
+   *
+   * @param config - The configuration data for the cell.
+   */
+  drawBackground(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
+    // Resolve the background color for the cell.
+    let color = CellRenderer.resolveOption(this.backgroundColor, config);
+
+    // Bail if there is no background color to draw.
+    if (!color) {
+      return;
+    }
+
+    // Fill the cell with the background color.
+    gc.fillStyle = color;
+    gc.fillRect(config.x, config.y, config.width, config.height);
+  }
+
+  /**
+   * Draw the placeholder for the cell.
+   *
+   * @param gc - The graphics context to use for drawing.
+   *
+   * @param config - The configuration data for the cell.
+   */
+  drawPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
+    // TODO Consider inheriting from/using a TextRenderer for rendering the placeholder
+    const textX = config.x + config.width / 2;
+    const textY = config.y + config.height / 2;
+
+    // Draw the placeholder.
+    gc.fillStyle = "black";  // TODO Make this part of the cell config
+    gc.fillText("loading...", textX, textY);  // TODO Make this "loading..." part of the cell config
+  }
+
+  /**
+   * Draw the image for the cell.
+   *
+   * @param gc - The graphics context to use for drawing.
+   *
+   * @param config - The configuration data for the cell.
+   */
+  drawImage(gc: GraphicsContext, config: CellRenderer.CellConfig): void {
+    // Bail early if there is nothing to draw
+    if (!config.value) {
+      return;
+    }
+
+    const img = ImageRenderer.dataCache.get(config.value);
+
+    // If it's not loaded yet, show the placeholder
+    if (!img) {
+      return this.drawPlaceholder(gc, config);
+    }
+
+    gc.drawImage(img, config.x, config.y, config.width, config.height);
+  }
+
+  static dataCache = new Map<string, HTMLImageElement>();
+}
+
+/**
+ * The namespace for the `ImageRenderer` class statics.
+ */
+export namespace ImageRenderer {
+  /**
+   * An options object for initializing an image renderer.
+   */
+  export interface IOptions {
+    /**
+     * The background color for the cells.
+     *
+     * The default is `''`.
+     */
+    backgroundColor?: CellRenderer.ConfigOption<string>;
+  }
+}

--- a/packages/datagrid/src/imagerenderer.ts
+++ b/packages/datagrid/src/imagerenderer.ts
@@ -44,7 +44,7 @@ export class ImageRenderer extends CellRenderer {
    * @returns Whether the renderer is ready for this config or not.
    */
   isReady(config: CellRenderer.CellConfig): boolean {
-    return ImageRenderer.dataCache.has(config.value);
+    return !config.value || ImageRenderer.dataCache.has(config.value);
   }
 
   /**
@@ -62,6 +62,7 @@ export class ImageRenderer extends CellRenderer {
 
     const img = new Image();
     img.onload = () => {
+      // Load image
       ImageRenderer.dataCache.set(config.value, img);
 
       loadedPromise.resolve();

--- a/packages/datagrid/src/imagerenderer.ts
+++ b/packages/datagrid/src/imagerenderer.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 /*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2019, PhosphorJS Contributors
+| Copyright (c) 2014-2023, Lumino Contributors
 |
 | Distributed under the terms of the BSD 3-Clause License.
 |
 | The full license is in the file LICENSE, distributed with this software.
 |----------------------------------------------------------------------------*/
 import { PromiseDelegate } from '@lumino/coreutils';
+import { AsyncCellRenderer } from './asynccellrenderer';
 import { CellRenderer } from './cellrenderer';
 
 import { GraphicsContext } from './graphicscontext';
@@ -15,12 +16,10 @@ import { GraphicsContext } from './graphicscontext';
 
 export type SizingMode = 'fit' | 'fill' | 'original';
 
-// TODO Inherit from AsyncCellRenderer?
-
 /**
  * A cell renderer which renders data values as images.
  */
-export class ImageRenderer extends CellRenderer {
+export class ImageRenderer extends AsyncCellRenderer {
   /**
    * Construct a new text renderer.
    *

--- a/packages/datagrid/src/imagerenderer.ts
+++ b/packages/datagrid/src/imagerenderer.ts
@@ -44,7 +44,7 @@ export class ImageRenderer extends CellRenderer {
    * @returns Whether the renderer is ready for this config or not.
    */
   isReady(config: CellRenderer.CellConfig): boolean {
-    return !config.value || ImageRenderer.dataCache.has(config.value);
+    return !config.value || ImageRenderer.dataCache.get(config.value) !== undefined;
   }
 
   /**
@@ -58,16 +58,19 @@ export class ImageRenderer extends CellRenderer {
       return;
     }
 
+    const value = config.value;
     const loadedPromise = new PromiseDelegate<void>();
+
+    ImageRenderer.dataCache.set(value, undefined);
 
     const img = new Image();
     img.onload = () => {
       // Load image
-      ImageRenderer.dataCache.set(config.value, img);
+      ImageRenderer.dataCache.set(value, img);
 
       loadedPromise.resolve();
     };
-    img.src = config.value;
+    img.src = value;
 
     return loadedPromise.promise;
   }
@@ -157,7 +160,7 @@ export class ImageRenderer extends CellRenderer {
     gc.drawImage(img, config.x, config.y, config.width, config.height);
   }
 
-  static dataCache = new Map<string, HTMLImageElement>();
+  static dataCache = new Map<string, HTMLImageElement | undefined>();
 }
 
 /**

--- a/packages/datagrid/src/index.ts
+++ b/packages/datagrid/src/index.ts
@@ -14,6 +14,7 @@
 export * from './basickeyhandler';
 export * from './basicmousehandler';
 export * from './basicselectionmodel';
+export * from './asynccellrenderer';
 export * from './cellrenderer';
 export * from './celleditor';
 export * from './celleditorcontroller';

--- a/packages/datagrid/src/index.ts
+++ b/packages/datagrid/src/index.ts
@@ -26,4 +26,5 @@ export * from './selectionmodel';
 export * from './sectionlist';
 export * from './textrenderer';
 export * from './hyperlinkrenderer';
+export * from './imagerenderer';
 export * from './cellgroup';

--- a/packages/datagrid/tests/src/imagerenderer.spec.ts
+++ b/packages/datagrid/tests/src/imagerenderer.spec.ts
@@ -1,0 +1,151 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import { expect } from 'chai';
+
+import { CellRenderer, GraphicsContext, ImageRenderer } from '@lumino/datagrid';
+
+class LoggingGraphicsContext extends GraphicsContext {
+  drawImage(img: HTMLImageElement, x: number, y: number, width?: number, height?: number): void {
+    if (width && height) {
+      super.drawImage(img, x, y, width, height);
+    } else {
+      super.drawImage(img, x, y);
+    }
+    this.images.push({ img, x, y, width, height });
+  }
+
+  images: any[] = [];
+}
+
+describe('@lumino/datagrid', () => {
+  let gc: LoggingGraphicsContext;
+  let img: HTMLImageElement;
+  const defaultCellConfig: CellRenderer.CellConfig = {
+    x: 5,
+    y: 6,
+    width: 240,
+    height: 20,
+    row: 0,
+    column: 0,
+    region: 'body',
+    value: '',
+    metadata: {}
+  };
+  beforeEach(() => {
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d')!;
+    gc = new LoggingGraphicsContext(context);
+    img = document.createElement('img');
+    img.width = 12;
+    img.height = 2;
+    ImageRenderer["dataCache"].set("test-image", img);
+  });
+  describe('ImageRenderer', () => {
+    describe('drawImage()', () => {
+      it('should take full available height by default', () => {
+        const renderer = new ImageRenderer();
+        renderer.drawImage(gc, {
+          ...defaultCellConfig,
+          value: 'test-image'
+        });
+        expect(gc.images.pop()).to.deep.eq({
+          img,
+          x: 5,
+          y: 6,
+          width: 120,
+          height: 20
+        });
+      });
+
+      it('should take full available width when requested', () => {
+        const renderer = new ImageRenderer({
+          width: '100%',
+          height: ''
+        });
+        renderer.drawImage(gc, {
+          ...defaultCellConfig,
+          value: 'test-image'
+        });
+        expect(gc.images.pop()).to.deep.eq({
+          img,
+          x: 5,
+          y: 6,
+          width: 240,
+          height: 40
+        });
+      });
+
+      it('should take full available width and height when requested', () => {
+        const renderer = new ImageRenderer({
+          width: '100%',
+          height: '100%'
+        });
+        renderer.drawImage(gc, {
+          ...defaultCellConfig,
+          value: 'test-image'
+        });
+        expect(gc.images.pop()).to.deep.eq({
+          img,
+          x: 5,
+          y: 6,
+          width: 240,
+          height: 20
+        });
+      });
+
+      it('should take width in pixels', () => {
+        const renderer = new ImageRenderer({
+          width: '24px',
+          height: ''
+        });
+        renderer.drawImage(gc, {
+          ...defaultCellConfig,
+          value: 'test-image'
+        });
+        expect(gc.images.pop()).to.deep.eq({
+          img,
+          x: 5,
+          y: 6,
+          width: 24,
+          height: 4
+        });
+      });
+
+      it('should take width and height pixels', () => {
+        const renderer = new ImageRenderer({
+          width: '24px',
+          height: '13px'
+        });
+        renderer.drawImage(gc, {
+          ...defaultCellConfig,
+          value: 'test-image'
+        });
+        expect(gc.images.pop()).to.deep.eq({
+          img,
+          x: 5,
+          y: 6,
+          width: 24,
+          height: 13
+        });
+      });
+
+      it('should take width in pixels and height in percentage', () => {
+        const renderer = new ImageRenderer({
+          width: '24px',
+          height: '50%'
+        });
+        renderer.drawImage(gc, {
+          ...defaultCellConfig,
+          value: 'test-image'
+        });
+        expect(gc.images.pop()).to.deep.eq({
+          img,
+          x: 5,
+          y: 6,
+          width: 24,
+          height: 10
+        });
+      });
+    });
+  });
+});

--- a/packages/datagrid/tests/src/imagerenderer.spec.ts
+++ b/packages/datagrid/tests/src/imagerenderer.spec.ts
@@ -5,7 +5,13 @@ import { expect } from 'chai';
 import { CellRenderer, GraphicsContext, ImageRenderer } from '@lumino/datagrid';
 
 class LoggingGraphicsContext extends GraphicsContext {
-  drawImage(img: HTMLImageElement, x: number, y: number, width?: number, height?: number): void {
+  drawImage(
+    img: HTMLImageElement,
+    x: number,
+    y: number,
+    width?: number,
+    height?: number
+  ): void {
     if (width && height) {
       super.drawImage(img, x, y, width, height);
     } else {
@@ -38,7 +44,7 @@ describe('@lumino/datagrid', () => {
     img = document.createElement('img');
     img.width = 12;
     img.height = 2;
-    ImageRenderer["dataCache"].set("test-image", img);
+    ImageRenderer['dataCache'].set('test-image', img);
   });
   describe('ImageRenderer', () => {
     describe('drawImage()', () => {

--- a/packages/datagrid/tests/src/index.spec.ts
+++ b/packages/datagrid/tests/src/index.spec.ts
@@ -2,3 +2,4 @@
 // Distributed under the terms of the Modified BSD License.
 
 import './textrenderer.spec';
+import './imagerenderer.spec';

--- a/review/api/datagrid.api.md
+++ b/review/api/datagrid.api.md
@@ -928,7 +928,7 @@ export namespace SelectionModel {
 }
 
 // @public (undocumented)
-export type SizingMode = 'fit' | 'fill' | 'original';
+export type SizingMode = 'fit-height' | 'fit-width' | 'fill' | 'original';
 
 // @public
 export class TextCellEditor extends InputCellEditor {

--- a/review/api/datagrid.api.md
+++ b/review/api/datagrid.api.md
@@ -679,27 +679,27 @@ export interface ICellInputValidatorResponse {
 export class ImageRenderer extends AsyncCellRenderer {
     constructor(options?: ImageRenderer.IOptions);
     readonly backgroundColor: CellRenderer.ConfigOption<string>;
-    // (undocumented)
-    static dataCache: Map<string, HTMLImageElement | undefined>;
     drawBackground(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
     drawImage(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
     drawPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
+    readonly height: CellRenderer.ConfigOption<string>;
     isReady(config: CellRenderer.CellConfig): boolean;
     load(config: CellRenderer.CellConfig): Promise<void>;
     paint(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
     paintPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
     readonly placeholder: CellRenderer.ConfigOption<string>;
-    readonly sizingMode: CellRenderer.ConfigOption<SizingMode>;
     readonly textColor: CellRenderer.ConfigOption<string>;
+    readonly width: CellRenderer.ConfigOption<string>;
 }
 
 // @public
 export namespace ImageRenderer {
     export interface IOptions {
         backgroundColor?: CellRenderer.ConfigOption<string>;
+        height?: CellRenderer.ConfigOption<string>;
         placeholder?: CellRenderer.ConfigOption<string>;
-        sizingMode?: CellRenderer.ConfigOption<SizingMode>;
         textColor?: CellRenderer.ConfigOption<string>;
+        width?: CellRenderer.ConfigOption<string>;
     }
 }
 
@@ -930,9 +930,6 @@ export namespace SelectionModel {
     };
     export type SelectionMode = 'row' | 'column' | 'cell';
 }
-
-// @public
-export type SizingMode = 'fit-height' | 'fit-width' | 'fill' | 'original';
 
 // @public
 export class TextCellEditor extends InputCellEditor {

--- a/review/api/datagrid.api.md
+++ b/review/api/datagrid.api.md
@@ -688,14 +688,18 @@ export class ImageRenderer extends AsyncCellRenderer {
     load(config: CellRenderer.CellConfig): Promise<void>;
     paint(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
     paintPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
+    readonly placeholder: CellRenderer.ConfigOption<string>;
     readonly sizingMode: CellRenderer.ConfigOption<SizingMode>;
+    readonly textColor: CellRenderer.ConfigOption<string>;
 }
 
 // @public
 export namespace ImageRenderer {
     export interface IOptions {
         backgroundColor?: CellRenderer.ConfigOption<string>;
+        placeholder?: CellRenderer.ConfigOption<string>;
         sizingMode?: CellRenderer.ConfigOption<SizingMode>;
+        textColor?: CellRenderer.ConfigOption<string>;
     }
 }
 
@@ -927,7 +931,7 @@ export namespace SelectionModel {
     export type SelectionMode = 'row' | 'column' | 'cell';
 }
 
-// @public (undocumented)
+// @public
 export type SizingMode = 'fit-height' | 'fit-width' | 'fill' | 'original';
 
 // @public

--- a/review/api/datagrid.api.md
+++ b/review/api/datagrid.api.md
@@ -13,6 +13,13 @@ import { Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 
 // @public
+export abstract class AsyncCellRenderer extends CellRenderer {
+    abstract isReady(config: CellRenderer.CellConfig): boolean;
+    abstract load(config: CellRenderer.CellConfig): Promise<void>;
+    abstract paintPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
+}
+
+// @public
 export class BasicKeyHandler implements DataGrid.IKeyHandler {
     dispose(): void;
     get isDisposed(): boolean;
@@ -669,6 +676,30 @@ export interface ICellInputValidatorResponse {
 }
 
 // @public
+export class ImageRenderer extends AsyncCellRenderer {
+    constructor(options?: ImageRenderer.IOptions);
+    readonly backgroundColor: CellRenderer.ConfigOption<string>;
+    // (undocumented)
+    static dataCache: Map<string, HTMLImageElement | undefined>;
+    drawBackground(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
+    drawImage(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
+    drawPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
+    isReady(config: CellRenderer.CellConfig): boolean;
+    load(config: CellRenderer.CellConfig): Promise<void>;
+    paint(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
+    paintPlaceholder(gc: GraphicsContext, config: CellRenderer.CellConfig): void;
+    readonly sizingMode: CellRenderer.ConfigOption<SizingMode>;
+}
+
+// @public
+export namespace ImageRenderer {
+    export interface IOptions {
+        backgroundColor?: CellRenderer.ConfigOption<string>;
+        sizingMode?: CellRenderer.ConfigOption<SizingMode>;
+    }
+}
+
+// @public
 export abstract class InputCellEditor extends CellEditor {
     // (undocumented)
     protected bindEvents(): void;
@@ -895,6 +926,9 @@ export namespace SelectionModel {
     };
     export type SelectionMode = 'row' | 'column' | 'cell';
 }
+
+// @public (undocumented)
+export type SizingMode = 'fit' | 'fill' | 'original';
 
 // @public
 export class TextCellEditor extends InputCellEditor {


### PR DESCRIPTION
This is a step towards fixing https://github.com/bloomberg/ipydatagrid/issues/253

## Introducing `AsyncCellRenderer`

Prior to this change, the Lumino datagrid would not allow rendering cells asynchronously. This means that rendering images was not really possible (unless the cell renderer had a reference to the datagrid and requested a redraw once the asynchronous task was done).

This PR introduces the `AsyncCellRenderer` abstract class, which the datagrid uses as following (more or less pseudo-code):
```typescript
if (renderer instanceof AsyncCellRenderer) {
  if (!renderer.isReady(config)) {
    // Paint a placeholder, waiting for all asynchronous tasks to be performed
    renderer.paintPlaceholder(gc, config);

    // Perform all asynchronous tasks (without waiting) then redraw the region of the cell
    renderer.load(config).then(() => {
      this.repaintRegion(cell.position);
    }); 
  } else {
    // The async renderer is ready, we can paint synchronously
    renderer.paint(gc, config);
  }
} else {
  // Classic synchronous painting
  renderer.paint(gc, config);
}
```

This allows supporting asynchronous cell rendering without slowing down the synchronous way.

## Introducing the `ImageRenderer`

This implements the `AsyncCellRenderer` and allows to load images in the datagrid:

![Screenshot from 2023-09-06 13-59-48](https://github.com/jupyterlab/lumino/assets/21197331/747a141a-7096-459f-9b85-bb3c74c549eb)
