### PR TITLE
Update versions for a new release

### DIFF
--- a/examples/example-accordionpanel/package.json
+++ b/examples/example-accordionpanel/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@lumino/example-accordionpanel",
-  "version": "2.1.4-alpha.0",
+  "version": "2.1.4",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/default-theme": "^2.1.4-alpha.0",
+    "@lumino/default-theme": "^2.1.4",
     "@lumino/messaging": "^2.0.1",
-    "@lumino/widgets": "^2.3.1-alpha.0"
+    "@lumino/widgets": "^2.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/examples/example-datagrid/package.json
+++ b/examples/example-datagrid/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@lumino/example-datagrid",
-  "version": "2.1.4-alpha.0",
+  "version": "2.1.4",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/datagrid": "^2.3.0-alpha.0",
-    "@lumino/default-theme": "^2.1.4-alpha.0",
-    "@lumino/dragdrop": "^2.1.3",
-    "@lumino/widgets": "^2.3.1-alpha.0"
+    "@lumino/datagrid": "^2.3.0",
+    "@lumino/default-theme": "^2.1.4",
+    "@lumino/dragdrop": "^2.1.4",
+    "@lumino/widgets": "^2.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/examples/example-dockpanel/package.json
+++ b/examples/example-dockpanel/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@lumino/example-dockpanel",
-  "version": "2.1.4-alpha.0",
+  "version": "2.1.4",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/commands": "^2.1.3",
-    "@lumino/default-theme": "^2.1.4-alpha.0",
-    "@lumino/dragdrop": "^2.1.3",
+    "@lumino/commands": "^2.2.0",
+    "@lumino/default-theme": "^2.1.4",
+    "@lumino/dragdrop": "^2.1.4",
     "@lumino/messaging": "^2.0.1",
-    "@lumino/widgets": "^2.3.1-alpha.0"
+    "@lumino/widgets": "^2.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/examples/example-menubar/package.json
+++ b/examples/example-menubar/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@lumino/example-menubar",
-  "version": "2.1.4-alpha.0",
+  "version": "2.1.4",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/default-theme": "^2.1.4-alpha.0",
+    "@lumino/default-theme": "^2.1.4",
     "@lumino/messaging": "^2.0.1",
