### PR TITLE
Move MenuBar index check to an overridable method

### DIFF
--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -140,13 +140,8 @@ export class MenuBar extends Widget {
    * If the menu cannot be activated, the index will be set to `-1`.
    */
   set activeIndex(value: number) {
-    // Adjust the value for an out of range index.
-    if (value < 0 || value >= this._menus.length) {
-      value = -1;
-    }
-
-    // An empty menu cannot be active
-    if (value > -1 && this._menus[value].items.length === 0) {
+    // Adjust the value for an invalid index.
+    if (!this.isValidIndex(value)) {
       value = -1;
     }
 
@@ -160,6 +155,16 @@ export class MenuBar extends Widget {
 
     // Schedule an update of the items.
     this.update();
+  }
+
+  /**
+   * Before setting a new index, this method is used to validate it.
+   * 
+   * By default it checks whether the index is within menu range
+   * and whether the corresponding menu has at least one item.
+   */
+  protected isValidIndex(index: number): boolean {
+    return index >= 0 && index < this._menus.length && this._menus[index].items.length > 0;
   }
 
   /**

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -159,12 +159,16 @@ export class MenuBar extends Widget {
 
   /**
    * Before setting a new index, this method is used to validate it.
-   * 
+   *
    * By default it checks whether the index is within menu range
    * and whether the corresponding menu has at least one item.
    */
   protected isValidIndex(index: number): boolean {
-    return index >= 0 && index < this._menus.length && this._menus[index].items.length > 0;
+    return (
+      index >= 0 &&
+      index < this._menus.length &&
+      this._menus[index].items.length > 0
+    );
   }
 
   /**

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -294,6 +294,29 @@ describe('@lumino/widgets', () => {
         expect(bar.activeIndex).to.equal(-1);
         bar.dispose();
       });
+
+      it('should allow adopting the validation check', () => {
+        class AllowEmptyMenusBar extends MenuBar {
+          protected override isValidIndex(index: number): boolean {
+            return index >= 0 && index < this.menus.length;
+          }
+        }
+        const bar = new AllowEmptyMenusBar();
+        let emptyMenu = new Menu({ commands });
+        bar.insertMenu(1, emptyMenu);
+
+        // check that empty menu can be active
+        bar.activeIndex = 1;
+        expect(bar.activeIndex).to.equal(1);
+
+        // other indices should still be disallowed
+        bar.activeIndex = -1;
+        expect(bar.activeIndex).to.equal(-1);
+        bar.activeIndex = 2;
+        expect(bar.activeIndex).to.equal(-1);
+
+        bar.dispose();
+      });
     });
 
     describe('#menus', () => {

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -789,6 +789,7 @@ export class MenuBar extends Widget {
     dispose(): void;
     handleEvent(event: Event): void;
     insertMenu(index: number, menu: Menu, update?: boolean): void;
+    protected isValidIndex(index: number): boolean;
     get menus(): ReadonlyArray<Menu>;
     protected onActivateRequest(msg: Message): void;
     protected onAfterDetach(msg: Message): void;


### PR DESCRIPTION
Added a protected isValidIndex method to the MenuBar class to handle index validation before setting an index.

This enables adopters to customize the validation logic, e.g., for supporting dynamic menus that may initially be empty.

Resolves #729 