### PR TITLE
Add `horizontalAlignment` to `Menu.open()` options

### DIFF
--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -465,9 +465,10 @@ export class Menu extends Widget {
     let forceY = options.forceY || false;
     const host = options.host ?? null;
     const ref = options.ref ?? null;
+    const align = options.align ?? 'left';
 
     // Open the menu as a root menu.
-    Private.openRootMenu(this, x, y, forceX, forceY, host, ref);
+    Private.openRootMenu(this, x, y, forceX, forceY, align, host, ref);
 
     // Activate the menu to accept keyboard input.
     this.activate();
@@ -1561,6 +1562,7 @@ namespace Private {
     y: number,
     forceX: boolean,
     forceY: boolean,
+    align: 'left' | 'right',
     host: HTMLElement | null,
     ref: HTMLElement | null
   ): void {
@@ -1590,6 +1592,13 @@ namespace Private {
 
     // Measure the size of the menu.
     let { width, height } = node.getBoundingClientRect();
+
+    // align the menu to the right corner of the host
+    if (align === 'right') {
+      x -= width;
+    }
+
+
 
     // Adjust the X position of the menu to fit on-screen.
     if (!forceX && x + width > px + cw) {

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1012,6 +1012,11 @@ export namespace Menu {
      */
     ref?: HTMLElement;
 
+    /**
+     * The alignment of the menu.
+     *
+     * The default is `'left'` unless the document `dir` attribute is `'rtl'`
+     */
     align?: 'left' | 'right';
   }
 

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -470,7 +470,16 @@ export class Menu extends Widget {
       (document.documentElement.dir === 'rtl' ? 'right' : 'left');
 
     // Open the menu as a root menu.
-    Private.openRootMenu(this, x, y, forceX, forceY, horizontalAlignment, host, ref);
+    Private.openRootMenu(
+      this,
+      x,
+      y,
+      forceX,
+      forceY,
+      horizontalAlignment,
+      host,
+      ref
+    );
 
     // Activate the menu to accept keyboard input.
     this.activate();

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1009,6 +1009,8 @@ export namespace Menu {
      * menu to be added as the last child of the host.
      */
     ref?: HTMLElement;
+
+    align?: 'left' | 'right';
   }
 
   /**

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -465,12 +465,12 @@ export class Menu extends Widget {
     let forceY = options.forceY || false;
     const host = options.host ?? null;
     const ref = options.ref ?? null;
-    const align =
-      options.align ??
+    const horizontalAlignment =
+      options.horizontalAlignment ??
       (document.documentElement.dir === 'rtl' ? 'right' : 'left');
 
     // Open the menu as a root menu.
-    Private.openRootMenu(this, x, y, forceX, forceY, align, host, ref);
+    Private.openRootMenu(this, x, y, forceX, forceY, horizontalAlignment, host, ref);
 
     // Activate the menu to accept keyboard input.
     this.activate();
@@ -1018,7 +1018,7 @@ export namespace Menu {
      *
      * The default is `'left'` unless the document `dir` attribute is `'rtl'`
      */
-    align?: 'left' | 'right';
+    horizontalAlignment?: 'left' | 'right';
   }
 
   /**
@@ -1569,7 +1569,7 @@ namespace Private {
     y: number,
     forceX: boolean,
     forceY: boolean,
-    align: 'left' | 'right',
+    horizontalAlignment: 'left' | 'right',
     host: HTMLElement | null,
     ref: HTMLElement | null
   ): void {
@@ -1601,7 +1601,7 @@ namespace Private {
     let { width, height } = node.getBoundingClientRect();
 
     // align the menu to the right of the target if requested or language is RTL
-    if (align === 'right') {
+    if (horizontalAlignment === 'right') {
       x -= width;
     }
 

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -465,7 +465,8 @@ export class Menu extends Widget {
     let forceY = options.forceY || false;
     const host = options.host ?? null;
     const ref = options.ref ?? null;
-    const align = options.align ?? 'left';
+    const align = options.align ?? (document.documentElement.dir === 'rtl' ? 'right' : 'left');
+
 
     // Open the menu as a root menu.
     Private.openRootMenu(this, x, y, forceX, forceY, align, host, ref);
@@ -1593,12 +1594,10 @@ namespace Private {
     // Measure the size of the menu.
     let { width, height } = node.getBoundingClientRect();
 
-    // align the menu to the right corner of the host
+    // align the menu to the right of the target if requested or language is RTL
     if (align === 'right') {
       x -= width;
     }
-
-
 
     // Adjust the X position of the menu to fit on-screen.
     if (!forceX && x + width > px + cw) {

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -465,8 +465,9 @@ export class Menu extends Widget {
     let forceY = options.forceY || false;
     const host = options.host ?? null;
     const ref = options.ref ?? null;
-    const align = options.align ?? (document.documentElement.dir === 'rtl' ? 'right' : 'left');
-
+    const align =
+      options.align ??
+      (document.documentElement.dir === 'rtl' ? 'right' : 'left');
 
     // Open the menu as a root menu.
     Private.openRootMenu(this, x, y, forceX, forceY, align, host, ref);

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -606,10 +606,20 @@ describe('@lumino/widgets', () => {
 
       it('should accept align menu flags', () => {
         menu.addItem({ command: 'test' });
-        menu.open(100, 100, { align: 'right' });
+        menu.open(300, 300, { align: 'right' });
         let { width } = menu.node.getBoundingClientRect();
-        const expectedX = 100 - width;
-        expect(menu.node.style.transform).to.equal(`translate(${ expectedX }px, 10px)`);
+        const expectedX = parseFloat((300 - width).toFixed(3));
+        expect(menu.node.style.transform).to.equal(`translate(${ expectedX }px, 300px)`);
+      });
+
+      it('align should default to right if language direction is rtl', () => {
+        document.documentElement.setAttribute('dir', 'rtl');
+        menu.addItem({ command: 'test' });
+        menu.open(300, 300);
+        let { width } = menu.node.getBoundingClientRect();
+        const expectedX = parseFloat((300 - width).toFixed(3));
+        expect(menu.node.style.transform).to.equal(`translate(${ expectedX }px, 300px)`);
+        document.documentElement.removeAttribute('dir');  // Reset the direction
       });
 
       it('should bail if already attached', () => {

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -608,7 +608,7 @@ describe('@lumino/widgets', () => {
         menu.addItem({ command: 'test' });
         menu.open(100, 100, { align: 'right' });
         let { width } = menu.node.getBoundingClientRect();
-        const expectedX = 10 - width;
+        const expectedX = 100 - width;
         expect(menu.node.style.transform).to.equal(`translate(${ expectedX }px, 10px)`);
       });
 

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -612,9 +612,7 @@ describe('@lumino/widgets', () => {
         expect(
           menu.node.style.transform.startsWith(`translate(${expectedX}`)
         ).to.equal(true);
-        expect(menu.node.style.transform.endsWith('px, 300px)')).to.equal(
-          true
-        );
+        expect(menu.node.style.transform.endsWith('px, 300px)')).to.equal(true);
       });
 
       it.only('align should default to right if language direction is rtl', () => {
@@ -626,9 +624,7 @@ describe('@lumino/widgets', () => {
         expect(
           menu.node.style.transform.startsWith(`translate(${expectedX}`)
         ).to.equal(true);
-        expect(menu.node.style.transform.endsWith('px, 300px)')).to.equal(
-          true
-        );
+        expect(menu.node.style.transform.endsWith('px, 300px)')).to.equal(true);
         document.documentElement.removeAttribute('dir'); // Reset the direction
       });
 

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -604,7 +604,7 @@ describe('@lumino/widgets', () => {
         );
       });
 
-      it('should accept align menu flags', () => {
+      it('should accept horizontalAlignment menu flags', () => {
         menu.addItem({ command: 'test' });
         menu.open(300, 300, { horizontalAlignment: 'right' });
         let { width } = menu.node.getBoundingClientRect();
@@ -615,7 +615,7 @@ describe('@lumino/widgets', () => {
         expect(menu.node.style.transform.endsWith('px, 300px)')).to.equal(true);
       });
 
-      it.only('align should default to right if language direction is rtl', () => {
+      it.only('horizontalAlignment should default to `right` if language direction is `rtl`', () => {
         document.documentElement.setAttribute('dir', 'rtl');
         menu.addItem({ command: 'test' });
         menu.open(300, 300);

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -608,7 +608,7 @@ describe('@lumino/widgets', () => {
         menu.addItem({ command: 'test' });
         menu.open(300, 300, { align: 'right' });
         let { width } = menu.node.getBoundingClientRect();
-        const expectedX = Math.round(300 - width);
+        const expectedX = Math.floor(300 - width);
         expect(
           menu.node.style.transform.startsWith(`translate(${expectedX}`)
         ).to.equal(true);
@@ -620,7 +620,7 @@ describe('@lumino/widgets', () => {
         menu.addItem({ command: 'test' });
         menu.open(300, 300);
         let { width } = menu.node.getBoundingClientRect();
-        const expectedX = Math.round(300 - width);
+        const expectedX = Math.floor(300 - width);
         expect(
           menu.node.style.transform.startsWith(`translate(${expectedX}`)
         ).to.equal(true);

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -604,6 +604,14 @@ describe('@lumino/widgets', () => {
         );
       });
 
+      it('should accept align menu flags', () => {
+        menu.addItem({ command: 'test' });
+        menu.open(100, 100, { align: 'right' });
+        let { width } = menu.node.getBoundingClientRect();
+        const expectedX = 10 - width;
+        expect(menu.node.style.transform).to.equal(`translate(${ expectedX }px, 10px)`);
+      });
+
       it('should bail if already attached', () => {
         menu.addItem({ command: 'test' });
         menu.open(10, 10);

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -606,7 +606,7 @@ describe('@lumino/widgets', () => {
 
       it('should accept align menu flags', () => {
         menu.addItem({ command: 'test' });
-        menu.open(300, 300, { align: 'right' });
+        menu.open(300, 300, { horizontalAlignment: 'right' });
         let { width } = menu.node.getBoundingClientRect();
         const expectedX = Math.floor(300 - width);
         expect(

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -608,20 +608,26 @@ describe('@lumino/widgets', () => {
         menu.addItem({ command: 'test' });
         menu.open(300, 300, { align: 'right' });
         let { width } = menu.node.getBoundingClientRect();
-        const expectedX = parseFloat((300 - width).toFixed(3));
-        expect(menu.node.style.transform).to.equal(
-          `translate(${expectedX}px, 300px)`
+        const expectedX = Math.round(300 - width);
+        expect(
+          menu.node.style.transform.startsWith(`translate(${expectedX}`)
+        ).to.equal(true);
+        expect(menu.node.style.transform.endsWith('px, 300px)')).to.equal(
+          true
         );
       });
 
-      it('align should default to right if language direction is rtl', () => {
+      it.only('align should default to right if language direction is rtl', () => {
         document.documentElement.setAttribute('dir', 'rtl');
         menu.addItem({ command: 'test' });
         menu.open(300, 300);
         let { width } = menu.node.getBoundingClientRect();
-        const expectedX = parseFloat((300 - width).toFixed(3));
-        expect(menu.node.style.transform).to.equal(
-          `translate(${expectedX}px, 300px)`
+        const expectedX = Math.round(300 - width);
+        expect(
+          menu.node.style.transform.startsWith(`translate(${expectedX}`)
+        ).to.equal(true);
+        expect(menu.node.style.transform.endsWith('px, 300px)')).to.equal(
+          true
         );
         document.documentElement.removeAttribute('dir'); // Reset the direction
       });

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -609,7 +609,9 @@ describe('@lumino/widgets', () => {
         menu.open(300, 300, { align: 'right' });
         let { width } = menu.node.getBoundingClientRect();
         const expectedX = parseFloat((300 - width).toFixed(3));
-        expect(menu.node.style.transform).to.equal(`translate(${ expectedX }px, 300px)`);
+        expect(menu.node.style.transform).to.equal(
+          `translate(${expectedX}px, 300px)`
+        );
       });
 
       it('align should default to right if language direction is rtl', () => {
@@ -618,8 +620,10 @@ describe('@lumino/widgets', () => {
         menu.open(300, 300);
         let { width } = menu.node.getBoundingClientRect();
         const expectedX = parseFloat((300 - width).toFixed(3));
-        expect(menu.node.style.transform).to.equal(`translate(${ expectedX }px, 300px)`);
-        document.documentElement.removeAttribute('dir');  // Reset the direction
+        expect(menu.node.style.transform).to.equal(
+          `translate(${expectedX}px, 300px)`
+        );
+        document.documentElement.removeAttribute('dir'); // Reset the direction
       });
 
       it('should bail if already attached', () => {

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -739,9 +739,9 @@ export namespace Menu {
         type?: ItemType;
     }
     export interface IOpenOptions {
-        align?: 'left' | 'right';
         forceX?: boolean;
         forceY?: boolean;
+        horizontalAlignment?: 'left' | 'right';
         host?: HTMLElement;
         ref?: HTMLElement;
     }

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -739,6 +739,7 @@ export namespace Menu {
         type?: ItemType;
     }
     export interface IOpenOptions {
+        align?: 'left' | 'right';
         forceX?: boolean;
         forceY?: boolean;
         host?: HTMLElement;


### PR DESCRIPTION
Closes #709 

Adds an "align" option to Menu.IOpenOptions that can be set to "left" or "right" and adjusts the menu position so the top left or right corner is matched to the given x and y coordinates based on the given align value. It defaults to left or right depending on the document `dir` attribute to account for the given language direction.