### PR TITLE
Add attachment node distinction for shadow DOM

### DIFF
--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -1,3 +1,14 @@
+# 2026-04-XX
+
+## Replace `widget.node` with `widget.attachmentNode`
+
+Lumino 2026-04-XX distinguishes between the widget contents node (`node`)
+and attachment node (`attachmentNode`) to enable shadow DOM support.
+By default attachment and contents node are the same, but subclasses
+may override the attachment node to represent a wrapper owning the shadow DOM root.
+Downstream layouts are encouraged to update methods attaching and detaching widgets
+to use attachment node to support moving the widgets to shadow DOM.
+
 # Migration guide for Lumino 1 to Lumino 2
 
 ## Iterables, iterators, and generators

--- a/packages/widgets/src/docklayout.ts
+++ b/packages/widgets/src/docklayout.ts
@@ -545,7 +545,7 @@ export class DockLayout extends Layout {
    */
   protected attachWidget(widget: Widget): void {
     // Do nothing if the widget is already attached.
-    if (this.parent!.node === widget.node.parentNode) {
+    if (this.parent!.node === widget.attachmentNode.parentNode) {
       return;
     }
 
@@ -558,7 +558,7 @@ export class DockLayout extends Layout {
     }
 
     // Add the widget's node to the parent.
-    this.parent!.node.appendChild(widget.node);
+    this.parent!.node.appendChild(widget.attachmentNode);
 
     // Send an `'after-attach'` message if the parent is attached.
     if (this.parent!.isAttached) {
@@ -576,7 +576,7 @@ export class DockLayout extends Layout {
    */
   protected detachWidget(widget: Widget): void {
     // Do nothing if the widget is not attached.
-    if (this.parent!.node !== widget.node.parentNode) {
+    if (this.parent!.node !== widget.attachmentNode.parentNode) {
       return;
     }
 
@@ -586,7 +586,7 @@ export class DockLayout extends Layout {
     }
 
     // Remove the widget's node from the parent.
-    this.parent!.node.removeChild(widget.node);
+    this.parent!.node.removeChild(widget.attachmentNode);
 
     // Send an `'after-detach'` message if the parent is attached.
     if (this.parent!.isAttached) {

--- a/packages/widgets/src/panellayout.ts
+++ b/packages/widgets/src/panellayout.ts
@@ -212,7 +212,7 @@ export class PanelLayout extends Layout {
     }
 
     // Insert the widget's node before the sibling.
-    this.parent!.node.insertBefore(widget.node, ref);
+    this.parent!.node.insertBefore(widget.attachmentNode, ref);
 
     // Send an `'after-attach'` message if the parent is attached.
     if (this.parent!.isAttached) {
@@ -251,7 +251,7 @@ export class PanelLayout extends Layout {
     }
 
     // Remove the widget's node from the parent.
-    this.parent!.node.removeChild(widget.node);
+    this.parent!.node.removeChild(widget.attachmentNode);
 
     // Send an `'after-detach'` and  message if the parent is attached.
     if (this.parent!.isAttached) {
@@ -267,7 +267,7 @@ export class PanelLayout extends Layout {
     }
 
     // Insert the widget's node before the sibling.
-    this.parent!.node.insertBefore(widget.node, ref);
+    this.parent!.node.insertBefore(widget.attachmentNode, ref);
 
     // Send an `'after-attach'` message if the parent is attached.
     if (this.parent!.isAttached) {
@@ -300,7 +300,7 @@ export class PanelLayout extends Layout {
     }
 
     // Remove the widget's node from the parent.
-    this.parent!.node.removeChild(widget.node);
+    this.parent!.node.removeChild(widget.attachmentNode);
 
     // Send an `'after-detach'` message if the parent is attached.
     if (this.parent!.isAttached) {

--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -41,6 +41,8 @@ export class Widget implements IMessageHandler, IObservableDisposable {
    */
   constructor(options: Widget.IOptions = {}) {
     this.node = Private.createNode(options);
+    this.attachmentNode = options.attachmentNode ?? this.node;
+    this.attachmentNode.classList.add('lm-attachmentNode');
     this.addClass('lm-Widget');
   }
 
@@ -95,6 +97,11 @@ export class Widget implements IMessageHandler, IObservableDisposable {
    * Get the DOM node owned by the widget.
    */
   readonly node: HTMLElement;
+
+  /**
+   * Get the node which should be attached to the parent in order to attach the widget.
+   */
+  readonly attachmentNode: HTMLElement;
 
   /**
    * Test whether the widget has been disposed.
@@ -817,6 +824,16 @@ export namespace Widget {
     node?: HTMLElement;
 
     /**
+     * The optional wrapper node to use for attachement to the parent widget.
+     *
+     * If both `node` and `attachmentNode` are provided, the `node`
+     * has to be in the DOM subtree or shadow DOM subtree of the `attachmentNode`.
+     *
+     * By default the same node as for `node` will be used.
+     */
+    attachmentNode?: HTMLElement;
+
+    /**
      * The optional element tag, used for constructing the widget's node.
      *
      * If a pre-constructed node is provided via the `node` arg, this
@@ -1113,14 +1130,15 @@ export namespace Widget {
     if (widget.parent) {
       throw new Error('Cannot attach a child widget.');
     }
-    if (widget.isAttached || widget.node.isConnected) {
+    if (widget.isAttached || widget.attachmentNode.isConnected) {
       throw new Error('Widget is already attached.');
     }
     if (!host.isConnected) {
       throw new Error('Host is not attached.');
     }
+
     MessageLoop.sendMessage(widget, Widget.Msg.BeforeAttach);
-    host.insertBefore(widget.node, ref);
+    host.insertBefore(widget.attachmentNode, ref);
     MessageLoop.sendMessage(widget, Widget.Msg.AfterAttach);
   }
 
@@ -1137,11 +1155,11 @@ export namespace Widget {
     if (widget.parent) {
       throw new Error('Cannot detach a child widget.');
     }
-    if (!widget.isAttached || !widget.node.isConnected) {
+    if (!widget.isAttached || !widget.attachmentNode.isConnected) {
       throw new Error('Widget is not attached.');
     }
     MessageLoop.sendMessage(widget, Widget.Msg.BeforeDetach);
-    widget.node.parentNode!.removeChild(widget.node);
+    widget.attachmentNode.parentNode!.removeChild(widget.attachmentNode);
     MessageLoop.sendMessage(widget, Widget.Msg.AfterDetach);
   }
 }

--- a/packages/widgets/tests/src/widget.spec.ts
+++ b/packages/widgets/tests/src/widget.spec.ts
@@ -104,6 +104,16 @@ class TestLayout extends Layout {
   private _widgets = [new Widget(), new Widget()];
 }
 
+class ShadowDOMWidget extends Widget {
+  constructor(options?: Widget.IOptions) {
+    const attachmentNode = document.createElement('div');
+    super({ ...options, attachmentNode });
+    attachmentNode.classList.add('lm-customAttachmentNode');
+    const root = attachmentNode.attachShadow({ mode: 'open' });
+    root.appendChild(this.node);
+  }
+}
+
 describe('@lumino/widgets', () => {
   describe('Widget', () => {
     describe('#constructor()', () => {
@@ -121,6 +131,25 @@ describe('@lumino/widgets', () => {
       it('should add the `lm-Widget` class', () => {
         let widget = new Widget();
         expect(widget.hasClass('lm-Widget')).to.equal(true);
+      });
+    });
+
+    describe('#attachmentNode', () => {
+      it('should default to the main node', () => {
+        let widget = new Widget();
+        expect(widget.attachmentNode).to.equal(widget.node);
+      });
+
+      it('should be overridable in a subclass', () => {
+        let widget = new ShadowDOMWidget();
+        expect(widget.attachmentNode).to.not.equal(widget.node);
+        expect(
+          widget.attachmentNode.classList.contains('lm-customAttachmentNode')
+        ).to.equal(true);
+        expect(widget.attachmentNode.shadowRoot).to.not.equal(null);
+        expect(
+          widget.attachmentNode.shadowRoot!.contains(widget.node)
+        ).to.equal(true);
       });
     });
 
@@ -1180,6 +1209,19 @@ describe('@lumino/widgets', () => {
         widget.dispose();
       });
 
+      it('should attach a shadow DOM widget to a host using attachmentNode', () => {
+        let widget = new ShadowDOMWidget();
+        expect(widget.isAttached).to.equal(false);
+        expect(widget.attachmentNode).to.not.equal(widget.node);
+        Widget.attach(widget, document.body);
+        expect(widget.isAttached).to.equal(true);
+        expect(document.body.contains(widget.attachmentNode)).to.equal(true);
+        expect(
+          widget.attachmentNode.shadowRoot!.contains(widget.node)
+        ).to.equal(true);
+        widget.dispose();
+      });
+
       it('should throw if the widget is not a root', () => {
         let parent = new Widget();
         let child = new Widget();
@@ -1252,6 +1294,16 @@ describe('@lumino/widgets', () => {
         Widget.detach(widget);
         expect(widget.messages).to.contain('before-detach');
         widget.dispose();
+      });
+
+      it('should detach a shadow DOM widget from its host using attachmentNode', () => {
+        let widget = new ShadowDOMWidget();
+        Widget.attach(widget, document.body);
+        expect(widget.isAttached).to.equal(true);
+        expect(document.body.contains(widget.attachmentNode)).to.equal(true);
+        Widget.detach(widget);
+        expect(widget.isAttached).to.equal(false);
+        expect(document.body.contains(widget.attachmentNode)).to.equal(false);
       });
     });
   });


### PR DESCRIPTION
This PR enables downstreams to define `ShadowDOMWidget` without introducing it to the public API surface of lumino. This is a minimal change adding a readonly `attachmentNode` attribute and `attachmentNode` constructor option.

- Extracted from https://github.com/jupyterlab/lumino/pull/517