### PR TITLE
Bump versions and fix yarn installation in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,6 @@ jobs:
         shell: bash
         run: |
           set -eux
-          npm install -g yarn
           yarn
 
       - name: Build Source
@@ -73,7 +72,6 @@ jobs:
         shell: bash
         run: |
           set -eux
-          npm install -g yarn
           yarn
 
       - name: Check linters

--- a/examples/example-accordionpanel/package.json
+++ b/examples/example-accordionpanel/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@lumino/example-accordionpanel",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/default-theme": "^2.1.5",
-    "@lumino/messaging": "^2.0.1",
-    "@lumino/widgets": "^2.3.2"
+    "@lumino/default-theme": "^2.1.6",
+    "@lumino/messaging": "^2.0.2",
+    "@lumino/widgets": "^2.4.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/examples/example-datagrid/package.json
+++ b/examples/example-datagrid/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@lumino/example-datagrid",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/datagrid": "^2.3.1",
-    "@lumino/default-theme": "^2.1.5",
-    "@lumino/dragdrop": "^2.1.4",
-    "@lumino/widgets": "^2.3.2"
+    "@lumino/datagrid": "^2.4.0",
+    "@lumino/default-theme": "^2.1.6",
+    "@lumino/dragdrop": "^2.1.5",
+    "@lumino/widgets": "^2.4.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/examples/example-dockpanel-amd/package.json
+++ b/examples/example-dockpanel-amd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/example-dockpanel-amd",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
     "test": "playwright test"

--- a/examples/example-dockpanel-iife/package.json
+++ b/examples/example-dockpanel-iife/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/example-dockpanel-iife",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
     "test": "playwright test"

--- a/examples/example-dockpanel/package.json
+++ b/examples/example-dockpanel/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@lumino/example-dockpanel",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/commands": "^2.3.0",
-    "@lumino/default-theme": "^2.1.5",
-    "@lumino/dragdrop": "^2.1.4",
-    "@lumino/messaging": "^2.0.1",
-    "@lumino/widgets": "^2.3.2"
+    "@lumino/commands": "^2.3.1",
+    "@lumino/default-theme": "^2.1.6",
+    "@lumino/dragdrop": "^2.1.5",
+    "@lumino/messaging": "^2.0.2",
+    "@lumino/widgets": "^2.4.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/examples/example-menubar/package.json
+++ b/examples/example-menubar/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@lumino/example-menubar",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/default-theme": "^2.1.5",
-    "@lumino/messaging": "^2.0.1",
-    "@lumino/widgets": "^2.3.2"
+    "@lumino/default-theme": "^2.1.6",
+    "@lumino/messaging": "^2.0.2",
+    "@lumino/widgets": "^2.4.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/examples/example-nested-dockpanel-amd/package.json
+++ b/examples/example-nested-dockpanel-amd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/example-nested-dockpanel-amd",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
     "test": "playwright test"

