### PR TITLE
Propagate scroll from backdrop

### DIFF
--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -1260,8 +1260,8 @@ namespace Private {
       // Hide the backdrop until the pointer moves to avoid issues with
       // native double click detection, used in e.g. datagrid editing.
       cursorBackdrop.style.transform = 'scale(0)';
-      resetBackdropScroll();
       body.appendChild(cursorBackdrop);
+      resetBackdropScroll();
       document.addEventListener('pointermove', alignBackdrop, {
         capture: true,
         passive: true

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -1315,38 +1315,25 @@ namespace Private {
       return;
     }
     // Apply the scroll delta to the correct target.
-    scrollTarget.scrollTop +=
-      cursorBackdrop.scrollTop - backdropScroll.scrollTop;
-    scrollTarget.scrollLeft +=
-      cursorBackdrop.scrollLeft - backdropScroll.scrollLeft;
+    scrollTarget.scrollTop += cursorBackdrop.scrollTop - backdropScrollOrigin;
+    scrollTarget.scrollLeft += cursorBackdrop.scrollLeft - backdropScrollOrigin;
 
-    // Update previous position for future delta calculation.
-    backdropScroll.scrollTop = cursorBackdrop.scrollTop;
-    backdropScroll.scrollLeft = cursorBackdrop.scrollLeft;
-
-    // Center the scroll position if needed.
+    // Center the scroll position.
     resetBackdropScroll();
   }
 
   /**
-   * If needed, reset the backdrop scroll to allow further scrolling.
+   * Reset the backdrop scroll to allow further scrolling.
    */
   function resetBackdropScroll() {
-    if (cursorBackdrop.scrollTop <= 0 || cursorBackdrop.scrollTop >= 1000) {
-      cursorBackdrop.scrollTop = backdropScroll.scrollTop = 500;
-    }
-    if (cursorBackdrop.scrollLeft <= 0 || cursorBackdrop.scrollLeft >= 1000) {
-      cursorBackdrop.scrollLeft = backdropScroll.scrollLeft = 500;
-    }
+    cursorBackdrop.scrollTop = backdropScrollOrigin;
+    cursorBackdrop.scrollLeft = backdropScrollOrigin;
   }
 
   /**
-   * Previous backdrop scroll position.
+   * The center of the backdrop node scroll area.
    */
-  let backdropScroll = {
-    scrollTop: 0,
-    scrollLeft: 0
-  };
+  const backdropScrollOrigin = 500;
 
   /**
    * Create cursor backdrop node.

--- a/packages/dragdrop/src/index.ts
+++ b/packages/dragdrop/src/index.ts
@@ -374,7 +374,7 @@ export class Drag implements IDisposable {
     let prevElem = this._currentElement;
 
     // Find the current indicated element at the given position.
-    let currElem = Private.findElementBehidBackdrop(event, this.document);
+    let currElem = Private.findElementBehindBackdrop(event, this.document);
 
     // Update the current element reference.
     this._currentElement = currElem;
@@ -840,7 +840,7 @@ namespace Private {
    * Find the event target using pointer position if given, or otherwise
    * the central position of the backdrop.
    */
-  export function findElementBehidBackdrop(
+  export function findElementBehindBackdrop(
     event?: PointerEvent,
     root: Document | ShadowRoot = document
   ) {
@@ -892,7 +892,7 @@ namespace Private {
     let y = event.clientY;
 
     // Get the element under the mouse.
-    let element: Element | null = findElementBehidBackdrop(event);
+    let element: Element | null = findElementBehindBackdrop(event);
 
     // Search for a scrollable target based on the mouse position.
     // The null assert in third clause of for-loop is required due to:
@@ -1305,7 +1305,7 @@ namespace Private {
     }
     // Get the element under behind the centre of the cursor backdrop
     // (essentially behind the cursor, but possibly a few pixels off).
-    let element: Element | null = findElementBehidBackdrop();
+    let element: Element | null = findElementBehindBackdrop();
     if (!element) {
       return;
     }

--- a/packages/dragdrop/style/index.css
+++ b/packages/dragdrop/style/index.css
@@ -29,8 +29,8 @@
 
 .lm-cursor-backdrop::after {
   content: '';
-  height: 1000px;
-  width: 1000px;
+  height: 1200px;
+  width: 1200px;
   display: block;
 }
 

--- a/packages/dragdrop/style/index.css
+++ b/packages/dragdrop/style/index.css
@@ -13,6 +13,8 @@
 |----------------------------------------------------------------------------*/
 
 .lm-cursor-backdrop {
+  top: 0px;
+  left: 0px;
   position: fixed;
   width: 200px;
   height: 200px;
@@ -20,6 +22,20 @@
   margin-left: -100px;
   will-change: transform;
   z-index: 100;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  overflow: scroll;
+}
+
+.lm-cursor-backdrop::after {
+  content: '';
+  height: 1000px;
+  width: 1000px;
+  display: block;
+}
+
+.lm-cursor-backdrop::-webkit-scrollbar {
+  display: none;
 }
 
 .lm-mod-drag-image {

--- a/packages/dragdrop/tests/src/index.spec.ts
+++ b/packages/dragdrop/tests/src/index.spec.ts
@@ -611,6 +611,34 @@ describe('@lumino/dragdrop', () => {
         expect(backdrop.style.transform).to.equal('translate(100px, 500px)');
         override.dispose();
       });
+
+      it('should propagate scroll to underlying target', () => {
+        let override = Drag.overrideCursor('wait');
+        const backdrop = document.querySelector(
+          '.lm-cursor-backdrop'
+        ) as HTMLElement;
+
+        const wrapper = document.createElement('div');
+        const content = document.createElement('div');
+        document.elementFromPoint = (_x, _y) => {
+          return wrapper;
+        };
+        document.body.appendChild(wrapper);
+        wrapper.appendChild(content);
+        wrapper.setAttribute('data-lm-dragscroll', 'true');
+        wrapper.style.overflow = 'scroll';
+        wrapper.style.height = '100px';
+        wrapper.style.width = '100px';
+        content.style.height = '200px';
+        content.style.width = '200px';
+
+        backdrop.scrollTop += 10;
+        backdrop.dispatchEvent(new Event('scroll'));
+
+        expect(wrapper.scrollTop).to.equal(10);
+        override.dispose();
+        document.body.removeChild(wrapper);
+      });
     });
   });
 });

