### PR TITLE
Add top and left positioning

### DIFF
--- a/packages/widgets/style/menu.css
+++ b/packages/widgets/style/menu.css
@@ -15,6 +15,8 @@
 .lm-Menu {
   z-index: 10000;
   position: absolute;
+  top: 0;
+  left: 0;
   white-space: nowrap;
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
When deploying JupyterLite on ReadTheDocs, statically positioned elements added by ReadTheDocs in the `<body>` tag cause JupyterLab’s absolutely positioned context menus (which are placed in the `<body>` tag) to be incorrectly offset downward by the height of these elements.

**Cf screenshot below:**

<img width="500"  alt="Screenshot 2025-12-16 at 16 15 04" src="https://github.com/user-attachments/assets/68f5b4d2-73ea-479f-a8ff-ef1c8156b611" />

This change ensures the context menus are correctly positioned by explicitly setting `top: 0`, resolving the visual misalignment.