### PR TITLE
adds isKeybinding arg to _executeKeyBinding

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -613,7 +613,7 @@ export class CommandRegistry {
    */
   private _executeKeyBinding(binding: CommandRegistry.IKeyBinding): void {
     let { command, args } = binding;
-    let newArgs = { ...args, isKeybinding: true };
+    let newArgs: ReadonlyPartialJSONObject = {_luminoEvent: { type: "keybinding", keys: binding.keys }, ...args};
     if (!this.hasCommand(command) || !this.isEnabled(command, newArgs)) {
       let word = this.hasCommand(command) ? 'enabled' : 'registered';
       let keys = binding.keys.join(', ');

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -711,6 +711,8 @@ export namespace CommandRegistry {
      * the command.
      *
      * This may be invoked even when `isEnabled` returns `false`.
+     * 
+     * If called via a keybinding the passed args will include a `_luminoEvent` that specify the event type and keys pressed for customization.
      */
     execute: CommandFunc<any | Promise<any>>;
 
@@ -866,6 +868,8 @@ export namespace CommandRegistry {
      * command as grayed-out or in some other non-interactive fashion.
      *
      * The default value is `() => true`.
+     * 
+     * If called via a keybinding the passed args will include a `_luminoEvent` that specify the event type and keys pressed for customization
      */
     isEnabled?: CommandFunc<boolean>;
 
@@ -991,7 +995,7 @@ export namespace CommandRegistry {
     /**
      * The arguments for the command, if necessary.
      *
-     * The default value is an empty object.
+     * The default value is an empty object. If a command is activated by _executeKeyBinding, `args = {_luminoEvent: {type: <string>, keys: <string[]>}}`
      */
     args?: ReadonlyPartialJSONObject;
 

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -613,7 +613,7 @@ export class CommandRegistry {
    */
   private _executeKeyBinding(binding: CommandRegistry.IKeyBinding): void {
     let { command, args } = binding;
-    let newArgs = {...args, "isKeybinding": true}
+    let newArgs = { ...args, isKeybinding: true };
     if (!this.hasCommand(command) || !this.isEnabled(command, newArgs)) {
       let word = this.hasCommand(command) ? 'enabled' : 'registered';
       let keys = binding.keys.join(', ');

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -613,7 +613,10 @@ export class CommandRegistry {
    */
   private _executeKeyBinding(binding: CommandRegistry.IKeyBinding): void {
     let { command, args } = binding;
-    let newArgs: ReadonlyPartialJSONObject = {_luminoEvent: { type: "keybinding", keys: binding.keys }, ...args};
+    let newArgs: ReadonlyPartialJSONObject = {
+      _luminoEvent: { type: 'keybinding', keys: binding.keys },
+      ...args
+    };
     if (!this.hasCommand(command) || !this.isEnabled(command, newArgs)) {
       let word = this.hasCommand(command) ? 'enabled' : 'registered';
       let keys = binding.keys.join(', ');
@@ -711,7 +714,7 @@ export namespace CommandRegistry {
      * the command.
      *
      * This may be invoked even when `isEnabled` returns `false`.
-     * 
+     *
      * If called via a keybinding the passed args will include a `_luminoEvent` that specify the event type and keys pressed for customization.
      */
     execute: CommandFunc<any | Promise<any>>;
@@ -868,7 +871,7 @@ export namespace CommandRegistry {
      * command as grayed-out or in some other non-interactive fashion.
      *
      * The default value is `() => true`.
-     * 
+     *
      * If called via a keybinding the passed args will include a `_luminoEvent` that specify the event type and keys pressed for customization
      */
     isEnabled?: CommandFunc<boolean>;

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -613,6 +613,7 @@ export class CommandRegistry {
    */
   private _executeKeyBinding(binding: CommandRegistry.IKeyBinding): void {
     let { command, args } = binding;
+    args.isKeybinding = true;
     if (!this.hasCommand(command) || !this.isEnabled(command, args)) {
       let word = this.hasCommand(command) ? 'enabled' : 'registered';
       let keys = binding.keys.join(', ');

--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -613,8 +613,8 @@ export class CommandRegistry {
    */
   private _executeKeyBinding(binding: CommandRegistry.IKeyBinding): void {
     let { command, args } = binding;
-    args.isKeybinding = true;
-    if (!this.hasCommand(command) || !this.isEnabled(command, args)) {
+    let newArgs = {...args, "isKeybinding": true}
+    if (!this.hasCommand(command) || !this.isEnabled(command, newArgs)) {
       let word = this.hasCommand(command) ? 'enabled' : 'registered';
       let keys = binding.keys.join(', ');
       let msg1 = `Cannot execute key binding '${keys}':`;
@@ -622,7 +622,7 @@ export class CommandRegistry {
       console.warn(`${msg1} ${msg2}`);
       return;
     }
-    this.execute(command, args);
+    this.execute(command, newArgs);
   }
 
   /**

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -701,9 +701,13 @@ describe('@lumino/commands', () => {
     describe('#processKeydownEvent()', () => {
       it('should dispatch on a correct keyboard event', () => {
         let called = false;
+        let _luminoEventType;
+        let _luminoEventKeys;
         registry.addCommand('test', {
-          execute: () => {
+          execute: (args) => {
             called = true;
+            _luminoEventType = (args._luminoEvent as ReadonlyJSONObject).type
+            _luminoEventKeys = (args._luminoEvent as ReadonlyJSONObject).keys
           }
         });
         registry.addKeyBinding({
@@ -718,6 +722,8 @@ describe('@lumino/commands', () => {
           })
         );
         expect(called).to.equal(true);
+        expect(_luminoEventType).to.equal('keybinding')
+        expect(_luminoEventKeys).to.contain('Ctrl ;')
       });
 
       it('should not dispatch on a suppressed node', () => {

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -704,10 +704,10 @@ describe('@lumino/commands', () => {
         let _luminoEventType;
         let _luminoEventKeys;
         registry.addCommand('test', {
-          execute: (args) => {
+          execute: args => {
             called = true;
-            _luminoEventType = (args._luminoEvent as ReadonlyJSONObject).type
-            _luminoEventKeys = (args._luminoEvent as ReadonlyJSONObject).keys
+            _luminoEventType = (args._luminoEvent as ReadonlyJSONObject).type;
+            _luminoEventKeys = (args._luminoEvent as ReadonlyJSONObject).keys;
           }
         });
         registry.addKeyBinding({
@@ -722,8 +722,8 @@ describe('@lumino/commands', () => {
           })
         );
         expect(called).to.equal(true);
-        expect(_luminoEventType).to.equal('keybinding')
-        expect(_luminoEventKeys).to.contain('Ctrl ;')
+        expect(_luminoEventType).to.equal('keybinding');
+        expect(_luminoEventKeys).to.contain('Ctrl ;');
       });
 
       it('should not dispatch on a suppressed node', () => {


### PR DESCRIPTION
Necessary for [jupyterlab issue #15046](https://github.com/jupyterlab/jupyterlab/issues/15046) .

relevant discussion captured in #570.

Simply appends an `isKeybinding` argument to `args` in `_executeKeyBinding`.