### PR TITLE
Keep tab widths frozen when closing tabs

### DIFF
--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -1406,14 +1406,21 @@ export class TabBar<T> extends Widget {
 
     // Clear the inline width on all tabs, triggering the CSS transition.
     let tabs = this.contentNode.children;
+    if (tabs.length === 0) {
+      this.removeClass('lm-mod-unfreezing');
+    } else {
+      const onTransitionEnd = (event: Event) => {
+        if ((event as TransitionEvent).propertyName === 'width') {
+          this.removeClass('lm-mod-unfreezing');
+          this.node.removeEventListener('transitionend', onTransitionEnd);
+        }
+      };
+      this.node.addEventListener('transitionend', onTransitionEnd);
+    }
+
     for (let i = 0, n = tabs.length; i < n; ++i) {
       (tabs[i] as HTMLElement).style.width = '';
     }
-
-    // Remove the unfreezing class after the transition completes.
-    setTimeout(() => {
-      this.removeClass('lm-mod-unfreezing');
-    }, 150);
 
     // Schedule an update to re-render the tabs at natural size.
     this.update();

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -502,6 +502,17 @@ export class TabBar<T> extends Widget {
    * This is a no-op if the index is out of range.
    */
   removeTabAt(index: number): void {
+    if (this._tabSizeFrozen) {
+      // Capture the widths of all tabs that will remain.
+      let tabs = this.contentNode.children;
+      this._frozenTabWidths = [];
+      for (let i = 0, n = tabs.length; i < n; ++i) {
+        if (i !== index) {
+          this._frozenTabWidths.push((tabs[i] as HTMLElement).offsetWidth);
+        }
+      }
+    }
+
     // Release the mouse before making any changes.
     this._releaseMouse();
 
@@ -606,6 +617,9 @@ export class TabBar<T> extends Widget {
       case 'pointerup':
         this._evtPointerUp(event as PointerEvent);
         break;
+      case 'pointerleave':
+        this._evtPointerLeave(event as PointerEvent);
+        break;
       case 'dblclick':
         this._evtDblClick(event as MouseEvent);
         break;
@@ -626,6 +640,7 @@ export class TabBar<T> extends Widget {
    */
   protected onBeforeAttach(msg: Message): void {
     this.node.addEventListener('pointerdown', this);
+    this.node.addEventListener('pointerleave', this);
     this.node.addEventListener('dblclick', this);
     this.node.addEventListener('keydown', this);
   }
@@ -635,6 +650,7 @@ export class TabBar<T> extends Widget {
    */
   protected onAfterDetach(msg: Message): void {
     this.node.removeEventListener('pointerdown', this);
+    this.node.removeEventListener('pointerleave', this);
     this.node.removeEventListener('dblclick', this);
     this.node.removeEventListener('keydown', this);
     this._releaseMouse();
@@ -664,6 +680,25 @@ export class TabBar<T> extends Widget {
       content[i] = renderer.renderTab({ title, current, zIndex, tabIndex });
     }
     VirtualDOM.render(content, this.contentNode);
+    if (this._tabSizeFrozen) {
+      let tabs = this.contentNode.children;
+      if (
+        this._frozenTabWidths &&
+        this._frozenTabWidths.length === tabs.length
+      ) {
+        for (let i = 0, n = tabs.length; i < n; ++i) {
+          (
+            tabs[i] as HTMLElement
+          ).style.width = `${this._frozenTabWidths[i]}px`;
+        }
+        this._frozenTabWidths = null;
+      } else {
+        for (let i = 0, n = tabs.length; i < n; ++i) {
+          let tab = tabs[i] as HTMLElement;
+          tab.style.width = `${tab.offsetWidth}px`;
+        }
+      }
+    }
   }
 
   /**
@@ -1103,6 +1138,7 @@ export class TabBar<T> extends Widget {
       // Emit the close requested signal if the close icon was released.
       let icon = tabs[index].querySelector(this.renderer.closeIconSelector);
       if (icon && icon.contains(event.target as HTMLElement)) {
+        this._tabSizeFrozen = true;
         this._tabCloseRequested.emit({ index, title });
         return;
       }
@@ -1349,6 +1385,40 @@ export class TabBar<T> extends Widget {
     this.update();
   }
 
+  /**
+   * Handle the `'pointerleave'` event for the tab bar.
+   *
+   * This restores the natural tab sizing after tabs were frozen
+   * due to a close-icon click.
+   */
+  private _evtPointerLeave(event: PointerEvent): void {
+    // Do nothing if tab sizes are not currently frozen.
+    if (!this._tabSizeFrozen) {
+      return;
+    }
+
+    // Unfreeze tab sizes.
+    this._tabSizeFrozen = false;
+    this._frozenTabWidths = null;
+
+    // Add the unfreezing class to enable a smooth width transition.
+    this.addClass('lm-mod-unfreezing');
+
+    // Clear the inline width on all tabs, triggering the CSS transition.
+    let tabs = this.contentNode.children;
+    for (let i = 0, n = tabs.length; i < n; ++i) {
+      (tabs[i] as HTMLElement).style.width = '';
+    }
+
+    // Remove the unfreezing class after the transition completes.
+    setTimeout(() => {
+      this.removeClass('lm-mod-unfreezing');
+    }, 150);
+
+    // Schedule an update to re-render the tabs at natural size.
+    this.update();
+  }
+
   private _name: string;
   private _currentIndex = -1;
   private _titles: Title<T>[] = [];
@@ -1357,6 +1427,8 @@ export class TabBar<T> extends Widget {
   private _titlesEditable: boolean = false;
   private _previousTitle: Title<T> | null = null;
   private _dragData: Private.IDragData | null = null;
+  private _tabSizeFrozen = false;
+  private _frozenTabWidths: number[] | null = null;
   private _addButtonEnabled: boolean = false;
   private _tabMoved = new Signal<this, TabBar.ITabMovedArgs<T>>(this);
   private _currentChanged = new Signal<this, TabBar.ICurrentChangedArgs<T>>(

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -659,6 +659,7 @@ export class TabBar<T> extends Widget {
     this.node.removeEventListener('dblclick', this);
     this.node.removeEventListener('keydown', this);
     this._clearUnfreezeTransitionState();
+    this._clearTabSizeFreezeState();
     this._releaseMouse();
   }
 
@@ -1487,6 +1488,21 @@ export class TabBar<T> extends Widget {
     if (this._unfreezeFallbackTimerID !== 0) {
       clearTimeout(this._unfreezeFallbackTimerID);
       this._unfreezeFallbackTimerID = 0;
+    }
+  }
+
+  /**
+   * Clear transient tab-size freeze state and styles.
+   */
+  private _clearTabSizeFreezeState(): void {
+    this._tabSizeFrozen = false;
+    this._frozenTabWidths = null;
+    this.removeClass('lm-mod-unfreezing');
+    let tabs = this.contentNode.children;
+    for (let i = 0, n = tabs.length; i < n; ++i) {
+      let tab = tabs[i] as HTMLElement;
+      tab.style.width = '';
+      tab.style.flexBasis = '';
     }
   }
 

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -502,14 +502,19 @@ export class TabBar<T> extends Widget {
    * This is a no-op if the index is out of range.
    */
   removeTabAt(index: number): void {
+    let indexIsValid = index >= 0 && index < this._titles.length;
     if (this._tabSizeFrozen) {
-      // Capture the widths of all tabs that will remain.
-      let tabs = this.contentNode.children;
-      this._frozenTabWidths = [];
-      for (let i = 0, n = tabs.length; i < n; ++i) {
-        if (i !== index) {
-          this._frozenTabWidths.push((tabs[i] as HTMLElement).offsetWidth);
+      if (indexIsValid) {
+        // Capture the widths of all tabs that will remain.
+        let tabs = this.contentNode.children;
+        this._frozenTabWidths = [];
+        for (let i = 0, n = tabs.length; i < n; ++i) {
+          if (i !== index) {
+            this._frozenTabWidths.push((tabs[i] as HTMLElement).offsetWidth);
+          }
         }
+      } else {
+        this._frozenTabWidths = null;
       }
     }
 
@@ -653,6 +658,7 @@ export class TabBar<T> extends Widget {
     this.node.removeEventListener('pointerleave', this);
     this.node.removeEventListener('dblclick', this);
     this.node.removeEventListener('keydown', this);
+    this._clearUnfreezeTransitionState();
     this._releaseMouse();
   }
 
@@ -687,15 +693,17 @@ export class TabBar<T> extends Widget {
         this._frozenTabWidths.length === tabs.length
       ) {
         for (let i = 0, n = tabs.length; i < n; ++i) {
-          (
-            tabs[i] as HTMLElement
-          ).style.width = `${this._frozenTabWidths[i]}px`;
+          this._setFrozenTabSize(
+            tabs[i] as HTMLElement,
+            this._frozenTabWidths[i]
+          );
         }
         this._frozenTabWidths = null;
       } else {
+        this._frozenTabWidths = null;
         for (let i = 0, n = tabs.length; i < n; ++i) {
           let tab = tabs[i] as HTMLElement;
-          tab.style.width = `${tab.offsetWidth}px`;
+          this._setFrozenTabSize(tab, tab.offsetWidth);
         }
       }
     }
@@ -1401,29 +1409,85 @@ export class TabBar<T> extends Widget {
     this._tabSizeFrozen = false;
     this._frozenTabWidths = null;
 
+    // Start a new unfreeze run and clear stale listeners/timers.
+    this._unfreezeRunID++;
+    let runID = this._unfreezeRunID;
+    this._clearUnfreezeTransitionState();
+
     // Add the unfreezing class to enable a smooth width transition.
     this.addClass('lm-mod-unfreezing');
 
     // Clear the inline width on all tabs, triggering the CSS transition.
     let tabs = this.contentNode.children;
+    for (let i = 0, n = tabs.length; i < n; ++i) {
+      let tab = tabs[i] as HTMLElement;
+      tab.style.width = '';
+      tab.style.flexBasis = '';
+    }
+
     if (tabs.length === 0) {
       this.removeClass('lm-mod-unfreezing');
     } else {
-      const onTransitionEnd = (event: Event) => {
-        if ((event as TransitionEvent).propertyName === 'width') {
-          this.removeClass('lm-mod-unfreezing');
-          this.node.removeEventListener('transitionend', onTransitionEnd);
+      let onTransitionDone = (event: Event) => {
+        let propertyName = (event as TransitionEvent).propertyName;
+        if (propertyName === 'width' || propertyName === 'flex-basis') {
+          this._finalizeUnfreezeRun(runID);
         }
       };
-      this.node.addEventListener('transitionend', onTransitionEnd);
-    }
-
-    for (let i = 0, n = tabs.length; i < n; ++i) {
-      (tabs[i] as HTMLElement).style.width = '';
+      this._unfreezeTransitionListener = onTransitionDone;
+      this.node.addEventListener('transitionend', onTransitionDone);
+      this.node.addEventListener('transitioncancel', onTransitionDone);
+      this._unfreezeFallbackTimerID = window.setTimeout(() => {
+        this._finalizeUnfreezeRun(runID);
+      }, 2000);
     }
 
     // Schedule an update to re-render the tabs at natural size.
     this.update();
+  }
+
+  /**
+   * Apply a frozen size to a tab.
+   *
+   * The width is mirrored to `flex-basis` so frozen sizing works even when
+   * themes define tab sizing through flex rules.
+   */
+  private _setFrozenTabSize(tab: HTMLElement, width: number): void {
+    let size = `${width}px`;
+    tab.style.width = size;
+    tab.style.flexBasis = size;
+  }
+
+  /**
+   * Finish an in-flight unfreeze transition run.
+   */
+  private _finalizeUnfreezeRun(runID: number): void {
+    if (runID !== this._unfreezeRunID) {
+      return;
+    }
+    this._clearUnfreezeTransitionState();
+    this.removeClass('lm-mod-unfreezing');
+  }
+
+  /**
+   * Remove unfreeze listeners and timers.
+   */
+  private _clearUnfreezeTransitionState(): void {
+    if (this._unfreezeTransitionListener) {
+      this.node.removeEventListener(
+        'transitionend',
+        this._unfreezeTransitionListener
+      );
+      this.node.removeEventListener(
+        'transitioncancel',
+        this._unfreezeTransitionListener
+      );
+      this._unfreezeTransitionListener = null;
+    }
+    if (this._unfreezeFallbackTimerID !== 0) {
+      clearTimeout(this._unfreezeFallbackTimerID);
+      this._unfreezeFallbackTimerID = 0;
+    }
   }
 
   private _name: string;
@@ -1436,6 +1500,9 @@ export class TabBar<T> extends Widget {
   private _dragData: Private.IDragData | null = null;
   private _tabSizeFrozen = false;
   private _frozenTabWidths: number[] | null = null;
+  private _unfreezeRunID = 0;
+  private _unfreezeFallbackTimerID = 0;
+  private _unfreezeTransitionListener: ((event: Event) => void) | null = null;
   private _addButtonEnabled: boolean = false;
   private _tabMoved = new Signal<this, TabBar.ITabMovedArgs<T>>(this);
   private _currentChanged = new Signal<this, TabBar.ICurrentChangedArgs<T>>(

--- a/packages/widgets/style/tabbar.css
+++ b/packages/widgets/style/tabbar.css
@@ -97,6 +97,10 @@
   transition: none;
 }
 
+.lm-TabBar.lm-mod-unfreezing .lm-TabBar-tab {
+  transition: width 150ms ease;
+}
+
 .lm-TabBar-tabLabel .lm-TabBar-tabInput {
   user-select: all;
   width: 100%;

--- a/packages/widgets/style/tabbar.css
+++ b/packages/widgets/style/tabbar.css
@@ -98,7 +98,9 @@
 }
 
 .lm-TabBar.lm-mod-unfreezing .lm-TabBar-tab {
-  transition: width 150ms ease;
+  transition:
+    width 150ms ease,
+    flex-basis 150ms ease;
 }
 
 .lm-TabBar-tabLabel .lm-TabBar-tabInput {

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1039,6 +1039,51 @@ describe('@lumino/widgets', () => {
           });
         });
       });
+
+      it('should not freeze tab widths if closed programmatically (e.g., keyboard shortcut)', () => {
+        populateBar(bar);
+        MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
+        let tabs = bar.contentNode.children;
+        let originalWidth = (tabs[0] as HTMLElement).style.width;
+
+        bar.removeTabAt(0);
+        MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
+
+        // Since it was closed programmatically (no close-icon click),
+        // widths should NOT be explicitly frozen.
+        expect((tabs[0] as HTMLElement).style.width).to.equal(originalWidth);
+      });
+
+      it('should freeze tab widths if closed via close icon and unfreeze on pointerleave', () => {
+        populateBar(bar);
+        MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
+
+        let tabs = bar.contentNode.children;
+        let closeIcon = tabs[0].querySelector(
+          bar.renderer.closeIconSelector
+        ) as HTMLElement;
+
+        bar.tabCloseRequested.connect((sender, args) => {
+          bar.removeTabAt(args.index);
+          MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
+        });
+
+        simulateOnNode(closeIcon, 'pointerdown');
+        simulateOnNode(closeIcon, 'pointerup');
+
+        let remainingTabs = bar.contentNode.children;
+        expect((remainingTabs[0] as HTMLElement).style.width).to.not.equal('');
+
+        bar.node.dispatchEvent(
+          new PointerEvent('pointerleave', { bubbles: false })
+        );
+        MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
+
+        expect(bar.hasClass('lm-mod-unfreezing')).to.equal(true);
+        for (let i = 0, n = remainingTabs.length; i < n; ++i) {
+          expect((remainingTabs[i] as HTMLElement).style.width).to.equal('');
+        }
+      });
     });
 
     describe('#clearTabs()', () => {

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1059,14 +1059,17 @@ describe('@lumino/widgets', () => {
         populateBar(bar);
         MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
         let tabs = bar.contentNode.children;
-        let originalWidth = (tabs[0] as HTMLElement).style.width;
 
         bar.removeTabAt(0);
         MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
 
         // Since it was closed programmatically (no close-icon click),
         // widths should NOT be explicitly frozen.
-        expect((tabs[0] as HTMLElement).style.width).to.equal(originalWidth);
+        tabs = bar.contentNode.children;
+        for (let i = 0, n = tabs.length; i < n; ++i) {
+          expect((tabs[i] as HTMLElement).style.width).to.equal('');
+          expect((tabs[i] as HTMLElement).style.flexBasis).to.equal('');
+        }
       });
 
       it('should freeze tab widths if closed via close icon and unfreeze on pointerleave', () => {

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -1058,14 +1058,13 @@ describe('@lumino/widgets', () => {
       it('should not freeze tab widths if closed programmatically (e.g., keyboard shortcut)', () => {
         populateBar(bar);
         MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
-        let tabs = bar.contentNode.children;
 
         bar.removeTabAt(0);
         MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
 
         // Since it was closed programmatically (no close-icon click),
         // widths should NOT be explicitly frozen.
-        tabs = bar.contentNode.children;
+        let tabs = bar.contentNode.children;
         for (let i = 0, n = tabs.length; i < n; ++i) {
           expect((tabs[i] as HTMLElement).style.width).to.equal('');
           expect((tabs[i] as HTMLElement).style.flexBasis).to.equal('');

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -118,6 +118,21 @@ function simulateOnNode(node: Element, action: Action): void {
   );
 }
 
+function createTransitionEvent(
+  type: 'transitionend' | 'transitioncancel',
+  propertyName: string
+): Event {
+  if (typeof TransitionEvent === 'function') {
+    return new TransitionEvent(type, {
+      bubbles: true,
+      propertyName
+    });
+  }
+  let event = new Event(type, { bubbles: true });
+  Object.defineProperty(event, 'propertyName', { value: propertyName });
+  return event;
+}
+
 describe('@lumino/widgets', () => {
   describe('TabBar', () => {
     let bar: LogTabBar;
@@ -1073,6 +1088,9 @@ describe('@lumino/widgets', () => {
 
         let remainingTabs = bar.contentNode.children;
         expect((remainingTabs[0] as HTMLElement).style.width).to.not.equal('');
+        expect((remainingTabs[0] as HTMLElement).style.flexBasis).to.not.equal(
+          ''
+        );
 
         bar.node.dispatchEvent(
           new PointerEvent('pointerleave', { bubbles: false })
@@ -1082,7 +1100,56 @@ describe('@lumino/widgets', () => {
         expect(bar.hasClass('lm-mod-unfreezing')).to.equal(true);
         for (let i = 0, n = remainingTabs.length; i < n; ++i) {
           expect((remainingTabs[i] as HTMLElement).style.width).to.equal('');
+          expect((remainingTabs[i] as HTMLElement).style.flexBasis).to.equal(
+            ''
+          );
         }
+      });
+
+      it('should remove unfreezing class on transition cancel or end', () => {
+        populateBar(bar);
+        MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
+
+        let tabs = bar.contentNode.children;
+        let closeIcon = tabs[0].querySelector(
+          bar.renderer.closeIconSelector
+        ) as HTMLElement;
+
+        bar.tabCloseRequested.connect((sender, args) => {
+          bar.removeTabAt(args.index);
+          MessageLoop.sendMessage(bar, Widget.Msg.UpdateRequest);
+        });
+
+        simulateOnNode(closeIcon, 'pointerdown');
+        simulateOnNode(closeIcon, 'pointerup');
+
+        bar.node.dispatchEvent(
+          new PointerEvent('pointerleave', { bubbles: false })
+        );
+        expect(bar.hasClass('lm-mod-unfreezing')).to.equal(true);
+
+        let firstRemainingTab = bar.contentNode.children[0];
+        firstRemainingTab.dispatchEvent(
+          createTransitionEvent('transitioncancel', 'flex-basis')
+        );
+        expect(bar.hasClass('lm-mod-unfreezing')).to.equal(false);
+
+        // Start another freeze/unfreeze run and finish on transition end.
+        closeIcon = bar.contentNode.children[0].querySelector(
+          bar.renderer.closeIconSelector
+        ) as HTMLElement;
+        simulateOnNode(closeIcon, 'pointerdown');
+        simulateOnNode(closeIcon, 'pointerup');
+        bar.node.dispatchEvent(
+          new PointerEvent('pointerleave', { bubbles: false })
+        );
+        expect(bar.hasClass('lm-mod-unfreezing')).to.equal(true);
+
+        firstRemainingTab = bar.contentNode.children[0];
+        firstRemainingTab.dispatchEvent(
+          createTransitionEvent('transitionend', 'width')
+        );
+        expect(bar.hasClass('lm-mod-unfreezing')).to.equal(false);
       });
     });
 


### PR DESCRIPTION
fixes https://github.com/jupyterlab/jupyterlab/issues/10514 

This pull request brings Chrome-like tab closing behavior to the TabBar. When a user clicks the close icon (x) on a tab, the remaining tabs temporarily maintain their current widths rather than immediately reflowing to fill the empty space. This ensures that the next tab's close button lands directly under the user's cursor. Once the user moves their cursor away from the tab bar, the tabs smoothly transition back to their natural sizes.

### Before
https://github.com/user-attachments/assets/347205a7-6494-49ca-9229-306b7d4c1e0b

### After
https://github.com/user-attachments/assets/d319f918-434e-48fb-bccf-5bcb8aab98c6



