### PR TITLE
Fix macos:firefox flaky tests

### DIFF
--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -111,7 +111,7 @@ function simulateOnNode(node: Element, action: Action): void {
   node.dispatchEvent(
     new PointerEvent(action, {
       clientX: rect.left + 1,
-      clientY: rect.top,
+      clientY: rect.top + 1,
       cancelable: true,
       bubbles: true
     })


### PR DESCRIPTION
Sometimes on macos firefox, the tabbar test simulate event function fails. For example, a pointerdown event fails the hit test and does not actually click on the target tab.

In this PR, we change the simulate function to target the event one pixel down from the top of the target node, just like we already target one pixel in from the left edge. This should fix flaky problems from accidentally missing the tab due to floating point issues.

Claude Code (Opus 4.5) helped diagnose and fix this issue.