### PR TITLE
[DataGrid] Add a feature to fit multiple column's width to their content

### DIFF
--- a/packages/datagrid/src/basicmousehandler.ts
+++ b/packages/datagrid/src/basicmousehandler.ts
@@ -641,8 +641,26 @@ export class BasicMouseHandler implements DataGrid.IMouseHandler {
             return;
           }
         }
-
-        grid.resizeColumn(colRegion, colIndex, null);
+        const cs = grid.selectionModel?.currentSelection();
+        const cv = grid.currentViewport;
+        const rowCount = grid.selectionModel?.dataModel.rowCount('body') ?? 0
+        if (colRegion == "body" && cs != null && cv != null && cs.r1 == 0 && cs.r2 == rowCount - 1){
+          // One or more columns are selected
+          let c1 = Math.max(Math.min(cs.c1, cs.c2), cv.firstColumn)
+          let c2 = Math.min(Math.max(cs.c1, cs.c2), cv.lastColumn)
+          if (c1 <= colIndex && colIndex <= c2){
+            // When we double-click one of the selected column headers, resize all visible selected columns.
+            for (let ci = c1; ci <= c2; ci++) {
+              grid.resizeColumn(colRegion, ci, null);
+            }
+          }else{
+            // When we double-click the column header outside the selection, resize only the clicked column.
+            grid.resizeColumn(colRegion, colIndex, null);
+          }
+        }else{
+          // When no columns are selected, resize only the clicked column.
+          grid.resizeColumn(colRegion, colIndex, null);
+        }
       }
     }
 


### PR DESCRIPTION
When I double-click the selected multiple column headers, I want to enable the multiple column widths to be fitted at once.

The version for the single column is implemented in #546.
In this PR, I extend this to support multiple visible columns.

I restricted resizing to the visible columns because of performance limitations. On my local machine, resizing a single column of trillion rows took 800 [ms]. So, resizing millions of columns will take hundreds of hours.

In my use case, I do not want to fit all columns. The goal is to display some columns of interest on one screen and compare their contents with minimum horizontal scrolling, so with this restriction, this feature makes enough practical sense.

The behavior of this implementation is as follows:

- When we double-click one of the selected column headers, resize all visible chosen columns.
- When we double-click the column header outside the selection, resize only the clicked column.
- When no columns are selected, resize only the clicked column.


This PR does not include a test code because I could not figure out how to implement the test code in such a case.
(ex, simulating a double click event at a specific header edge in a data-grid)
If there is any examples which I can refer, let me know and I will check them out.
