### PR TITLE
Don't refresh if palette is within a hidden branch

### DIFF
--- a/buildutils/src/rollup.tests.config.js
+++ b/buildutils/src/rollup.tests.config.js
@@ -5,13 +5,15 @@
 
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import sourcemaps from 'rollup-plugin-sourcemaps';
 
 export function createRollupTestConfig(options) {
   return {
     input: './lib/index.spec.js',
     output: {
-      file: './lib/bundle.test.js'
+      file: './lib/bundle.test.js',
+      sourcemap: true
     },
-    plugins: [commonjs(), nodeResolve()]
+    plugins: [commonjs(), nodeResolve(), sourcemaps()]
   };
 }

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -295,7 +295,9 @@ export class CommandPalette extends Widget {
    * A message handler invoked on an `'update-request'` message.
    */
   protected onUpdateRequest(msg: Message): void {
-    if (this.isHidden) {
+    if (this.isWithinHiddenWidget()) {
+      // Ensure to clear the content if the widget is hidden
+      VirtualDOM.render(null, this.contentNode);
       return;
     }
 

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -295,7 +295,7 @@ export class CommandPalette extends Widget {
    * A message handler invoked on an `'update-request'` message.
    */
   protected onUpdateRequest(msg: Message): void {
-    if (this.isWithinHiddenWidget()) {
+    if (!this.isVisible) {
       // Ensure to clear the content if the widget is hidden
       VirtualDOM.render(null, this.contentNode);
       return;

--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -882,7 +882,7 @@ export namespace Widget {
      * The widget is visible.
      *
      * @deprecated since 2.7.0, apply that flag consistently was not reliable
-     * so it was drop in favor of a recursive check of the visibility of all parents.
+     * so it was dropped in favor of a recursive check of the visibility of all parents.
      */
     IsVisible = 0x8,
 

--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -112,6 +112,10 @@ export class Widget implements IMessageHandler, IObservableDisposable {
 
   /**
    * Test whether the widget is explicitly hidden.
+   *
+   * #### Notes
+   * You should prefer `!{@link isVisible}` over `{@link isHidden}` if you want to know if the
+   * widget is hidden as this does not test if the widget is hidden because one of its ancestors is hidden.
    */
   get isHidden(): boolean {
     return this.testFlag(Widget.Flag.IsHidden);
@@ -123,9 +127,20 @@ export class Widget implements IMessageHandler, IObservableDisposable {
    * #### Notes
    * A widget is visible when it is attached to the DOM, is not
    * explicitly hidden, and has no explicitly hidden ancestors.
+   *
+   * Since 2.7.0, this does not rely on the {@link Widget.Flag.IsVisible} flag.
+   * It recursively checks the visibility of all parent widgets.
    */
   get isVisible(): boolean {
-    return this.testFlag(Widget.Flag.IsVisible);
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let parent: Widget | null = this;
+    do {
+      if (parent.isHidden || !parent.isAttached) {
+        return false;
+      }
+      parent = parent.parent;
+    } while (parent != null);
+    return true;
   }
 
   /**
@@ -462,25 +477,6 @@ export class Widget implements IMessageHandler, IObservableDisposable {
   }
 
   /**
-   * Check if the widget or any of it's parents is hidden.
-   *
-   * Checking parents is necessary as lumino does not propagate visibility
-   * changes from parents down to children (although it does notify parents
-   * about changes to children visibility).
-   */
-  isWithinHiddenWidget(): boolean {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let parent: Widget | null = this;
-    do {
-      if (parent.isHidden) {
-        return true;
-      }
-      parent = parent.parent;
-    } while (parent != null);
-    return false;
-  }
-
-  /**
    * Show or hide the widget according to a boolean value.
    *
    * @param hidden - `true` to hide the widget, or `false` to show it.
@@ -501,6 +497,9 @@ export class Widget implements IMessageHandler, IObservableDisposable {
    *
    * #### Notes
    * This will not typically be called directly by user code.
+   *
+   * Since 2.7.0, {@link Widget.Flag.IsVisible} is deprecated.
+   * It will be removed in a future version.
    */
   testFlag(flag: Widget.Flag): boolean {
     return (this._flags & flag) !== 0;
@@ -511,6 +510,9 @@ export class Widget implements IMessageHandler, IObservableDisposable {
    *
    * #### Notes
    * This will not typically be called directly by user code.
+   *
+   * Since 2.7.0, {@link Widget.Flag.IsVisible} is deprecated.
+   * It will be removed in a future version.
    */
   setFlag(flag: Widget.Flag): void {
     this._flags |= flag;
@@ -521,6 +523,9 @@ export class Widget implements IMessageHandler, IObservableDisposable {
    *
    * #### Notes
    * This will not typically be called directly by user code.
+   *
+   * Since 2.7.0, {@link Widget.Flag.IsVisible} is deprecated.
+   * It will be removed in a future version.
    */
   clearFlag(flag: Widget.Flag): void {
     this._flags &= ~flag;
@@ -875,6 +880,9 @@ export namespace Widget {
 
     /**
      * The widget is visible.
+     *
+     * @deprecated since 2.7.0, apply that flag consistently was not reliable
+     * so it was drop in favor of a recursive check of the visibility of all parents.
      */
     IsVisible = 0x8,
 

--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -462,6 +462,25 @@ export class Widget implements IMessageHandler, IObservableDisposable {
   }
 
   /**
+   * Check if the widget or any of it's parents is hidden.
+   *
+   * Checking parents is necessary as lumino does not propagate visibility
+   * changes from parents down to children (although it does notify parents
+   * about changes to children visibility).
+   */
+  isWithinHiddenWidget(): boolean {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let parent: Widget | null = this;
+    do {
+      if (parent.isHidden) {
+        return true;
+      }
+      parent = parent.parent;
+    } while (parent != null);
+    return false;
+  }
+
+  /**
    * Show or hide the widget according to a boolean value.
    *
    * @param hidden - `true` to hide the widget, or `false` to show it.

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -553,6 +553,44 @@ describe('@lumino/widgets', () => {
           'example:run-cell'
         );
       });
+
+      it('should clear the widget content if hidden', () => {
+        commands.addCommand('test', { execute: () => {}, label: 'test' });
+        palette.addItem({ command: 'test', category: 'test' });
+        const content = palette.contentNode;
+        const itemClass = '.lm-CommandPalette-item';
+        const items = () => content.querySelectorAll(itemClass);
+
+        palette.refresh();
+        MessageLoop.flush();
+
+        expect(items()).to.have.length(1);
+
+        palette.hide();
+        palette.refresh();
+        MessageLoop.flush();
+        expect(items()).to.have.length(0);
+      });
+
+      it('should clear the widget content if container is hidden', () => {
+        const parent = new Widget();
+        palette.parent = parent;
+        commands.addCommand('test', { execute: () => {}, label: 'test' });
+        palette.addItem({ command: 'test', category: 'test' });
+        const content = palette.contentNode;
+        const itemClass = '.lm-CommandPalette-item';
+        const items = () => content.querySelectorAll(itemClass);
+
+        palette.refresh();
+        MessageLoop.flush();
+
+        expect(items()).to.have.length(1);
+
+        parent.hide();
+        palette.refresh();
+        MessageLoop.flush();
+        expect(items()).to.have.length(0);
+      });
     });
 
     describe('#handleEvent()', () => {

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -44,6 +44,7 @@ describe('@lumino/widgets', () => {
   beforeEach(() => {
     commands = new CommandRegistry();
     palette = new CommandPalette({ commands });
+    Widget.attach(palette, document.body);
   });
 
   afterEach(() => {
@@ -493,65 +494,76 @@ describe('@lumino/widgets', () => {
         });
 
         let palette = new CommandPalette({ commands });
-        palette.addItem({ command: 'example:cut', category: 'Edit' });
-        palette.addItem({ command: 'example:copy', category: 'Edit' });
-        palette.addItem({ command: 'example:paste', category: 'Edit' });
-        palette.addItem({ command: 'example:one', category: 'Number' });
-        palette.addItem({ command: 'example:two', category: 'Number' });
-        palette.addItem({ command: 'example:three', category: 'Number' });
-        palette.addItem({ command: 'example:four', category: 'Number' });
-        palette.addItem({ command: 'example:black', category: 'Number' });
-        palette.addItem({ command: 'example:new-tab', category: 'File' });
-        palette.addItem({ command: 'example:close-tab', category: 'File' });
-        palette.addItem({ command: 'example:save-on-exit', category: 'File' });
-        palette.addItem({
-          command: 'example:open-task-manager',
-          category: 'File'
-        });
-        palette.addItem({ command: 'example:close', category: 'File' });
-        palette.addItem({
-          command: 'example:clear-cell',
-          category: 'Notebook Cell Operations'
-        });
-        palette.addItem({
-          command: 'example:cut-cells',
-          category: 'Notebook Cell Operations'
-        });
-        palette.addItem({
-          command: 'example:run-cell',
-          category: 'Notebook Cell Operations'
-        });
-        palette.addItem({ command: 'example:cell-test', category: 'Console' });
-        palette.addItem({ command: 'notebook:new', category: 'Notebook' });
-        palette.id = 'palette';
+        Widget.attach(palette, document.body);
+        try {
+          palette.addItem({ command: 'example:cut', category: 'Edit' });
+          palette.addItem({ command: 'example:copy', category: 'Edit' });
+          palette.addItem({ command: 'example:paste', category: 'Edit' });
+          palette.addItem({ command: 'example:one', category: 'Number' });
+          palette.addItem({ command: 'example:two', category: 'Number' });
+          palette.addItem({ command: 'example:three', category: 'Number' });
+          palette.addItem({ command: 'example:four', category: 'Number' });
+          palette.addItem({ command: 'example:black', category: 'Number' });
+          palette.addItem({ command: 'example:new-tab', category: 'File' });
+          palette.addItem({ command: 'example:close-tab', category: 'File' });
+          palette.addItem({
+            command: 'example:save-on-exit',
+            category: 'File'
+          });
+          palette.addItem({
+            command: 'example:open-task-manager',
+            category: 'File'
+          });
+          palette.addItem({ command: 'example:close', category: 'File' });
+          palette.addItem({
+            command: 'example:clear-cell',
+            category: 'Notebook Cell Operations'
+          });
+          palette.addItem({
+            command: 'example:cut-cells',
+            category: 'Notebook Cell Operations'
+          });
+          palette.addItem({
+            command: 'example:run-cell',
+            category: 'Notebook Cell Operations'
+          });
+          palette.addItem({
+            command: 'example:cell-test',
+            category: 'Console'
+          });
+          palette.addItem({ command: 'notebook:new', category: 'Notebook' });
+          palette.id = 'palette';
 
-        // Search the command palette: update the inputNode, then force a refresh
-        palette.inputNode.value = 'clea';
-        palette.refresh();
-        MessageLoop.flush();
+          // Search the command palette: update the inputNode, then force a refresh
+          palette.inputNode.value = 'clea';
+          palette.refresh();
+          MessageLoop.flush();
 
-        // Expect that headers and items appear in descending score order,
-        // even if the same header occurs multiple times.
-        const children = palette.contentNode.children;
-        expect(children.length).to.equal(7);
-        expect(children[0].textContent).to.equal('Notebook Cell Operations');
-        expect(children[1].getAttribute('data-command')).to.equal(
-          'example:clear-cell'
-        );
-        // The next match should be from a different category
-        expect(children[2].textContent).to.equal('File');
-        expect(children[3].getAttribute('data-command')).to.equal(
-          'example:close-tab'
-        );
-        // The next match should be the same as in a previous category
-        expect(children[4].textContent).to.equal('Notebook Cell Operations');
-        expect(children[5].getAttribute('data-command')).to.equal(
-          'example:cut-cells'
-        );
-        // The next match has the same category as the previous one did, so the header is not repeated
-        expect(children[6].getAttribute('data-command')).to.equal(
-          'example:run-cell'
-        );
+          // Expect that headers and items appear in descending score order,
+          // even if the same header occurs multiple times.
+          const children = palette.contentNode.children;
+          expect(children.length).to.equal(7);
+          expect(children[0].textContent).to.equal('Notebook Cell Operations');
+          expect(children[1].getAttribute('data-command')).to.equal(
+            'example:clear-cell'
+          );
+          // The next match should be from a different category
+          expect(children[2].textContent).to.equal('File');
+          expect(children[3].getAttribute('data-command')).to.equal(
+            'example:close-tab'
+          );
+          // The next match should be the same as in a previous category
+          expect(children[4].textContent).to.equal('Notebook Cell Operations');
+          expect(children[5].getAttribute('data-command')).to.equal(
+            'example:cut-cells'
+          );
+          // The next match has the same category as the previous one did, so the header is not repeated
+          expect(children[6].getAttribute('data-command')).to.equal(
+            'example:run-cell'
+          );
+        } finally {
+          palette.dispose();
+        }
       });
 
       it('should clear the widget content if hidden', () => {
@@ -574,22 +586,27 @@ describe('@lumino/widgets', () => {
 
       it('should clear the widget content if container is hidden', () => {
         const parent = new Widget();
-        palette.parent = parent;
-        commands.addCommand('test', { execute: () => {}, label: 'test' });
-        palette.addItem({ command: 'test', category: 'test' });
-        const content = palette.contentNode;
-        const itemClass = '.lm-CommandPalette-item';
-        const items = () => content.querySelectorAll(itemClass);
+        Widget.attach(parent, document.body);
+        try {
+          palette.parent = parent;
+          commands.addCommand('test', { execute: () => {}, label: 'test' });
+          palette.addItem({ command: 'test', category: 'test' });
+          const content = palette.contentNode;
+          const itemClass = '.lm-CommandPalette-item';
+          const items = () => content.querySelectorAll(itemClass);
 
-        palette.refresh();
-        MessageLoop.flush();
+          palette.refresh();
+          MessageLoop.flush();
 
-        expect(items()).to.have.length(1);
+          expect(items()).to.have.length(1);
 
-        parent.hide();
-        palette.refresh();
-        MessageLoop.flush();
-        expect(items()).to.have.length(0);
+          parent.hide();
+          palette.refresh();
+          MessageLoop.flush();
+          expect(items()).to.have.length(0);
+        } finally {
+          parent.dispose();
+        }
       });
     });
 
@@ -597,11 +614,14 @@ describe('@lumino/widgets', () => {
       it('should handle click, keydown, and input events', () => {
         let palette = new LogPalette({ commands });
         Widget.attach(palette, document.body);
-        ['click', 'keydown', 'input'].forEach(type => {
-          palette.node.dispatchEvent(new Event(type, { bubbles }));
-          expect(palette.events).to.contain(type);
-        });
-        palette.dispose();
+        try {
+          ['click', 'keydown', 'input'].forEach(type => {
+            palette.node.dispatchEvent(new Event(type, { bubbles }));
+            expect(palette.events).to.contain(type);
+          });
+        } finally {
+          palette.dispose();
+        }
       });
 
       context('click', () => {
@@ -610,7 +630,6 @@ describe('@lumino/widgets', () => {
           commands.addCommand('test', { execute: () => (called = true) });
 
           palette.addItem(defaultOptions);
-          Widget.attach(palette, document.body);
           MessageLoop.flush();
 
           let node = palette.contentNode.querySelector(
@@ -625,7 +644,6 @@ describe('@lumino/widgets', () => {
           commands.addCommand('test', { execute: () => (called = true) });
 
           palette.addItem(defaultOptions);
-          Widget.attach(palette, document.body);
           MessageLoop.flush();
 
           let node = palette.contentNode.querySelector(
@@ -642,7 +660,6 @@ describe('@lumino/widgets', () => {
           let content = palette.contentNode;
 
           palette.addItem(defaultOptions);
-          Widget.attach(palette, document.body);
           MessageLoop.flush();
 
           let node = content.querySelector('.lm-mod-active');
@@ -663,7 +680,6 @@ describe('@lumino/widgets', () => {
           let content = palette.contentNode;
 
           palette.addItem(defaultOptions);
-          Widget.attach(palette, document.body);
           MessageLoop.flush();
 
           let node = content.querySelector('.lm-mod-active');
@@ -685,7 +701,6 @@ describe('@lumino/widgets', () => {
           let content = palette.contentNode;
 
           palette.addItem(defaultOptions);
-          Widget.attach(palette, document.body);
           MessageLoop.flush();
 
           let node = content.querySelector('.lm-mod-active');
@@ -715,7 +730,6 @@ describe('@lumino/widgets', () => {
           let content = palette.contentNode;
 
           palette.addItem(defaultOptions);
-          Widget.attach(palette, document.body);
           MessageLoop.flush();
 
           expect(content.querySelector('.lm-mod-active')).to.equal(null);
@@ -742,7 +756,6 @@ describe('@lumino/widgets', () => {
             palette.addItem({ command: name, category: 'test' });
           });
 
-          Widget.attach(palette, document.body);
           MessageLoop.flush();
 
           let content = palette.contentNode;
@@ -772,7 +785,6 @@ describe('@lumino/widgets', () => {
             });
           });
 
-          Widget.attach(palette, document.body);
           MessageLoop.flush();
 
           let headers = () =>

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1815,6 +1815,7 @@ describe('@lumino/widgets', () => {
          * TODO:
          * Find a way to trigger the change of focus.
          */
+        /*
         it.skip('should keep focus on the second tab on tabulation', () => {
           const node = document.createElement('div');
           node.setAttribute('tabindex', '0');
@@ -1844,6 +1845,7 @@ describe('@lumino/widgets', () => {
           );
           expect(document.activeElement).to.equal(secondTab);
         });
+        */
       });
 
       context('contextmenu', () => {

--- a/packages/widgets/tests/src/widget.spec.ts
+++ b/packages/widgets/tests/src/widget.spec.ts
@@ -253,6 +253,15 @@ describe('@lumino/widgets', () => {
         let widget = new Widget();
         expect(widget.isVisible).to.equal(false);
       });
+
+      it('should be false if the widget is not hidden but its parent is hidden', () => {
+        let parent = new Widget();
+        parent.hide();
+        let widget = new Widget();
+        widget.parent = parent;
+        expect(widget.isHidden).to.equal(false);
+        expect(widget.isVisible).to.equal(false);
+      });
     });
 
     describe('#node', () => {
@@ -682,28 +691,6 @@ describe('@lumino/widgets', () => {
         widget.hide();
         expect(widget.messages).to.not.contain('before-hide');
         widget.dispose();
-      });
-    });
-
-    describe('#isWithinHiddenWidget()', () => {
-      it('should be true if the widget is hidden', () => {
-        let widget = new Widget();
-        widget.hide();
-        expect(widget.isWithinHiddenWidget()).to.equal(true);
-      });
-
-      it('should be false if the widget is not hidden without parent', () => {
-        let widget = new Widget();
-        expect(widget.isWithinHiddenWidget()).to.equal(false);
-      });
-
-      it('should be true if the widget is not hidden but parent is hidden', () => {
-        let parent = new Widget();
-        parent.hide();
-        let widget = new Widget();
-        widget.parent = parent;
-        expect(widget.isHidden).to.equal(false);
-        expect(widget.isWithinHiddenWidget()).to.equal(true);
       });
     });
 

--- a/packages/widgets/tests/src/widget.spec.ts
+++ b/packages/widgets/tests/src/widget.spec.ts
@@ -685,6 +685,28 @@ describe('@lumino/widgets', () => {
       });
     });
 
+    describe('#isWithinHiddenWidget()', () => {
+      it('should be true if the widget is hidden', () => {
+        let widget = new Widget();
+        widget.hide();
+        expect(widget.isWithinHiddenWidget()).to.equal(true);
+      });
+
+      it('should be false if the widget is not hidden without parent', () => {
+        let widget = new Widget();
+        expect(widget.isWithinHiddenWidget()).to.equal(false);
+      });
+
+      it('should be true if the widget is not hidden but parent is hidden', () => {
+        let parent = new Widget();
+        parent.hide();
+        let widget = new Widget();
+        widget.parent = parent;
+        expect(widget.isHidden).to.equal(false);
+        expect(widget.isWithinHiddenWidget()).to.equal(true);
+      });
+    });
+
     describe('#setHidden()', () => {
       it('should call hide if `hidden = true`', () => {
         let widget = new LogWidget();

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -1319,7 +1319,6 @@ export class Widget implements IMessageHandler, IObservableDisposable {
     get isDisposed(): boolean;
     get isHidden(): boolean;
     get isVisible(): boolean;
-    isWithinHiddenWidget(): boolean;
     get layout(): Layout | null;
     set layout(value: Layout | null);
     readonly node: HTMLElement;
@@ -1365,6 +1364,7 @@ export namespace Widget {
         IsAttached = 2,
         IsDisposed = 1,
         IsHidden = 4,
+        // @deprecated
         IsVisible = 8
     }
     export enum HiddenMode {

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -1319,6 +1319,7 @@ export class Widget implements IMessageHandler, IObservableDisposable {
     get isDisposed(): boolean;
     get isHidden(): boolean;
     get isVisible(): boolean;
+    isWithinHiddenWidget(): boolean;
     get layout(): Layout | null;
     set layout(value: Layout | null);
     readonly node: HTMLElement;


### PR DESCRIPTION
Fixes #744

- Add new method `Widget.isWithinHiddenWidget` to test if a widget is hidden or within an hidden parent

> I'm not happy with the name `isWithinHiddenWidget` nor with `isAnyHidden`. Happy to change it to something else; I thought about `isAnyParentHidden`

I would recommend merging #745 prior to this to ensure tests are passing on CI.

---

This PR has two side effects:
- commenting a left over skipped test from #745 - the skipped test are marked as failing when run in debug mode but not otherwise it seems. I have no ideas why this is happening.
- I turn on the generation of source maps for tests; this makes debugging much more efficient.