-    "@lumino/widgets": "^2.3.1-alpha.0"
+    "@lumino/widgets": "^2.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/application",
-  "version": "2.3.0-alpha.0",
+  "version": "2.3.0",
   "description": "Lumino Pluggable Application",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -44,9 +44,9 @@
     "displayName": "application"
   },
   "dependencies": {
-    "@lumino/commands": "^2.1.3",
+    "@lumino/commands": "^2.2.0",
     "@lumino/coreutils": "^2.1.2",
-    "@lumino/widgets": "^2.3.1-alpha.0"
+    "@lumino/widgets": "^2.3.1"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/commands",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Lumino Commands",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/datagrid",
-  "version": "2.3.0-alpha.0",
+  "version": "2.3.0",
   "description": "Lumino Tabular Data Grid",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -55,11 +55,11 @@
     "@lumino/coreutils": "^2.1.2",
     "@lumino/disposable": "^2.1.2",
     "@lumino/domutils": "^2.0.1",
-    "@lumino/dragdrop": "^2.1.3",
+    "@lumino/dragdrop": "^2.1.4",
     "@lumino/keyboard": "^2.0.1",
     "@lumino/messaging": "^2.0.1",
     "@lumino/signaling": "^2.1.2",
-    "@lumino/widgets": "^2.3.1-alpha.0"
+    "@lumino/widgets": "^2.3.1"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/default-theme",
-  "version": "2.1.4-alpha.0",
+  "version": "2.1.4",
   "description": "Lumino Default Theme",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -23,8 +23,8 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "dependencies": {
-    "@lumino/dragdrop": "^2.1.3",
-    "@lumino/widgets": "^2.3.1-alpha.0"
+    "@lumino/dragdrop": "^2.1.4",
+    "@lumino/widgets": "^2.3.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/dragdrop",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Lumino Drag and Drop",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/widgets",
-  "version": "2.3.1-alpha.0",
+  "version": "2.3.1",
   "description": "Lumino Widgets",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -55,11 +55,11 @@
   },
   "dependencies": {
     "@lumino/algorithm": "^2.0.1",
-    "@lumino/commands": "^2.1.3",
+    "@lumino/commands": "^2.2.0",
     "@lumino/coreutils": "^2.1.2",
     "@lumino/disposable": "^2.1.2",
     "@lumino/domutils": "^2.0.1",
-    "@lumino/dragdrop": "^2.1.3",
+    "@lumino/dragdrop": "^2.1.4",
     "@lumino/keyboard": "^2.0.1",
     "@lumino/messaging": "^2.0.1",
     "@lumino/properties": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,9 +309,9 @@ __metadata:
   resolution: "@lumino/application@workspace:packages/application"
   dependencies:
     "@lumino/buildutils": ^2.0.1
-    "@lumino/commands": ^2.1.3
+    "@lumino/commands": ^2.2.0
     "@lumino/coreutils": ^2.1.2
-    "@lumino/widgets": ^2.3.1-alpha.0
+    "@lumino/widgets": ^2.3.1
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -382,7 +382,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/commands@^2.1.3, @lumino/commands@workspace:packages/commands":
+"@lumino/commands@^2.2.0, @lumino/commands@workspace:packages/commands":
   version: 0.0.0-use.local
   resolution: "@lumino/commands@workspace:packages/commands"
   dependencies:
@@ -449,7 +449,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/datagrid@^2.3.0-alpha.0, @lumino/datagrid@workspace:packages/datagrid":
+"@lumino/datagrid@^2.3.0, @lumino/datagrid@workspace:packages/datagrid":
   version: 0.0.0-use.local
   resolution: "@lumino/datagrid@workspace:packages/datagrid"
   dependencies:
@@ -458,11 +458,11 @@ __metadata:
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/domutils": ^2.0.1
-    "@lumino/dragdrop": ^2.1.3
+    "@lumino/dragdrop": ^2.1.4
     "@lumino/keyboard": ^2.0.1
     "@lumino/messaging": ^2.0.1
     "@lumino/signaling": ^2.1.2
-    "@lumino/widgets": ^2.3.1-alpha.0
+    "@lumino/widgets": ^2.3.1
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -488,12 +488,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/default-theme@^2.1.4-alpha.0, @lumino/default-theme@workspace:packages/default-theme":
+"@lumino/default-theme@^2.1.4, @lumino/default-theme@workspace:packages/default-theme":
   version: 0.0.0-use.local
   resolution: "@lumino/default-theme@workspace:packages/default-theme"
   dependencies:
-    "@lumino/dragdrop": ^2.1.3
-    "@lumino/widgets": ^2.3.1-alpha.0
+    "@lumino/dragdrop": ^2.1.4
+    "@lumino/widgets": ^2.3.1
   languageName: unknown
   linkType: soft
 
@@ -558,7 +558,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/dragdrop@^2.1.3, @lumino/dragdrop@workspace:packages/dragdrop":
+"@lumino/dragdrop@^2.1.4, @lumino/dragdrop@workspace:packages/dragdrop":
   version: 0.0.0-use.local
   resolution: "@lumino/dragdrop@workspace:packages/dragdrop"
   dependencies:
@@ -596,9 +596,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-accordionpanel@workspace:examples/example-accordionpanel"
   dependencies:
-    "@lumino/default-theme": ^2.1.4-alpha.0
+    "@lumino/default-theme": ^2.1.4
     "@lumino/messaging": ^2.0.1
-    "@lumino/widgets": ^2.3.1-alpha.0
+    "@lumino/widgets": ^2.3.1
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -611,10 +611,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-datagrid@workspace:examples/example-datagrid"
   dependencies:
-    "@lumino/datagrid": ^2.3.0-alpha.0
-    "@lumino/default-theme": ^2.1.4-alpha.0
-    "@lumino/dragdrop": ^2.1.3
-    "@lumino/widgets": ^2.3.1-alpha.0
+    "@lumino/datagrid": ^2.3.0
+    "@lumino/default-theme": ^2.1.4
+    "@lumino/dragdrop": ^2.1.4
+    "@lumino/widgets": ^2.3.1
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -643,11 +643,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-dockpanel@workspace:examples/example-dockpanel"
   dependencies:
-    "@lumino/commands": ^2.1.3
-    "@lumino/default-theme": ^2.1.4-alpha.0
-    "@lumino/dragdrop": ^2.1.3
+    "@lumino/commands": ^2.2.0
+    "@lumino/default-theme": ^2.1.4
+    "@lumino/dragdrop": ^2.1.4
     "@lumino/messaging": ^2.0.1
-    "@lumino/widgets": ^2.3.1-alpha.0
+    "@lumino/widgets": ^2.3.1
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -660,9 +660,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-menubar@workspace:examples/example-menubar"
   dependencies:
-    "@lumino/default-theme": ^2.1.4-alpha.0
+    "@lumino/default-theme": ^2.1.4
     "@lumino/messaging": ^2.0.1
-    "@lumino/widgets": ^2.3.1-alpha.0
+    "@lumino/widgets": ^2.3.1
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -870,17 +870,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/widgets@^2.3.1-alpha.0, @lumino/widgets@workspace:packages/widgets":
+"@lumino/widgets@^2.3.1, @lumino/widgets@workspace:packages/widgets":
   version: 0.0.0-use.local
   resolution: "@lumino/widgets@workspace:packages/widgets"
   dependencies:
     "@lumino/algorithm": ^2.0.1
     "@lumino/buildutils": ^2.0.1
-    "@lumino/commands": ^2.1.3
+    "@lumino/commands": ^2.2.0
     "@lumino/coreutils": ^2.1.2
     "@lumino/disposable": ^2.1.2
     "@lumino/domutils": ^2.0.1
-    "@lumino/dragdrop": ^2.1.3
+    "@lumino/dragdrop": ^2.1.4
     "@lumino/keyboard": ^2.0.1
     "@lumino/messaging": ^2.0.1
     "@lumino/properties": ^2.0.1


### PR DESCRIPTION
This follows an earlier [v2023.9.25-alpha.0](https://github.com/jupyterlab/lumino/releases/tag/v2023.9.25-alpha.0).