### PR TITLE
Skip processing prevented default key event

### DIFF
--- a/packages/commands/src/index.ts
+++ b/packages/commands/src/index.ts
@@ -511,8 +511,13 @@ export class CommandRegistry {
    * events will not invoke commands.
    */
   processKeydownEvent(event: KeyboardEvent): void {
-    // Bail immediately if playing back keystrokes.
-    if (this._replaying || CommandRegistry.isModifierKeyPressed(event)) {
+    // Bail immediately if playing back keystrokes
+    // or if the event has been processed
+    if (
+      event.defaultPrevented ||
+      this._replaying ||
+      CommandRegistry.isModifierKeyPressed(event)
+    ) {
       return;
     }
 

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -797,6 +797,30 @@ describe('@lumino/commands', () => {
         expect(count).to.equal(0);
       });
 
+      it('should not dispatch on a prevented keydown event', () => {
+        let called = false;
+        registry.addCommand('test', {
+          execute: args => {
+            called = true;
+          }
+        });
+        registry.addKeyBinding({
+          keys: ['Ctrl ;'],
+          selector: `#${elem.id}`,
+          command: 'test'
+        });
+        const event = new KeyboardEvent('keydown', {
+          keyCode: 59,
+          ctrlKey: true,
+          cancelable: true
+        });
+
+        event.preventDefault();
+
+        elem.dispatchEvent(event);
+        expect(called).to.equal(false);
+      });
+
       it('should dispatch with multiple chords in a key sequence', () => {
         let count = 0;
         registry.addCommand('test', {


### PR DESCRIPTION
This removes the processing of keydown event by the commands registry if it is prevented (aka already treated).