### PR TITLE
Bump versions for v2025.4.30

### DIFF
--- a/examples/example-accordionpanel/package.json
+++ b/examples/example-accordionpanel/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@lumino/example-accordionpanel",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/default-theme": "^2.1.9",
+    "@lumino/default-theme": "^2.1.10",
     "@lumino/messaging": "^2.0.3",
-    "@lumino/widgets": "^2.7.0"
+    "@lumino/widgets": "^2.7.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/examples/example-datagrid/package.json
+++ b/examples/example-datagrid/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@lumino/example-datagrid",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/datagrid": "^2.5.1",
-    "@lumino/default-theme": "^2.1.9",
+    "@lumino/datagrid": "^2.5.2",
+    "@lumino/default-theme": "^2.1.10",
     "@lumino/dragdrop": "^2.1.6",
-    "@lumino/widgets": "^2.7.0"
+    "@lumino/widgets": "^2.7.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/examples/example-dockpanel/package.json
+++ b/examples/example-dockpanel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/example-dockpanel",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "@lumino/commands": "^2.3.2",
-    "@lumino/default-theme": "^2.1.9",
+    "@lumino/default-theme": "^2.1.10",
     "@lumino/dragdrop": "^2.1.6",
     "@lumino/messaging": "^2.0.3",
-    "@lumino/widgets": "^2.7.0"
+    "@lumino/widgets": "^2.7.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/examples/example-menubar/package.json
+++ b/examples/example-menubar/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@lumino/example-menubar",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "private": true,
   "scripts": {
     "build": "tsc && rollup -c",
     "clean": "rimraf build"
   },
   "dependencies": {
-    "@lumino/default-theme": "^2.1.9",
+    "@lumino/default-theme": "^2.1.10",
     "@lumino/messaging": "^2.0.3",
-    "@lumino/widgets": "^2.7.0"
+    "@lumino/widgets": "^2.7.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/application",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Lumino Pluggable Application",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -40,7 +40,7 @@
   "dependencies": {
     "@lumino/commands": "^2.3.2",
     "@lumino/coreutils": "^2.2.1",
-    "@lumino/widgets": "^2.7.0"
+    "@lumino/widgets": "^2.7.1"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.2",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/datagrid",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Lumino Tabular Data Grid",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -46,7 +46,7 @@
     "@lumino/keyboard": "^2.0.3",
     "@lumino/messaging": "^2.0.3",
     "@lumino/signaling": "^2.1.4",
-    "@lumino/widgets": "^2.7.0"
+    "@lumino/widgets": "^2.7.1"
   },
   "devDependencies": {
     "@lumino/buildutils": "^2.0.2",

--- a/packages/default-theme/package.json
+++ b/packages/default-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/default-theme",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Lumino Default Theme",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@lumino/dragdrop": "^2.1.6",
-    "@lumino/widgets": "^2.7.0"
+    "@lumino/widgets": "^2.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumino/widgets",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Lumino Widgets",
   "homepage": "https://github.com/jupyterlab/lumino",
   "bugs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,7 +311,7 @@ __metadata:
     "@lumino/buildutils": ^2.0.2
     "@lumino/commands": ^2.3.2
     "@lumino/coreutils": ^2.2.1
-    "@lumino/widgets": ^2.7.0
+    "@lumino/widgets": ^2.7.1
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -430,7 +430,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/datagrid@^2.5.1, @lumino/datagrid@workspace:packages/datagrid":
+"@lumino/datagrid@^2.5.2, @lumino/datagrid@workspace:packages/datagrid":
   version: 0.0.0-use.local
   resolution: "@lumino/datagrid@workspace:packages/datagrid"
   dependencies:
@@ -443,7 +443,7 @@ __metadata:
     "@lumino/keyboard": ^2.0.3
     "@lumino/messaging": ^2.0.3
     "@lumino/signaling": ^2.1.4
-    "@lumino/widgets": ^2.7.0
+    "@lumino/widgets": ^2.7.1
     "@microsoft/api-extractor": ^7.36.0
     "@rollup/plugin-commonjs": ^24.0.0
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -464,12 +464,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/default-theme@^2.1.9, @lumino/default-theme@workspace:packages/default-theme":
+"@lumino/default-theme@^2.1.10, @lumino/default-theme@workspace:packages/default-theme":
   version: 0.0.0-use.local
   resolution: "@lumino/default-theme@workspace:packages/default-theme"
   dependencies:
     "@lumino/dragdrop": ^2.1.6
-    "@lumino/widgets": ^2.7.0
+    "@lumino/widgets": ^2.7.1
   languageName: unknown
   linkType: soft
 
@@ -556,9 +556,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-accordionpanel@workspace:examples/example-accordionpanel"
   dependencies:
-    "@lumino/default-theme": ^2.1.9
+    "@lumino/default-theme": ^2.1.10
     "@lumino/messaging": ^2.0.3
-    "@lumino/widgets": ^2.7.0
+    "@lumino/widgets": ^2.7.1
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -571,10 +571,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-datagrid@workspace:examples/example-datagrid"
   dependencies:
-    "@lumino/datagrid": ^2.5.1
-    "@lumino/default-theme": ^2.1.9
+    "@lumino/datagrid": ^2.5.2
+    "@lumino/default-theme": ^2.1.10
     "@lumino/dragdrop": ^2.1.6
-    "@lumino/widgets": ^2.7.0
+    "@lumino/widgets": ^2.7.1
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -604,10 +604,10 @@ __metadata:
   resolution: "@lumino/example-dockpanel@workspace:examples/example-dockpanel"
   dependencies:
     "@lumino/commands": ^2.3.2
-    "@lumino/default-theme": ^2.1.9
+    "@lumino/default-theme": ^2.1.10
     "@lumino/dragdrop": ^2.1.6
     "@lumino/messaging": ^2.0.3
-    "@lumino/widgets": ^2.7.0
+    "@lumino/widgets": ^2.7.1
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -620,9 +620,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lumino/example-menubar@workspace:examples/example-menubar"
   dependencies:
-    "@lumino/default-theme": ^2.1.9
+    "@lumino/default-theme": ^2.1.10
     "@lumino/messaging": ^2.0.3
-    "@lumino/widgets": ^2.7.0
+    "@lumino/widgets": ^2.7.1
     "@rollup/plugin-node-resolve": ^15.0.1
     rimraf: ^5.0.1
     rollup: ^3.25.1
@@ -800,7 +800,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lumino/widgets@^2.7.0, @lumino/widgets@workspace:packages/widgets":
+"@lumino/widgets@^2.7.1, @lumino/widgets@workspace:packages/widgets":
   version: 0.0.0-use.local
   resolution: "@lumino/widgets@workspace:packages/widgets"
   dependencies:


### PR DESCRIPTION
```
Changes:
 - @lumino/example-accordionpanel: 2.1.9 => 2.1.10 (private)
 - @lumino/example-datagrid: 2.1.9 => 2.1.10 (private)
 - @lumino/example-dockpanel: 2.1.9 => 2.1.10 (private)
 - @lumino/example-menubar: 2.1.9 => 2.1.10 (private)
 - @lumino/application: 2.4.3 => 2.4.4
 - @lumino/datagrid: 2.5.1 => 2.5.2
 - @lumino/default-theme: 2.1.9 => 2.1.10
 - @lumino/widgets: 2.7.0 => 2.7.1
```