### PR TITLE
Remove the overflow rule on widgets

### DIFF
--- a/packages/widgets/style/widget.css
+++ b/packages/widgets/style/widget.css
@@ -15,7 +15,6 @@
 .lm-Widget {
   box-sizing: border-box;
   position: relative;
-  overflow: hidden;
 }
 
 .lm-Widget.lm-mod-hidden {


### PR DESCRIPTION
This removes the `overflow: hidden` CSS rule on widget.

The rationale behind this change is that 
* this is highly unexpected in the web
* it is very hard to work around as widget are nested within widgets that a app plugin does not control

It breaks the ability to have sub items overflow for example one having custom list picker or context menus in cell outputs.