### PR TITLE
Keydown event at bubbling phase

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -189,6 +189,20 @@ export class Application<T extends Widget = Widget> {
   }
 
   /**
+   * Getter and setter for the bubblingKeydown experimental flag.
+   *
+   * @experimental
+   */
+  get bubblingKeydown(): boolean {
+    return this._bubblingKeydown;
+  }
+  set bubblingKeydown(value: boolean) {
+    document.removeEventListener('keydown', this, !this._bubblingKeydown);
+    this._bubblingKeydown = value;
+    document.addEventListener('keydown', this, !this._bubblingKeydown);
+  }
+
+  /**
    * Get a plugin description.
    *
    * @param id - The ID of the plugin of interest.
@@ -723,10 +737,10 @@ export namespace Application {
     ignorePlugins?: string[];
 
     /**
-     * A flag to handle the keydown events at bubbling phase.
+     * Whether to capture keydown event at bubbling or capturing (default) phase for
+     * keyboard shortcuts.
      *
-     * #### Notes
-     * If not provides, the keydown events are handled at capture phase.
+     * @experimental
      */
     bubblingKeydown?: boolean;
   }

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -722,6 +722,12 @@ export namespace Application {
      */
     ignorePlugins?: string[];
 
+    /**
+     * A flag to handle the keydown events at bubbling phase.
+     *
+     * #### Notes
+     * If not provides, the keydown events are handled at capture phase.
+     */
     bubblingKeydown?: boolean;
   }
 }

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -506,6 +506,8 @@ export class Application<T extends Widget = Widget> {
     // Mark the application as started;
     this._started = true;
 
+    this._bubblingKeydown = options.bubblingKeydown || false;
+
     // Parse the host ID for attaching the shell.
     const hostID = options.hostID || '';
 
@@ -606,8 +608,11 @@ export class Application<T extends Widget = Widget> {
    * A subclass may reimplement this method as needed.
    */
   protected addEventListeners(): void {
+    if (this._bubblingKeydown) {
+      console.log('The keydown events are handled during bubbling phase');
+    }
     document.addEventListener('contextmenu', this);
-    document.addEventListener('keydown', this, true);
+    document.addEventListener('keydown', this, !this._bubblingKeydown);
     window.addEventListener('resize', this);
   }
 
@@ -663,6 +668,7 @@ export class Application<T extends Widget = Widget> {
   private _plugins = new Map<string, Private.IPluginData>();
   private _services = new Map<Token<any>, string>();
   private _started = false;
+  private _bubblingKeydown = false;
 }
 
 /**
@@ -715,6 +721,8 @@ export namespace Application {
      * This will override `startPlugins` and any `autoStart` plugins.
      */
     ignorePlugins?: string[];
+
+    bubblingKeydown?: boolean;
   }
 }
 

--- a/review/api/application.api.md
+++ b/review/api/application.api.md
@@ -17,6 +17,8 @@ export class Application<T extends Widget = Widget> {
     activatePlugin(id: string): Promise<void>;
     protected addEventListeners(): void;
     protected attachShell(id: string): void;
+    get bubblingKeydown(): boolean;
+    set bubblingKeydown(value: boolean);
     readonly commands: CommandRegistry;
     readonly contextMenu: ContextMenu;
     deactivatePlugin(id: string): Promise<string[]>;
@@ -46,7 +48,6 @@ export namespace Application {
         shell: T;
     }
     export interface IStartOptions {
-        // (undocumented)
         bubblingKeydown?: boolean;
         hostID?: string;
         ignorePlugins?: string[];

--- a/review/api/application.api.md
+++ b/review/api/application.api.md
@@ -46,6 +46,8 @@ export namespace Application {
         shell: T;
     }
     export interface IStartOptions {
+        // (undocumented)
+        bubblingKeydown?: boolean;
         hostID?: string;
         ignorePlugins?: string[];
         startPlugins?: string[];


### PR DESCRIPTION
This PR adds an experimental parameter when starting application to handle the keydown event at bubbling phase.

Currently the keydown events are handled at capture phase. With this PR it with possible to switch from capture to bubbling at startup.

See https://github.com/jupyterlab/jupyterlab/pull/14115#issuecomment-1727686379 for context.

cc. @fcollonval @krassowski @gabalafou 