### PR TITLE
Remove dynamic keyboard event mode

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -608,9 +608,6 @@ export class Application<T extends Widget = Widget> {
    * A subclass may reimplement this method as needed.
    */
   protected addEventListeners(): void {
-    if (this._bubblingKeydown) {
-      console.debug('The keydown events are handled during bubbling phase');
-    }
     document.addEventListener('contextmenu', this);
     document.addEventListener('keydown', this, !this._bubblingKeydown);
     window.addEventListener('resize', this);

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -189,20 +189,6 @@ export class Application<T extends Widget = Widget> {
   }
 
   /**
-   * Getter and setter for the bubblingKeydown experimental flag.
-   *
-   * @experimental
-   */
-  get bubblingKeydown(): boolean {
-    return this._bubblingKeydown;
-  }
-  set bubblingKeydown(value: boolean) {
-    document.removeEventListener('keydown', this, !this._bubblingKeydown);
-    this._bubblingKeydown = value;
-    document.addEventListener('keydown', this, !this._bubblingKeydown);
-  }
-
-  /**
    * Get a plugin description.
    *
    * @param id - The ID of the plugin of interest.
@@ -623,7 +609,7 @@ export class Application<T extends Widget = Widget> {
    */
   protected addEventListeners(): void {
     if (this._bubblingKeydown) {
-      console.log('The keydown events are handled during bubbling phase');
+      console.debug('The keydown events are handled during bubbling phase');
     }
     document.addEventListener('contextmenu', this);
     document.addEventListener('keydown', this, !this._bubblingKeydown);

--- a/review/api/application.api.md
+++ b/review/api/application.api.md
@@ -17,8 +17,6 @@ export class Application<T extends Widget = Widget> {
     activatePlugin(id: string): Promise<void>;
     protected addEventListeners(): void;
     protected attachShell(id: string): void;
-    get bubblingKeydown(): boolean;
-    set bubblingKeydown(value: boolean);
     readonly commands: CommandRegistry;
     readonly contextMenu: ContextMenu;
     deactivatePlugin(id: string): Promise<string[]>;


### PR DESCRIPTION
This PR is a follow up of https://github.com/jupyterlab/lumino/pull/635, to remove an experimental implementation.

The keyboard event mode cannot be dynamically set up anymore, only when the application starts.