### PR TITLE
Add links to the examples and documentation contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,15 +83,20 @@ The documentation is built with [sphinx](https://www.sphinx-doc.org/en/master/)
 making use of the [PyData Sphinx theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/index.html).
 
 To build it locally
+
 - create and activate an isolated development environment with the necessary dependencies
-with
+  with
+
 ```bash
 conda env create -f docs/environment.yml
 conda activate lumino_documentation
 ```
+
 - build, for example the html version, with
+
 ```bash
 cd docs
 make html
 ```
+
 The HTML pages are then located in the `build/html` directory.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,3 +76,22 @@ To add an example to the static examples:
 - Add appropriate link in: `docs/source/examples.rst`
 - Add the example name to the `EXAMPLES` in `docs/source/conf.py`
 - Add `ignore-links` config in `package.json`
+
+## Documentation
+
+The documentation is built with [sphinx](https://www.sphinx-doc.org/en/master/)
+making use of the [PyData Sphinx theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/index.html).
+
+To build it locally
+- create and activate an isolated development environment with the necessary dependencies
+with
+```bash
+conda env create -f docs/environment.yml
+conda activate lumino_documentation
+```
+- build, for example the html version, with
+```bash
+cd docs
+make html
+```
+The HTML pages are then located in the `build/html` directory.

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -52,6 +52,9 @@ import { TextRenderer } from './textrenderer';
  * the child widgets of a data grid directly is undefined behavior.
  *
  * This class is not designed to be subclassed.
+ * 
+ * See also the related [example](../../examples/datagrid/index.html) and
+ * its [source](https://github.com/jupyterlab/lumino/tree/main/examples/example-datagrid).
  */
 export class DataGrid extends Widget {
   /**

--- a/packages/datagrid/src/datagrid.ts
+++ b/packages/datagrid/src/datagrid.ts
@@ -52,7 +52,7 @@ import { TextRenderer } from './textrenderer';
  * the child widgets of a data grid directly is undefined behavior.
  *
  * This class is not designed to be subclassed.
- * 
+ *
  * See also the related [example](../../examples/datagrid/index.html) and
  * its [source](https://github.com/jupyterlab/lumino/tree/main/examples/example-datagrid).
  */

--- a/packages/widgets/src/accordionpanel.ts
+++ b/packages/widgets/src/accordionpanel.ts
@@ -15,7 +15,7 @@ import { Widget } from './widget';
  *
  * #### Notes
  * This class provides a convenience wrapper around {@link AccordionLayout}.
- * 
+ *
  * See also the related [example](../../examples/accordionpanel/index.html) and
  * its [source](https://github.com/jupyterlab/lumino/tree/main/examples/example-accordionpanel).
  */
@@ -24,7 +24,7 @@ export class AccordionPanel extends SplitPanel {
    * Construct a new accordion panel.
    *
    * @param options - The options for initializing the accordion panel.
-   * 
+   *
    */
   constructor(options: AccordionPanel.IOptions = {}) {
     super({ ...options, layout: Private.createLayout(options) });

--- a/packages/widgets/src/accordionpanel.ts
+++ b/packages/widgets/src/accordionpanel.ts
@@ -15,12 +15,16 @@ import { Widget } from './widget';
  *
  * #### Notes
  * This class provides a convenience wrapper around {@link AccordionLayout}.
+ * 
+ * See also the related [example](../../examples/accordionpanel/index.html) and
+ * its [source](https://github.com/jupyterlab/lumino/tree/main/examples/example-accordionpanel).
  */
 export class AccordionPanel extends SplitPanel {
   /**
    * Construct a new accordion panel.
    *
    * @param options - The options for initializing the accordion panel.
+   * 
    */
   constructor(options: AccordionPanel.IOptions = {}) {
     super({ ...options, layout: Private.createLayout(options) });

--- a/packages/widgets/src/boxpanel.ts
+++ b/packages/widgets/src/boxpanel.ts
@@ -120,12 +120,16 @@ export namespace BoxPanel {
     /**
      * The layout direction of the panel.
      *
+     * Possible values are documented in {@link BoxLayout.Direction}.
+     *
      * The default is `'top-to-bottom'`.
      */
     direction?: Direction;
 
     /**
      * The content alignment of the panel.
+     *
+     * Possible values are documented in {@link BoxLayout.Alignment}.
      *
      * The default is `'start'`.
      */

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -31,7 +31,7 @@ import { Widget } from './widget';
 
 /**
  * A widget which provides a flexible docking area for widgets.
- * 
+ *
  * #### Notes
  * See also the related [example](../../examples/dockpanel/index.html) and
  * its [source](https://github.com/jupyterlab/lumino/tree/main/examples/example-dockpanel).

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -31,6 +31,10 @@ import { Widget } from './widget';
 
 /**
  * A widget which provides a flexible docking area for widgets.
+ * 
+ * #### Notes
+ * See also the related [example](../../examples/dockpanel/index.html) and
+ * its [source](https://github.com/jupyterlab/lumino/tree/main/examples/example-dockpanel).
  */
 export class DockPanel extends Widget {
   /**

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -33,6 +33,10 @@ import { Widget } from './widget';
 
 /**
  * A widget which displays menus as a canonical menu bar.
+ *
+ * #### Notes
+ * See also the related [example](../../examples/menubar/index.html) and
+ * its [source](https://github.com/jupyterlab/lumino/tree/main/examples/example-menubar).
  */
 export class MenuBar extends Widget {
   /**

--- a/packages/widgets/src/splitlayout.ts
+++ b/packages/widgets/src/splitlayout.ts
@@ -745,7 +745,7 @@ export namespace SplitLayout {
      * The orientation of the layout.
      *
      * Possible values are documented in {@link SplitLayout.Orientation}.
-     * 
+     *
      * The default is `'horizontal'`.
      */
     orientation?: Orientation;

--- a/packages/widgets/src/splitlayout.ts
+++ b/packages/widgets/src/splitlayout.ts
@@ -744,12 +744,16 @@ export namespace SplitLayout {
     /**
      * The orientation of the layout.
      *
+     * Possible values are documented in {@link SplitLayout.Orientation}.
+     * 
      * The default is `'horizontal'`.
      */
     orientation?: Orientation;
 
     /**
      * The content alignment of the layout.
+     *
+     * Possible values are documented in {@link SplitLayout.Alignment}.
      *
      * The default is `'start'`.
      */


### PR DESCRIPTION
Dear maintainers
this pull request adds the links to the examples from the related API pages.

The values of some options are also made explicit in the documentation: the additions are not exhaustive, I've added those I've used ... :grin:

While working on the documentation I couldn't find instructions about how to specifically contribute  to the documentation: I've took the liberty to add a small paragraph about that in `CONTRIBUTING.md`.
Perhaps I just missed the related documentation...

This pull request closes #740.

Thanks for considering it.