### PR TITLE
Run workflows that were pinned to no-longer supported `ubuntu-20.04` on `ubuntu-latest`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   header-license-fix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 20.04 is no longer supported on GH Actions, see https://github.com/actions/runner-images/issues/11101

These two workflows are currently failing to run on PRs:

![image](https://github.com/user-attachments/assets/a1e48b75-e46d-4f55-83b2-98dedb888162)

The codeql template recommends using `ubuntu-latest` anyways.