--- a/packages/algorithm/package.json
+++ b/packages/algorithm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/algorithm",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Lumino Algorithms and Iterators",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/application",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Lumino Pluggable Application",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -38,9 +38,9 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/commands": "^2.3.0",
-    "@lumino/coreutils": "^2.1.2",
-    "@lumino/widgets": "^2.3.2"
+    "@lumino/commands": "^2.3.1",
+    "@lumino/coreutils": "^2.2.0",
+    "@lumino/widgets": "^2.4.0"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/collections",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Lumino Generic Collections",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -38,7 +38,7 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/algorithm": "^2.0.1"
+    "@lumino/algorithm": "^2.0.2"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/commands",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Lumino Commands",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -38,13 +38,13 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/algorithm": "^2.0.1",
-    "@lumino/coreutils": "^2.1.2",
-    "@lumino/disposable": "^2.1.2",
-    "@lumino/domutils": "^2.0.1",
-    "@lumino/keyboard": "^2.0.1",
-    "@lumino/signaling": "^2.1.2",
-    "@lumino/virtualdom": "^2.0.1"
+    "@lumino/algorithm": "^2.0.2",
+    "@lumino/coreutils": "^2.2.0",
+    "@lumino/disposable": "^2.1.3",
+    "@lumino/domutils": "^2.0.2",
+    "@lumino/keyboard": "^2.0.2",
+    "@lumino/signaling": "^2.1.3",
+    "@lumino/virtualdom": "^2.0.2"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/coreutils/package.json
+++ b/packages/coreutils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/coreutils",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Lumino Core Utilities",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -40,7 +40,7 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/algorithm": "^2.0.1"
+    "@lumino/algorithm": "^2.0.2"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/datagrid",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Lumino Tabular Data Grid",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -38,15 +38,15 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/algorithm": "^2.0.1",
-    "@lumino/coreutils": "^2.1.2",
-    "@lumino/disposable": "^2.1.2",
-    "@lumino/domutils": "^2.0.1",
-    "@lumino/dragdrop": "^2.1.4",
-    "@lumino/keyboard": "^2.0.1",
-    "@lumino/messaging": "^2.0.1",
-    "@lumino/signaling": "^2.1.2",
-    "@lumino/widgets": "^2.3.2"
+    "@lumino/algorithm": "^2.0.2",
+    "@lumino/coreutils": "^2.2.0",
+    "@lumino/disposable": "^2.1.3",
+    "@lumino/domutils": "^2.0.2",
+    "@lumino/dragdrop": "^2.1.5",
+    "@lumino/keyboard": "^2.0.2",
+    "@lumino/messaging": "^2.0.2",
+    "@lumino/signaling": "^2.1.3",
+    "@lumino/widgets": "^2.4.0"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/default-theme",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "Lumino Default Theme",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -23,8 +23,8 @@
     "url": "https://github.com/jupyterlab/lumino.git"
   },
   "dependencies": {
-    "@lumino/dragdrop": "^2.1.4",
-    "@lumino/widgets": "^2.3.2"
+    "@lumino/dragdrop": "^2.1.5",
+    "@lumino/widgets": "^2.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/disposable/package.json
+++ b/packages/disposable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/disposable",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Lumino Disposable",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -38,7 +38,7 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/signaling": "^2.1.2"
+    "@lumino/signaling": "^2.1.3"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/domutils/package.json
+++ b/packages/domutils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/domutils",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Lumino DOM Utilities",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {

--- a/packages/dragdrop/package.json
+++ b/packages/dragdrop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/dragdrop",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Lumino Drag and Drop",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -41,8 +41,8 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/coreutils": "^2.1.2",
-    "@lumino/disposable": "^2.1.2"
+    "@lumino/coreutils": "^2.2.0",
+    "@lumino/disposable": "^2.1.3"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/keyboard",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Lumino Keyboard",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/messaging",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Lumino Message Passing",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -38,8 +38,8 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/algorithm": "^2.0.1",
-    "@lumino/collections": "^2.0.1"
+    "@lumino/algorithm": "^2.0.2",
+    "@lumino/collections": "^2.0.2"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/polling/package.json
+++ b/packages/polling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/polling",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Lumino Polling",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -38,9 +38,9 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/coreutils": "^2.1.2",
-    "@lumino/disposable": "^2.1.2",
-    "@lumino/signaling": "^2.1.2"
+    "@lumino/coreutils": "^2.2.0",
+    "@lumino/disposable": "^2.1.3",
+    "@lumino/signaling": "^2.1.3"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/properties",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Lumino Attached Properties",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {

--- a/packages/signaling/package.json
+++ b/packages/signaling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/signaling",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Lumino Signals and Slots",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -38,8 +38,8 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/algorithm": "^2.0.1",
-    "@lumino/coreutils": "^2.1.2"
+    "@lumino/algorithm": "^2.0.2",
+    "@lumino/coreutils": "^2.2.0"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/virtualdom/package.json
+++ b/packages/virtualdom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/virtualdom",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Lumino Virtual DOM",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -38,7 +38,7 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/algorithm": "^2.0.1"
+    "@lumino/algorithm": "^2.0.2"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/widgets",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Lumino Widgets",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -41,17 +41,17 @@
     "watch": "tsc --build --watch"
   },
   "dependencies": {
-    "@lumino/algorithm": "^2.0.1",
-    "@lumino/commands": "^2.3.0",
-    "@lumino/coreutils": "^2.1.2",
-    "@lumino/disposable": "^2.1.2",
-    "@lumino/domutils": "^2.0.1",
-    "@lumino/dragdrop": "^2.1.4",
-    "@lumino/keyboard": "^2.0.1",
-    "@lumino/messaging": "^2.0.1",
-    "@lumino/properties": "^2.0.1",
-    "@lumino/signaling": "^2.1.2",
-    "@lumino/virtualdom": "^2.0.1"
+    "@lumino/algorithm": "^2.0.2",
+    "@lumino/commands": "^2.3.1",
+    "@lumino/coreutils": "^2.2.0",
+    "@lumino/disposable": "^2.1.3",
+    "@lumino/domutils": "^2.0.2",
+    "@lumino/dragdrop": "^2.1.5",
+    "@lumino/keyboard": "^2.0.2",
+    "@lumino/messaging": "^2.0.2",
+    "@lumino/properties": "^2.0.2",
+    "@lumino/signaling": "^2.1.3",
+    "@lumino/virtualdom": "^2.0.2"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,7 +279,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/algorithm@^2.0.1, @lumino/algorithm@workspace:packages/algorithm":
+"@lumino/algorithm@^2.0.2, @lumino/algorithm@workspace:packages/algorithm":
   version: 0.0.0-use.local
   resolution: "@lumino/algorithm@workspace:packages/algorithm"
   dependencies:
@@ -309,9 +309,9 @@ __metadata:
   resolution: "@lumino/application@workspace:packages/application"
   dependencies:
     "@lumino/buildutils": ^2.0.1
-    "@lumino/commands": ^2.3.0
-    "@lumino/coreutils": ^2.1.2
-    "@lumino/widgets": ^2.3.2
+    "@lumino/commands": ^2.3.1
+    "@lumino/coreutils": ^2.2.0
+    "@lumino/widgets": ^2.4.0
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -346,11 +346,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/collections@^2.0.1, @lumino/collections@workspace:packages/collections":
+"@lumino/collections@^2.0.2, @lumino/collections@workspace:packages/collections":
   version: 0.0.0-use.local
   resolution: "@lumino/collections@workspace:packages/collections"
   dependencies:
-    "@lumino/algorithm": ^2.0.1
+    "@lumino/algorithm": ^2.0.2
     "@lumino/buildutils": ^2.0.1
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
@@ -372,18 +372,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/commands@^2.3.0, @lumino/commands@workspace:packages/commands":
+"@lumino/commands@^2.3.1, @lumino/commands@workspace:packages/commands":
   version: 0.0.0-use.local
   resolution: "@lumino/commands@workspace:packages/commands"
   dependencies:
-    "@lumino/algorithm": ^2.0.1
+    "@lumino/algorithm": ^2.0.2
     "@lumino/buildutils": ^2.0.1
-    "@lumino/coreutils": ^2.1.2
-    "@lumino/disposable": ^2.1.2
-    "@lumino/domutils": ^2.0.1
-    "@lumino/keyboard": ^2.0.1
-    "@lumino/signaling": ^2.1.2
-    "@lumino/virtualdom": ^2.0.1
+    "@lumino/coreutils": ^2.2.0
+    "@lumino/disposable": ^2.1.3
+    "@lumino/domutils": ^2.0.2
+    "@lumino/keyboard": ^2.0.2
+    "@lumino/signaling": ^2.1.3
+    "@lumino/virtualdom": ^2.0.2
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -404,11 +404,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/coreutils@^2.1.2, @lumino/coreutils@workspace:packages/coreutils":
+"@lumino/coreutils@^2.2.0, @lumino/coreutils@workspace:packages/coreutils":
   version: 0.0.0-use.local
   resolution: "@lumino/coreutils@workspace:packages/coreutils"
   dependencies:
-    "@lumino/algorithm": ^2.0.1
+    "@lumino/algorithm": ^2.0.2
     "@lumino/buildutils": ^2.0.1
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
@@ -430,20 +430,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/datagrid@^2.3.1, @lumino/datagrid@workspace:packages/datagrid":
+"@lumino/datagrid@^2.4.0, @lumino/datagrid@workspace:packages/datagrid":
   version: 0.0.0-use.local
   resolution: "@lumino/datagrid@workspace:packages/datagrid"
   dependencies:
-    "@lumino/algorithm": ^2.0.1
+    "@lumino/algorithm": ^2.0.2
     "@lumino/buildutils": ^2.0.1
-    "@lumino/coreutils": ^2.1.2
-    "@lumino/disposable": ^2.1.2
-    "@lumino/domutils": ^2.0.1
-    "@lumino/dragdrop": ^2.1.4
-    "@lumino/keyboard": ^2.0.1
-    "@lumino/messaging": ^2.0.1
-    "@lumino/signaling": ^2.1.2
-    "@lumino/widgets": ^2.3.2
+    "@lumino/coreutils": ^2.2.0
+    "@lumino/disposable": ^2.1.3
+    "@lumino/domutils": ^2.0.2
+    "@lumino/dragdrop": ^2.1.5
+    "@lumino/keyboard": ^2.0.2
+    "@lumino/messaging": ^2.0.2
+    "@lumino/signaling": ^2.1.3
+    "@lumino/widgets": ^2.4.0
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -464,21 +464,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/default-theme@^2.1.5, @lumino/default-theme@workspace:packages/default-theme":
+"@lumino/default-theme@^2.1.6, @lumino/default-theme@workspace:packages/default-theme":
   version: 0.0.0-use.local
   resolution: "@lumino/default-theme@workspace:packages/default-theme"
   dependencies:
-    "@lumino/dragdrop": ^2.1.4
-    "@lumino/widgets": ^2.3.2
+    "@lumino/dragdrop": ^2.1.5
+    "@lumino/widgets": ^2.4.0
   languageName: unknown
   linkType: soft
 
-"@lumino/disposable@^2.1.2, @lumino/disposable@workspace:packages/disposable":
+"@lumino/disposable@^2.1.3, @lumino/disposable@workspace:packages/disposable":
   version: 0.0.0-use.local
   resolution: "@lumino/disposable@workspace:packages/disposable"
   dependencies:
     "@lumino/buildutils": ^2.0.1
-    "@lumino/signaling": ^2.1.2
+    "@lumino/signaling": ^2.1.3
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -499,7 +499,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/domutils@^2.0.1, @lumino/domutils@workspace:packages/domutils":
+"@lumino/domutils@^2.0.2, @lumino/domutils@workspace:packages/domutils":
   version: 0.0.0-use.local
   resolution: "@lumino/domutils@workspace:packages/domutils"
   dependencies:
@@ -524,13 +524,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/dragdrop@^2.1.4, @lumino/dragdrop@workspace:packages/dragdrop":
+"@lumino/dragdrop@^2.1.5, @lumino/dragdrop@workspace:packages/dragdrop":
   version: 0.0.0-use.local
   resolution: "@lumino/dragdrop@workspace:packages/dragdrop"
   dependencies:
     "@lumino/buildutils": ^2.0.1
-    "@lumino/coreutils": ^2.1.2
-    "@lumino/disposable": ^2.1.2
+    "@lumino/coreutils": ^2.2.0
+    "@lumino/disposable": ^2.1.3
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -556,9 +556,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-accordionpanel@workspace:examples/example-accordionpanel"
   dependencies:
-    "@lumino/default-theme": ^2.1.5
-    "@lumino/messaging": ^2.0.1
-    "@lumino/widgets": ^2.3.2
+    "@lumino/default-theme": ^2.1.6
+    "@lumino/messaging": ^2.0.2
+    "@lumino/widgets": ^2.4.0
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -571,10 +571,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-datagrid@workspace:examples/example-datagrid"
   dependencies:
-    "@lumino/datagrid": ^2.3.1
-    "@lumino/default-theme": ^2.1.5
-    "@lumino/dragdrop": ^2.1.4
-    "@lumino/widgets": ^2.3.2
+    "@lumino/datagrid": ^2.4.0
+    "@lumino/default-theme": ^2.1.6
+    "@lumino/dragdrop": ^2.1.5
+    "@lumino/widgets": ^2.4.0
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -603,11 +603,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-dockpanel@workspace:examples/example-dockpanel"
   dependencies:
-    "@lumino/commands": ^2.3.0
-    "@lumino/default-theme": ^2.1.5
-    "@lumino/dragdrop": ^2.1.4
-    "@lumino/messaging": ^2.0.1
-    "@lumino/widgets": ^2.3.2
+    "@lumino/commands": ^2.3.1
+    "@lumino/default-theme": ^2.1.6
+    "@lumino/dragdrop": ^2.1.5
+    "@lumino/messaging": ^2.0.2
+    "@lumino/widgets": ^2.4.0
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -620,9 +620,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-menubar@workspace:examples/example-menubar"
   dependencies:
-    "@lumino/default-theme": ^2.1.5
-    "@lumino/messaging": ^2.0.1
-    "@lumino/widgets": ^2.3.2
+    "@lumino/default-theme": ^2.1.6
+    "@lumino/messaging": ^2.0.2
+    "@lumino/widgets": ^2.4.0
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -639,7 +639,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/keyboard@^2.0.1, @lumino/keyboard@workspace:packages/keyboard":
+"@lumino/keyboard@^2.0.2, @lumino/keyboard@workspace:packages/keyboard":
   version: 0.0.0-use.local
   resolution: "@lumino/keyboard@workspace:packages/keyboard"
   dependencies:
@@ -664,13 +664,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/messaging@^2.0.1, @lumino/messaging@workspace:packages/messaging":
+"@lumino/messaging@^2.0.2, @lumino/messaging@workspace:packages/messaging":
   version: 0.0.0-use.local
   resolution: "@lumino/messaging@workspace:packages/messaging"
   dependencies:
-    "@lumino/algorithm": ^2.0.1
+    "@lumino/algorithm": ^2.0.2
     "@lumino/buildutils": ^2.0.1
-    "@lumino/collections": ^2.0.1
+    "@lumino/collections": ^2.0.2
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -697,9 +697,9 @@ __metadata:
   resolution: "@lumino/polling@workspace:packages/polling"
   dependencies:
     "@lumino/buildutils": ^2.0.1
-    "@lumino/coreutils": ^2.1.2
-    "@lumino/disposable": ^2.1.2
-    "@lumino/signaling": ^2.1.2
+    "@lumino/coreutils": ^2.2.0
+    "@lumino/disposable": ^2.1.3
+    "@lumino/signaling": ^2.1.3
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -721,7 +721,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/properties@^2.0.1, @lumino/properties@workspace:packages/properties":
+"@lumino/properties@^2.0.2, @lumino/properties@workspace:packages/properties":
   version: 0.0.0-use.local
   resolution: "@lumino/properties@workspace:packages/properties"
   dependencies:
@@ -746,13 +746,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/signaling@^2.1.2, @lumino/signaling@workspace:packages/signaling":
+"@lumino/signaling@^2.1.3, @lumino/signaling@workspace:packages/signaling":
   version: 0.0.0-use.local
   resolution: "@lumino/signaling@workspace:packages/signaling"
   dependencies:
-    "@lumino/algorithm": ^2.0.1
+    "@lumino/algorithm": ^2.0.2
     "@lumino/buildutils": ^2.0.1
-    "@lumino/coreutils": ^2.1.2
+    "@lumino/coreutils": ^2.2.0
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -774,11 +774,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/virtualdom@^2.0.1, @lumino/virtualdom@workspace:packages/virtualdom":
+"@lumino/virtualdom@^2.0.2, @lumino/virtualdom@workspace:packages/virtualdom":
   version: 0.0.0-use.local
   resolution: "@lumino/virtualdom@workspace:packages/virtualdom"
   dependencies:
-    "@lumino/algorithm": ^2.0.1
+    "@lumino/algorithm": ^2.0.2
     "@lumino/buildutils": ^2.0.1
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
@@ -800,22 +800,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/widgets@^2.3.2, @lumino/widgets@workspace:packages/widgets":
+"@lumino/widgets@^2.4.0, @lumino/widgets@workspace:packages/widgets":
   version: 0.0.0-use.local
   resolution: "@lumino/widgets@workspace:packages/widgets"
   dependencies:
-    "@lumino/algorithm": ^2.0.1
+    "@lumino/algorithm": ^2.0.2
     "@lumino/buildutils": ^2.0.1
-    "@lumino/commands": ^2.3.0
-    "@lumino/coreutils": ^2.1.2
-    "@lumino/disposable": ^2.1.2
-    "@lumino/domutils": ^2.0.1
-    "@lumino/dragdrop": ^2.1.4
-    "@lumino/keyboard": ^2.0.1
-    "@lumino/messaging": ^2.0.1
-    "@lumino/properties": ^2.0.1
-    "@lumino/signaling": ^2.1.2
-    "@lumino/virtualdom": ^2.0.1
+    "@lumino/commands": ^2.3.1
+    "@lumino/coreutils": ^2.2.0
+    "@lumino/disposable": ^2.1.3
+    "@lumino/domutils": ^2.0.2
+    "@lumino/dragdrop": ^2.1.5
+    "@lumino/keyboard": ^2.0.2
+    "@lumino/messaging": ^2.0.2
+    "@lumino/properties": ^2.0.2
+    "@lumino/signaling": ^2.1.3
+    "@lumino/virtualdom": ^2.0.2
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1


### PR DESCRIPTION
PRs included in the coming release:

* Accept individual modifier keys as valid keybindings by @g547315 in https://github.com/jupyterlab/lumino/pull/637
* Datagrid: Add a public API to get the current viewport by @martinRenou in https://github.com/jupyterlab/lumino/pull/695
* Support host and ref options in Menu.open by @ianthomas23 in https://github.com/jupyterlab/lumino/pull/700
* Extract plugin handling in a `PluginRegistry` class independent of the `Application` by @fcollonval in https://github.com/jupyterlab/lumino/pull/703
* Interleaves search results across categories by @JasonWeill in https://github.com/jupyterlab/lumino/pull/706
---
* Align typedoc config with JupyterLab by @fcollonval in https://github.com/jupyterlab/lumino/pull/696
* Switch from karma to web-test-runner by @fcollonval in https://github.com/jupyterlab/lumino/pull/704
* Don't bail early when running all tests by @fcollonval in https://github.com/jupyterlab/lumino/pull/707
---
* Bump the actions group with 1 update by @dependabot in https://github.com/jupyterlab/lumino/pull/694
* Bump ejs from 3.1.8 to 3.1.10 by @dependabot in https://github.com/jupyterlab/lumino/pull/702
* Bump the actions group with 2 updates by @dependabot in https://github.com/jupyterlab/lumino/pull/701
* Bump tj-actions/changed-files from 44.3.0 to 44.5.2 in the actions group by @dependabot in https://github.com/jupyterlab/lumino/pull/708
* Bump braces from 3.0.2 to 3.0.3 by @dependabot in https://github.com/jupyterlab/lumino/pull/710
