### PR TITLE
Fix more macos firefox tests

### DIFF
--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -514,14 +514,15 @@ describe('@lumino/widgets', () => {
           expect(args.index).to.equal(0);
           expect(args.title).to.equal(bar.titles[0]);
           expect(args.clientX).to.equal(rect.right + 200);
-          expect(args.clientY).to.equal(rect.top);
+          // Firefox on macos sometimes returns floats for rect.top
+          expect(args.clientY).to.equal(Math.round(rect.top));
           called = true;
         });
         let rect = bar.contentNode.getBoundingClientRect();
         document.body.dispatchEvent(
           new PointerEvent('pointermove', {
             clientX: rect.right + 200,
-            clientY: rect.top,
+            clientY: Math.round(rect.top),
             cancelable: true
           })
         );
@@ -1428,14 +1429,15 @@ describe('@lumino/widgets', () => {
             expect(args.index).to.equal(0);
             expect(args.title).to.equal(bar.titles[0]);
             expect(args.clientX).to.equal(rect.right + 200);
-            expect(args.clientY).to.equal(rect.top);
+            // Firefox on macos sometimes returns floats for rect.top
+            expect(args.clientY).to.equal(Math.round(rect.top));
             called = true;
           });
           let rect = bar.contentNode.getBoundingClientRect();
           document.body.dispatchEvent(
             new PointerEvent('pointermove', {
               clientX: rect.right + 200,
-              clientY: rect.top,
+              clientY: Math.round(rect.top),
               cancelable: true
             })
           );


### PR DESCRIPTION
As a follow-up to #786, this fixes more tests where we have pointer events right on the element boundaries. We instead move the pointer event 1px into the element to ensure we hit the element.

This should fix some more tests that were flaky over in #784.