### PR TITLE
Optional prevent default and asynchronous hold for keybinding execution

### DIFF
--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -821,6 +821,70 @@ describe('@lumino/commands', () => {
         expect(called).to.equal(false);
       });
 
+      it('should prevent default on dispatch', () => {
+        registry.addCommand('test', {
+          execute: () => void 0
+        });
+        registry.addKeyBinding({
+          keys: ['Ctrl ;'],
+          selector: `#${elem.id}`,
+          command: 'test'
+        });
+        const event = new KeyboardEvent('keydown', {
+          keyCode: 59,
+          ctrlKey: true
+        });
+        let defaultPrevented = false;
+        event.preventDefault = () => {
+          defaultPrevented = true;
+        };
+        elem.dispatchEvent(event);
+        expect(defaultPrevented).to.equal(true);
+      });
+
+      it('should not prevent default when sequence does not match', () => {
+        registry.addCommand('test', {
+          execute: () => void 0
+        });
+        registry.addKeyBinding({
+          keys: ['Ctrl ;'],
+          selector: `#${elem.id}`,
+          command: 'test'
+        });
+        const event = new KeyboardEvent('keydown', {
+          keyCode: 59,
+          ctrlKey: false
+        });
+        let defaultPrevented = false;
+        event.preventDefault = () => {
+          defaultPrevented = true;
+        };
+        elem.dispatchEvent(event);
+        expect(defaultPrevented).to.equal(false);
+      });
+
+      it('should not prevent default if keybinding opts out', () => {
+        registry.addCommand('test', {
+          execute: () => void 0
+        });
+        registry.addKeyBinding({
+          keys: ['Ctrl ;'],
+          selector: `#${elem.id}`,
+          command: 'test',
+          preventDefault: false
+        });
+        const event = new KeyboardEvent('keydown', {
+          keyCode: 59,
+          ctrlKey: true
+        });
+        let defaultPrevented = false;
+        event.preventDefault = () => {
+          defaultPrevented = true;
+        };
+        elem.dispatchEvent(event);
+        expect(defaultPrevented).to.equal(false);
+      });
+
       it('should dispatch with multiple chords in a key sequence', () => {
         let count = 0;
         registry.addCommand('test', {

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -1322,6 +1322,50 @@ describe('@lumino/commands', () => {
       });
     });
 
+    describe('.holdKeyBindingExecution()', () => {
+      it('should proceed with command execution if permission of the event resolves to true', () => {
+        let called = false;
+        registry.addCommand('test', {
+          execute: () => {
+            called = true;
+          }
+        });
+        registry.addKeyBinding({
+          keys: ['Ctrl ;'],
+          selector: `#${elem.id}`,
+          command: 'test'
+        });
+        const event = new KeyboardEvent('keydown', {
+          keyCode: 59,
+          ctrlKey: true
+        });
+        registry.holdKeyBindingExecution(event, Promise.resolve(true));
+        elem.dispatchEvent(event);
+        expect(called).to.equal(false);
+      });
+
+      it('should prevent command execution if permission of the event resolves to false', () => {
+        let called = false;
+        registry.addCommand('test', {
+          execute: () => {
+            called = true;
+          }
+        });
+        registry.addKeyBinding({
+          keys: ['Ctrl ;'],
+          selector: `#${elem.id}`,
+          command: 'test'
+        });
+        const event = new KeyboardEvent('keydown', {
+          keyCode: 59,
+          ctrlKey: true
+        });
+        registry.holdKeyBindingExecution(event, Promise.resolve(false));
+        elem.dispatchEvent(event);
+        expect(called).to.equal(false);
+      });
+    });
+
     describe('.parseKeystroke()', () => {
       it('should parse a keystroke into its parts', () => {
         let parts = CommandRegistry.parseKeystroke('Ctrl Shift Alt S');

--- a/packages/commands/tests/src/index.spec.ts
+++ b/packages/commands/tests/src/index.spec.ts
@@ -1374,6 +1374,31 @@ describe('@lumino/commands', () => {
         const called = await calledPromise;
         expect(called).to.equal(false);
       });
+
+      it('should prevent command execution if permission for any of the events resolves to false', async () => {
+        registry.addCommand('test', {
+          execute
+        });
+        registry.addKeyBinding({
+          keys: ['Shift ['],
+          selector: `#${elem.id}`,
+          command: 'test'
+        });
+        const shiftEvent = new KeyboardEvent('keydown', {
+          keyCode: 16,
+          shiftKey: true
+        });
+        const bracketEvent = new KeyboardEvent('keydown', {
+          keyCode: 219,
+          shiftKey: true
+        });
+        registry.holdKeyBindingExecution(shiftEvent, Promise.resolve(true));
+        registry.holdKeyBindingExecution(bracketEvent, Promise.resolve(false));
+        elem.dispatchEvent(shiftEvent);
+        elem.dispatchEvent(bracketEvent);
+        const called = await calledPromise;
+        expect(called).to.equal(false);
+      });
     });
 
     describe('.parseKeystroke()', () => {

--- a/review/api/commands.api.md
+++ b/review/api/commands.api.md
@@ -22,6 +22,7 @@ export class CommandRegistry {
     describedBy(id: string, args?: ReadonlyPartialJSONObject): Promise<CommandRegistry.Description>;
     execute(id: string, args?: ReadonlyPartialJSONObject): Promise<any>;
     hasCommand(id: string): boolean;
+    holdKeyBindingExecution(event: KeyboardEvent, permission: Promise<boolean>): void;
     icon(id: string, args?: ReadonlyPartialJSONObject): VirtualElement.IRenderer | undefined;
     iconClass(id: string, args?: ReadonlyPartialJSONObject): string;
     iconLabel(id: string, args?: ReadonlyPartialJSONObject): string;
@@ -79,6 +80,7 @@ export namespace CommandRegistry {
         readonly args: ReadonlyPartialJSONObject;
         readonly command: string;
         readonly keys: ReadonlyArray<string>;
+        readonly preventDefault?: boolean;
         readonly selector: string;
     }
     export interface IKeyBindingChangedArgs {
@@ -91,6 +93,7 @@ export namespace CommandRegistry {
         keys: string[];
         linuxKeys?: string[];
         macKeys?: string[];
+        preventDefault?: boolean;
         selector: string;
         winKeys?: string[];
     }


### PR DESCRIPTION
Closes https://github.com/jupyterlab/lumino/issues/688

- Adds `preventDefault` option to `IKeyBinding` and `IKeyBindingOptions` to enable downstreams to opt out of preventing default on the processed keyboard events
- Adds `CommandRegistry.holdKeyBindingExecution(event: KeyboardEvent, permission: Promise<boolean>): void;` method which enables downstream to hold the execution of a keybinding until the permission to execute resolves to `true`, or to prevent it if it resolves with `false`