--- a/packages/dragdrop/tests/src/index.spec.ts
+++ b/packages/dragdrop/tests/src/index.spec.ts
@@ -629,13 +629,17 @@ describe('@lumino/dragdrop', () => {
         wrapper.style.overflow = 'scroll';
         wrapper.style.height = '100px';
         wrapper.style.width = '100px';
-        content.style.height = '200px';
-        content.style.width = '200px';
+        content.style.height = '2000px';
+        content.style.width = '2000px';
 
-        backdrop.scrollTop += 10;
+        backdrop.scrollTop += 400;
         backdrop.dispatchEvent(new Event('scroll'));
+        expect(wrapper.scrollTop).to.equal(400);
 
-        expect(wrapper.scrollTop).to.equal(10);
+        backdrop.scrollTop += 400;
+        backdrop.dispatchEvent(new Event('scroll'));
+        expect(wrapper.scrollTop).to.equal(800);
+
         override.dispose();
         document.body.removeChild(wrapper);
       });


### PR DESCRIPTION
### References

Fixes https://github.com/jupyterlab/jupyterlab/issues/14881

### Code changes

- makes the `.lm-cursor-backdrop` scrollable using a pseudo-element and stlyes, but hiding the scrollbar
- propagates intercepted scroll events to relevant element with `data-lm-dragscroll` property
- adds `top`/`left` to `.lm-cursor-backdrop` as in https://github.com/jupyterlab/lumino/pull/651

### User-facing changes

Restoring scrolling in browser when dragging cells:

![fixed-scrolling-notebook](https://github.com/jupyterlab/lumino/assets/5832902/1ed1a60a-5ea2-4611-9aed-e6c14e54dc86)

Once https://github.com/jupyterlab/jupyterlab/pull/15318 is in, also enables scrolling in file browser with selection

![after-file-browser](https://github.com/jupyterlab/lumino/assets/5832902/12bb7e4b-229a-4fc2-a009-7a9a3bb0d928)

### Backwards-incompatible changes

None