### PR TITLE
Switch from `hub` to `gh` CLI

### DIFF
--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -16,11 +16,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure git to use https
-        run: git config --global hub.protocol https
-
       - name: Checkout the branch from the PR that triggered the job
-        run: hub pr checkout ${{ github.event.pull_request.number }}
+        run: gh pr checkout ${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Changes required following hub deprecation: https://github.com/actions/runner-images/issues/8362