### PR TITLE
Added a test to check the add tab button has a role of button

### DIFF
--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1615,7 +1615,6 @@ describe('@lumino/widgets', () => {
           expect(bar.addButtonNode.getAttribute('tabindex')).to.equal('-1');
         });
 
-        
         it('should have a role attribute of button', () => {
           populateBar(bar);
           expect(bar.addButtonNode.getAttribute('role')).to.equal('button');

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1615,6 +1615,12 @@ describe('@lumino/widgets', () => {
           expect(bar.addButtonNode.getAttribute('tabindex')).to.equal('-1');
         });
 
+        
+        it('should have a role attribute of button', () => {
+          populateBar(bar);
+          expect(bar.addButtonNode.getAttribute('role')).to.equal('button');
+        });
+
         it('should focus the second tab on right arrow keydown', () => {
           populateBar(bar);
           const firstTab = bar.contentNode.firstChild as HTMLElement;


### PR DESCRIPTION
**References**

Related PR - https://github.com/jupyterlab/lumino/pull/615

**Code changes**

Added a test to check the add tab button has a role of button. This allows the user to tab to it using a keyboard.

**User-facing changes**

None

**Backwards-incompatible changes**

None