### PR TITLE
Add default top/left for `.lm-mod-drag-image`

### DIFF
--- a/packages/dragdrop/style/index.css
+++ b/packages/dragdrop/style/index.css
@@ -23,5 +23,7 @@
 }
 
 .lm-mod-drag-image {
+  top: 0px;
+  left: 0px;
   will-change: transform;
 }


### PR DESCRIPTION
Ref: https://github.com/jupyter/nbdime/pull/723

This ensures that the drag image is correctly positioned in applications which add non-absolutely positioned containers to the `<body>`.