### PR TITLE
Freeze size of heavy nodes when resizing panels

### DIFF
--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -1184,6 +1184,7 @@ export class DockPanel extends Widget {
       entry.el.style.height = `${entry.rect.height}px`;
       entry.el.style.minHeight = `${entry.rect.height}px`;
       entry.el.style.contain = 'strict';
+      entry.el.classList.add('lm-layout-frozen');
     }
 
     console.log(`[DockPanel] froze ${this._frozenElements.length} elements`);
@@ -1274,6 +1275,7 @@ export class DockPanel extends Widget {
       entry.element.style.minWidth = entry.prevMinWidth;
       entry.element.style.height = entry.prevHeight;
       entry.element.style.minHeight = entry.prevMinHeight;
+      entry.element.classList.remove('lm-layout-frozen');
     }
     this._frozenElements = [];
   }
@@ -1686,7 +1688,7 @@ namespace Private {
    * The periodic interval (in ms) for refreshing frozen element
    * sizes during long continuous drags.
    */
-  export const REFRESH_INTERVAL_MS = 2000;
+  export const REFRESH_INTERVAL_MS = 5000;
 
   /**
    * An object which holds mouse press data.

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -761,6 +761,9 @@ export class DockPanel extends Widget {
     // pointerdown will detect if the resulting frame is slow.
     let layout = this.layout as DockLayout;
     layout.moveHandle(this._pressData.handle, xPos, yPos);
+
+    // Debounce: refresh frozen elements after the user stops moving.
+    this._scheduleRefresh();
   }
 
   /**
@@ -1148,15 +1151,22 @@ export class DockPanel extends Widget {
       Private.collectHeavyWidgets(child, this._nodeCountThreshold, targets);
     }
 
-    // Pass 1: read all dimensions before mutations.
-    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
+    // Collect widget nodes and their direct DOM children.
+    let elements: HTMLElement[] = [];
     for (let target of targets) {
       let el = target.node;
+      elements.push(el);
+      for (let i = 0; i < el.children.length; i++) {
+        elements.push(el.children[i] as HTMLElement);
+      }
+    }
+
+    // Pass 1: read all dimensions before mutations.
+    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
+    for (let el of elements) {
       if (el.style.contain === 'strict') {
-        console.log(`[DockPanel] "${target.title.label}" already has contain:strict, skipping`);
         continue;
       }
-      console.log(`[DockPanel] freezing "${target.title.label}" (${el.querySelectorAll('*').length} nodes)`);
       entries.push({
         el,
         rect: el.getBoundingClientRect(),
@@ -1181,11 +1191,31 @@ export class DockPanel extends Widget {
 
     console.log(`[DockPanel] froze ${this._frozenElements.length} heavy widget nodes`);
 
+    // Start periodic interval to keep sizes roughly correct
+    // during long continuous drags.
     if (this._frozenElements.length > 0 && this._intervalId === 0) {
       this._intervalId = window.setInterval(() => {
         this._refreshFrozenElements();
       }, Private.REFRESH_INTERVAL_MS);
     }
+  }
+
+  /**
+   * Schedule a debounced refresh of frozen elements. Resets on
+   * each call so the refresh only fires after the user stops
+   * moving the handle.
+   */
+  private _scheduleRefresh(): void {
+    if (this._frozenElements.length === 0) {
+      return;
+    }
+    if (this._refreshTimerId !== 0) {
+      clearTimeout(this._refreshTimerId);
+    }
+    this._refreshTimerId = window.setTimeout(() => {
+      this._refreshTimerId = 0;
+      this._refreshFrozenElements();
+    }, Private.REFRESH_DEBOUNCE_MS);
   }
 
   /**
@@ -1218,6 +1248,10 @@ export class DockPanel extends Widget {
    */
   private _unfreezeElements(): void {
     console.log(`[DockPanel] unfreezing ${this._frozenElements.length} elements`);
+    if (this._refreshTimerId !== 0) {
+      clearTimeout(this._refreshTimerId);
+      this._refreshTimerId = 0;
+    }
     if (this._intervalId !== 0) {
       clearInterval(this._intervalId);
       this._intervalId = 0;
@@ -1233,6 +1267,7 @@ export class DockPanel extends Widget {
 
   private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
   private _frozenElements: Private.IFrozenElement[] = [];
+  private _refreshTimerId = 0;
   private _intervalId = 0;
 }
 
@@ -1626,10 +1661,16 @@ namespace Private {
   export const DEFAULT_NODE_COUNT_THRESHOLD = 100;
 
   /**
-   * The interval (in ms) at which frozen elements have their sizes
-   * refreshed during handle dragging.
+   * The delay (in ms) after the last pointer move before refreshing
+   * frozen element sizes.
    */
-  export const REFRESH_INTERVAL_MS = 5000;
+  export const REFRESH_DEBOUNCE_MS = 300;
+
+  /**
+   * The periodic interval (in ms) for refreshing frozen element
+   * sizes during long continuous drags.
+   */
+  export const REFRESH_INTERVAL_MS = 2000;
 
   /**
    * An object which holds mouse press data.
@@ -1771,18 +1812,41 @@ namespace Private {
   }
 
   /**
+   * The minimum total text length in a widget's subtree to
+   * consider it heavy, independent of node count.
+   */
+  export const DEFAULT_TEXT_LENGTH_THRESHOLD = 25000;
+
+  /**
+   * Determine whether a DOM subtree is heavy enough to warrant
+   * containment. A subtree is heavy if it has many nodes or a
+   * large amount of text content.
+   */
+  export function isDOMHeavy(
+    el: HTMLElement,
+    nodeCountThreshold: number,
+    textLengthThreshold: number = DEFAULT_TEXT_LENGTH_THRESHOLD
+  ): boolean {
+    if (el.querySelectorAll('*').length >= nodeCountThreshold) {
+      return true;
+    }
+    if ((el.textContent?.length ?? 0) >= textLengthThreshold) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Recursively find the deepest widgets whose subtree is heavy
-   * (node count >= threshold) but whose child widgets are all
-   * individually light. This places containment as low in the
-   * DOM tree as possible.
+   * but whose child widgets are all individually light. This
+   * places containment as low in the DOM tree as possible.
    */
   export function collectHeavyWidgets(
     widget: Widget,
     threshold: number,
     result: Widget[]
   ): void {
-    let nodeCount = widget.node.querySelectorAll('*').length;
-    if (nodeCount < threshold) {
+    if (!isDOMHeavy(widget.node, threshold)) {
       return;
     }
     let layout = widget.layout;
@@ -1794,7 +1858,7 @@ namespace Private {
     // Check if any child widget is individually heavy.
     let anyChildHeavy = false;
     for (let child of layout) {
-      if (child.node.querySelectorAll('*').length >= threshold) {
+      if (isDOMHeavy(child.node, threshold)) {
         anyChildHeavy = true;
         break;
       }

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -1104,7 +1104,7 @@ export class DockPanel extends Widget {
     }
     try {
       this._performanceObserver = new PerformanceObserver(() => {
-        if (this._frozenElements.length === 0) {
+        if (this._frozenGroups.length === 0) {
           console.log('[DockPanel] long task detected during drag, freezing heavy leaf widgets');
           this._freezeHeavyLeaves();
         }
@@ -1141,7 +1141,7 @@ export class DockPanel extends Widget {
    * subtree exceeds the node count threshold.
    */
   private _freezeHeavyLeaves(): void {
-    if (this._frozenElements.length > 0) {
+    if (this._frozenGroups.length > 0) {
       return;
     }
 
@@ -1151,49 +1151,55 @@ export class DockPanel extends Widget {
       Private.collectHeavyWidgets(child, this._nodeCountThreshold, targets);
     }
 
-    // Collect widget nodes and their direct DOM children.
-    let elements: HTMLElement[] = [];
+    // Collect elements grouped by target widget.
+    let groups: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[][] = [];
     for (let target of targets) {
       let el = target.node;
-      elements.push(el);
+      let elements: HTMLElement[] = [el];
       for (let i = 0; i < el.children.length; i++) {
         elements.push(el.children[i] as HTMLElement);
       }
-    }
-
-    // Pass 1: read all dimensions before mutations.
-    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
-    for (let el of elements) {
-      if (el.style.contain === 'strict') {
-        continue;
+      // Read dimensions for this group.
+      let group: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
+      for (let elem of elements) {
+        if (elem.style.contain === 'strict') {
+          continue;
+        }
+        group.push({
+          el: elem,
+          rect: elem.getBoundingClientRect(),
+          prevContain: elem.style.contain,
+          prevWidth: elem.style.width,
+          prevHeight: elem.style.height
+        });
       }
-      entries.push({
-        el,
-        rect: el.getBoundingClientRect(),
-        prevContain: el.style.contain,
-        prevWidth: el.style.width,
-        prevHeight: el.style.height
-      });
+      if (group.length > 0) {
+        groups.push(group);
+      }
     }
 
-    // Pass 2: apply containment and pinned sizes.
-    for (let entry of entries) {
-      this._frozenElements.push({
-        element: entry.el,
-        prevContain: entry.prevContain,
-        prevWidth: entry.prevWidth,
-        prevHeight: entry.prevHeight
-      });
-      entry.el.style.width = `${entry.rect.width}px`;
-      entry.el.style.height = `${entry.rect.height}px`;
-      entry.el.style.contain = 'strict';
+    // Apply containment and pinned sizes.
+    for (let group of groups) {
+      let frozenGroup: Private.IFrozenElement[] = [];
+      for (let entry of group) {
+        frozenGroup.push({
+          element: entry.el,
+          prevContain: entry.prevContain,
+          prevWidth: entry.prevWidth,
+          prevHeight: entry.prevHeight
+        });
+        entry.el.style.width = `${entry.rect.width}px`;
+        entry.el.style.height = `${entry.rect.height}px`;
+        entry.el.style.contain = 'strict';
+      }
+      this._frozenGroups.push(frozenGroup);
     }
 
-    console.log(`[DockPanel] froze ${this._frozenElements.length} heavy widget nodes`);
+    console.log(`[DockPanel] froze ${this._frozenGroups.length} groups`);
 
     // Start periodic interval to keep sizes roughly correct
     // during long continuous drags.
-    if (this._frozenElements.length > 0 && this._intervalId === 0) {
+    if (this._frozenGroups.length > 0 && this._intervalId === 0) {
       this._intervalId = window.setInterval(() => {
         this._refreshFrozenElements();
       }, Private.REFRESH_INTERVAL_MS);
@@ -1206,7 +1212,7 @@ export class DockPanel extends Widget {
    * moving the handle.
    */
   private _scheduleRefresh(): void {
-    if (this._frozenElements.length === 0) {
+    if (this._frozenGroups.length === 0) {
       return;
     }
     if (this._refreshTimerId !== 0) {
@@ -1219,27 +1225,35 @@ export class DockPanel extends Widget {
   }
 
   /**
-   * Temporarily lift containment, let the browser reflow, then
-   * re-apply with updated sizes.
+   * Refresh frozen groups one at a time, spreading the reflow
+   * cost across multiple animation frames.
    */
   private _refreshFrozenElements(): void {
-    console.log(`[DockPanel] refreshing ${this._frozenElements.length} frozen elements`);
-    for (let entry of this._frozenElements) {
-      let el = entry.element;
-      el.style.contain = entry.prevContain;
-      el.style.width = '';
-      el.style.height = '';
-    }
-    for (let entry of this._frozenElements) {
-      entry.element.offsetHeight;
-    }
-    let rects = this._frozenElements.map(entry => entry.element.getBoundingClientRect());
-    for (let i = 0; i < this._frozenElements.length; i++) {
-      let el = this._frozenElements[i].element;
-      el.style.width = `${rects[i].width}px`;
-      el.style.height = `${rects[i].height}px`;
-      el.style.contain = 'strict';
-    }
+    console.log(`[DockPanel] refreshing ${this._frozenGroups.length} frozen groups (staggered)`);
+    let g = 0;
+    const step = () => {
+      if (g >= this._frozenGroups.length) {
+        this._refreshRAFId = 0;
+        return;
+      }
+      let group = this._frozenGroups[g];
+      // Lift containment for all elements in this group.
+      for (let entry of group) {
+        entry.element.style.contain = entry.prevContain;
+        entry.element.style.width = '';
+        entry.element.style.height = '';
+      }
+      // Read all rects, then re-pin.
+      let rects = group.map(entry => entry.element.getBoundingClientRect());
+      for (let i = 0; i < group.length; i++) {
+        group[i].element.style.width = `${rects[i].width}px`;
+        group[i].element.style.height = `${rects[i].height}px`;
+        group[i].element.style.contain = 'strict';
+      }
+      g++;
+      this._refreshRAFId = requestAnimationFrame(step);
+    };
+    this._refreshRAFId = requestAnimationFrame(step);
   }
 
   /**
@@ -1247,27 +1261,33 @@ export class DockPanel extends Widget {
    * elements.
    */
   private _unfreezeElements(): void {
-    console.log(`[DockPanel] unfreezing ${this._frozenElements.length} elements`);
+    console.log(`[DockPanel] unfreezing ${this._frozenGroups.length} groups`);
     if (this._refreshTimerId !== 0) {
       clearTimeout(this._refreshTimerId);
       this._refreshTimerId = 0;
+    }
+    if (this._refreshRAFId !== 0) {
+      cancelAnimationFrame(this._refreshRAFId);
+      this._refreshRAFId = 0;
     }
     if (this._intervalId !== 0) {
       clearInterval(this._intervalId);
       this._intervalId = 0;
     }
-    for (let entry of this._frozenElements) {
-      let el = entry.element;
-      el.style.contain = entry.prevContain;
-      el.style.width = entry.prevWidth;
-      el.style.height = entry.prevHeight;
+    for (let group of this._frozenGroups) {
+      for (let entry of group) {
+        entry.element.style.contain = entry.prevContain;
+        entry.element.style.width = entry.prevWidth;
+        entry.element.style.height = entry.prevHeight;
+      }
     }
-    this._frozenElements = [];
+    this._frozenGroups = [];
   }
 
   private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
-  private _frozenElements: Private.IFrozenElement[] = [];
+  private _frozenGroups: Private.IFrozenElement[][] = [];
   private _refreshTimerId = 0;
+  private _refreshRAFId = 0;
   private _intervalId = 0;
 }
 

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -1104,7 +1104,7 @@ export class DockPanel extends Widget {
     }
     try {
       this._performanceObserver = new PerformanceObserver(() => {
-        if (this._frozenGroups.length === 0) {
+        if (this._frozenElements.length === 0) {
           console.log('[DockPanel] long task detected during drag, freezing heavy leaf widgets');
           this._freezeHeavyLeaves();
         }
@@ -1141,7 +1141,7 @@ export class DockPanel extends Widget {
    * subtree exceeds the node count threshold.
    */
   private _freezeHeavyLeaves(): void {
-    if (this._frozenGroups.length > 0) {
+    if (this._frozenElements.length > 0) {
       return;
     }
 
@@ -1151,55 +1151,46 @@ export class DockPanel extends Widget {
       Private.collectHeavyWidgets(child, this._nodeCountThreshold, targets);
     }
 
-    // Collect elements grouped by target widget.
-    let groups: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[][] = [];
+    // Read dimensions before mutations.
+    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevMinWidth: string; prevHeight: string; prevMinHeight: string }[] = [];
     for (let target of targets) {
       let el = target.node;
-      let elements: HTMLElement[] = [el];
-      for (let i = 0; i < el.children.length; i++) {
-        elements.push(el.children[i] as HTMLElement);
+      if (el.style.contain === 'strict') {
+        continue;
       }
-      // Read dimensions for this group.
-      let group: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
-      for (let elem of elements) {
-        if (elem.style.contain === 'strict') {
-          continue;
-        }
-        group.push({
-          el: elem,
-          rect: elem.getBoundingClientRect(),
-          prevContain: elem.style.contain,
-          prevWidth: elem.style.width,
-          prevHeight: elem.style.height
-        });
-      }
-      if (group.length > 0) {
-        groups.push(group);
-      }
+      entries.push({
+        el,
+        rect: el.getBoundingClientRect(),
+        prevContain: el.style.contain,
+        prevWidth: el.style.width,
+        prevMinWidth: el.style.minWidth,
+        prevHeight: el.style.height,
+        prevMinHeight: el.style.minHeight
+      });
     }
 
     // Apply containment and pinned sizes.
-    for (let group of groups) {
-      let frozenGroup: Private.IFrozenElement[] = [];
-      for (let entry of group) {
-        frozenGroup.push({
-          element: entry.el,
-          prevContain: entry.prevContain,
-          prevWidth: entry.prevWidth,
-          prevHeight: entry.prevHeight
-        });
-        entry.el.style.width = `${entry.rect.width}px`;
-        entry.el.style.height = `${entry.rect.height}px`;
-        entry.el.style.contain = 'strict';
-      }
-      this._frozenGroups.push(frozenGroup);
+    for (let entry of entries) {
+      this._frozenElements.push({
+        element: entry.el,
+        prevContain: entry.prevContain,
+        prevWidth: entry.prevWidth,
+        prevMinWidth: entry.prevMinWidth,
+        prevHeight: entry.prevHeight,
+        prevMinHeight: entry.prevMinHeight
+      });
+      entry.el.style.width = `${entry.rect.width}px`;
+      entry.el.style.minWidth = `${entry.rect.width}px`;
+      entry.el.style.height = `${entry.rect.height}px`;
+      entry.el.style.minHeight = `${entry.rect.height}px`;
+      entry.el.style.contain = 'strict';
     }
 
-    console.log(`[DockPanel] froze ${this._frozenGroups.length} groups`);
+    console.log(`[DockPanel] froze ${this._frozenElements.length} elements`);
 
     // Start periodic interval to keep sizes roughly correct
     // during long continuous drags.
-    if (this._frozenGroups.length > 0 && this._intervalId === 0) {
+    if (this._frozenElements.length > 0 && this._intervalId === 0) {
       this._intervalId = window.setInterval(() => {
         this._refreshFrozenElements();
       }, Private.REFRESH_INTERVAL_MS);
@@ -1212,7 +1203,7 @@ export class DockPanel extends Widget {
    * moving the handle.
    */
   private _scheduleRefresh(): void {
-    if (this._frozenGroups.length === 0) {
+    if (this._frozenElements.length === 0) {
       return;
     }
     if (this._refreshTimerId !== 0) {
@@ -1225,33 +1216,36 @@ export class DockPanel extends Widget {
   }
 
   /**
-   * Refresh frozen groups one at a time, spreading the reflow
+   * Refresh frozen elements one at a time, spreading the reflow
    * cost across multiple animation frames.
    */
   private _refreshFrozenElements(): void {
-    console.log(`[DockPanel] refreshing ${this._frozenGroups.length} frozen groups (staggered)`);
-    let g = 0;
+    console.log(`[DockPanel] refreshing ${this._frozenElements.length} frozen elements (staggered)`);
+    let i = 0;
     const step = () => {
-      if (g >= this._frozenGroups.length) {
+      if (i >= this._frozenElements.length) {
         this._refreshRAFId = 0;
         return;
       }
-      let group = this._frozenGroups[g];
-      // Lift containment for all elements in this group.
-      for (let entry of group) {
-        entry.element.style.contain = entry.prevContain;
-        entry.element.style.width = '';
-        entry.element.style.height = '';
-      }
-      // Read all rects, then re-pin.
-      let rects = group.map(entry => entry.element.getBoundingClientRect());
-      for (let i = 0; i < group.length; i++) {
-        group[i].element.style.width = `${rects[i].width}px`;
-        group[i].element.style.height = `${rects[i].height}px`;
-        group[i].element.style.contain = 'strict';
-      }
-      g++;
-      this._refreshRAFId = requestAnimationFrame(step);
+      let entry = this._frozenElements[i];
+      let el = entry.element;
+      // Frame 1: lift containment to let the browser settle layout.
+      el.style.contain = entry.prevContain;
+      el.style.width = '';
+      el.style.minWidth = '';
+      el.style.height = '';
+      el.style.minHeight = '';
+      // Frame 2: read the settled rect and re-pin.
+      this._refreshRAFId = requestAnimationFrame(() => {
+        let rect = el.getBoundingClientRect();
+        el.style.width = `${rect.width}px`;
+        el.style.minWidth = `${rect.width}px`;
+        el.style.height = `${rect.height}px`;
+        el.style.minHeight = `${rect.height}px`;
+        el.style.contain = 'strict';
+        i++;
+        this._refreshRAFId = requestAnimationFrame(step);
+      });
     };
     this._refreshRAFId = requestAnimationFrame(step);
   }
@@ -1261,7 +1255,7 @@ export class DockPanel extends Widget {
    * elements.
    */
   private _unfreezeElements(): void {
-    console.log(`[DockPanel] unfreezing ${this._frozenGroups.length} groups`);
+    console.log(`[DockPanel] unfreezing ${this._frozenElements.length} elements`);
     if (this._refreshTimerId !== 0) {
       clearTimeout(this._refreshTimerId);
       this._refreshTimerId = 0;
@@ -1274,18 +1268,18 @@ export class DockPanel extends Widget {
       clearInterval(this._intervalId);
       this._intervalId = 0;
     }
-    for (let group of this._frozenGroups) {
-      for (let entry of group) {
-        entry.element.style.contain = entry.prevContain;
-        entry.element.style.width = entry.prevWidth;
-        entry.element.style.height = entry.prevHeight;
-      }
+    for (let entry of this._frozenElements) {
+      entry.element.style.contain = entry.prevContain;
+      entry.element.style.width = entry.prevWidth;
+      entry.element.style.minWidth = entry.prevMinWidth;
+      entry.element.style.height = entry.prevHeight;
+      entry.element.style.minHeight = entry.prevMinHeight;
     }
-    this._frozenGroups = [];
+    this._frozenElements = [];
   }
 
   private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
-  private _frozenGroups: Private.IFrozenElement[][] = [];
+  private _frozenElements: Private.IFrozenElement[] = [];
   private _refreshTimerId = 0;
   private _refreshRAFId = 0;
   private _intervalId = 0;
@@ -1672,7 +1666,9 @@ namespace Private {
     element: HTMLElement;
     prevContain: string;
     prevWidth: string;
+    prevMinWidth: string;
     prevHeight: string;
+    prevMinHeight: string;
   }
 
   /**

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -1104,7 +1104,7 @@ export class DockPanel extends Widget {
     }
     try {
       this._performanceObserver = new PerformanceObserver(() => {
-        if (this._frozenElements.length === 0) {
+        if (this._frozenGroups.length === 0) {
           console.log('[DockPanel] long task detected during drag, freezing heavy leaf widgets');
           this._freezeHeavyLeaves();
         }
@@ -1141,7 +1141,7 @@ export class DockPanel extends Widget {
    * subtree exceeds the node count threshold.
    */
   private _freezeHeavyLeaves(): void {
-    if (this._frozenElements.length > 0) {
+    if (this._frozenGroups.length > 0) {
       return;
     }
 
@@ -1152,46 +1152,124 @@ export class DockPanel extends Widget {
     }
 
     // Read dimensions before mutations.
-    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevMinWidth: string; prevHeight: string; prevMinHeight: string }[] = [];
+    let groups: {
+      el: HTMLElement;
+      rect: DOMRect;
+      isHead: boolean;
+      prevContain: string;
+      prevWidth: string;
+      prevMinWidth: string;
+      prevMaxWidth: string;
+      prevHeight: string;
+      prevMinHeight: string;
+      prevMaxHeight: string;
+      prevContentVisibility: string;
+      prevContainIntrinsicWidth: string;
+      prevContainIntrinsicHeight: string;
+    }[][] = [];
     for (let target of targets) {
-      let el = target.node;
-      if (el.style.contain === 'strict') {
+      let head = target.node;
+      if (head.style.contain === 'strict') {
         continue;
       }
-      entries.push({
-        el,
-        rect: el.getBoundingClientRect(),
-        prevContain: el.style.contain,
-        prevWidth: el.style.width,
-        prevMinWidth: el.style.minWidth,
-        prevHeight: el.style.height,
-        prevMinHeight: el.style.minHeight
+
+      let group: {
+        el: HTMLElement;
+        rect: DOMRect;
+        isHead: boolean;
+        prevContain: string;
+        prevWidth: string;
+        prevMinWidth: string;
+        prevMaxWidth: string;
+        prevHeight: string;
+        prevMinHeight: string;
+        prevMaxHeight: string;
+        prevContentVisibility: string;
+        prevContainIntrinsicWidth: string;
+        prevContainIntrinsicHeight: string;
+      }[] = [];
+
+      group.push({
+        el: head,
+        rect: head.getBoundingClientRect(),
+        isHead: true,
+        prevContain: head.style.contain,
+        prevWidth: head.style.width,
+        prevMinWidth: head.style.minWidth,
+        prevMaxWidth: head.style.maxWidth,
+        prevHeight: head.style.height,
+        prevMinHeight: head.style.minHeight,
+        prevMaxHeight: head.style.maxHeight,
+        prevContentVisibility: head.style.getPropertyValue('content-visibility'),
+        prevContainIntrinsicWidth: head.style.containIntrinsicWidth,
+        prevContainIntrinsicHeight: head.style.containIntrinsicHeight
       });
+
+      for (let i = 0; i < head.children.length; i++) {
+        let child = head.children[i] as HTMLElement;
+        group.push({
+          el: child,
+          rect: child.getBoundingClientRect(),
+          isHead: false,
+          prevContain: child.style.contain,
+          prevWidth: child.style.width,
+          prevMinWidth: child.style.minWidth,
+          prevMaxWidth: child.style.maxWidth,
+          prevHeight: child.style.height,
+          prevMinHeight: child.style.minHeight,
+          prevMaxHeight: child.style.maxHeight,
+          prevContentVisibility: child.style.getPropertyValue('content-visibility'),
+          prevContainIntrinsicWidth: child.style.containIntrinsicWidth,
+          prevContainIntrinsicHeight: child.style.containIntrinsicHeight
+        });
+      }
+
+      groups.push(group);
     }
 
     // Apply containment and pinned sizes.
-    for (let entry of entries) {
-      this._frozenElements.push({
-        element: entry.el,
-        prevContain: entry.prevContain,
-        prevWidth: entry.prevWidth,
-        prevMinWidth: entry.prevMinWidth,
-        prevHeight: entry.prevHeight,
-        prevMinHeight: entry.prevMinHeight
-      });
-      entry.el.style.width = `${entry.rect.width}px`;
-      entry.el.style.minWidth = `${entry.rect.width}px`;
-      entry.el.style.height = `${entry.rect.height}px`;
-      entry.el.style.minHeight = `${entry.rect.height}px`;
-      entry.el.style.contain = 'strict';
-      entry.el.classList.add('lm-layout-frozen');
+    for (let group of groups) {
+      let frozenGroup: Private.IFrozenElement[] = [];
+      for (let entry of group) {
+        frozenGroup.push({
+          element: entry.el,
+          isHead: entry.isHead,
+          prevContain: entry.prevContain,
+          prevWidth: entry.prevWidth,
+          prevMinWidth: entry.prevMinWidth,
+          prevMaxWidth: entry.prevMaxWidth,
+          prevHeight: entry.prevHeight,
+          prevMinHeight: entry.prevMinHeight,
+          prevMaxHeight: entry.prevMaxHeight,
+          prevContentVisibility: entry.prevContentVisibility,
+          prevContainIntrinsicWidth: entry.prevContainIntrinsicWidth,
+          prevContainIntrinsicHeight: entry.prevContainIntrinsicHeight
+        });
+
+        entry.el.style.width = `${entry.rect.width}px`;
+        entry.el.style.minWidth = `${entry.rect.width}px`;
+        entry.el.style.maxWidth = `${entry.rect.width}px`;
+        entry.el.style.maxHeight = `${entry.rect.height}px`;
+
+        if (entry.isHead) {
+          entry.el.style.height = `${entry.rect.height}px`;
+          entry.el.style.minHeight = `${entry.rect.height}px`;
+          entry.el.style.contain = 'strict';
+          entry.el.classList.add('lm-layout-frozen');
+        } else {
+          entry.el.style.setProperty('content-visibility', 'auto');
+          entry.el.style.containIntrinsicWidth = `${entry.rect.width}px`;
+          entry.el.style.containIntrinsicHeight = `${entry.rect.height}px`;
+        }
+      }
+      this._frozenGroups.push(frozenGroup);
     }
 
-    console.log(`[DockPanel] froze ${this._frozenElements.length} elements`);
+    console.log(`[DockPanel] froze ${this._frozenGroups.length} groups`);
 
     // Start periodic interval to keep sizes roughly correct
     // during long continuous drags.
-    if (this._frozenElements.length > 0 && this._intervalId === 0) {
+    if (this._frozenGroups.length > 0 && this._intervalId === 0) {
       this._intervalId = window.setInterval(() => {
         this._refreshFrozenElements();
       }, Private.REFRESH_INTERVAL_MS);
@@ -1204,7 +1282,7 @@ export class DockPanel extends Widget {
    * moving the handle.
    */
   private _scheduleRefresh(): void {
-    if (this._frozenElements.length === 0) {
+    if (this._frozenGroups.length === 0) {
       return;
     }
     if (this._refreshTimerId !== 0) {
@@ -1217,34 +1295,54 @@ export class DockPanel extends Widget {
   }
 
   /**
-   * Refresh frozen elements one at a time, spreading the reflow
+   * Refresh frozen groups one at a time, spreading the reflow
    * cost across multiple animation frames.
    */
   private _refreshFrozenElements(): void {
-    console.log(`[DockPanel] refreshing ${this._frozenElements.length} frozen elements (staggered)`);
-    let i = 0;
+    console.log(`[DockPanel] refreshing ${this._frozenGroups.length} frozen groups (staggered)`);
+    let g = 0;
     const step = () => {
-      if (i >= this._frozenElements.length) {
+      if (g >= this._frozenGroups.length) {
         this._refreshRAFId = 0;
         return;
       }
-      let entry = this._frozenElements[i];
-      let el = entry.element;
+      let group = this._frozenGroups[g];
       // Frame 1: lift containment to let the browser settle layout.
-      el.style.contain = entry.prevContain;
-      el.style.width = '';
-      el.style.minWidth = '';
-      el.style.height = '';
-      el.style.minHeight = '';
+      for (let entry of group) {
+        let el = entry.element;
+        el.style.contain = entry.prevContain;
+        el.style.width = '';
+        el.style.minWidth = '';
+        el.style.maxWidth = '';
+        el.style.height = '';
+        el.style.minHeight = '';
+        el.style.maxHeight = '';
+        el.style.setProperty('content-visibility', entry.prevContentVisibility);
+        el.style.containIntrinsicWidth = entry.prevContainIntrinsicWidth;
+        el.style.containIntrinsicHeight = entry.prevContainIntrinsicHeight;
+      }
       // Frame 2: read the settled rect and re-pin.
       this._refreshRAFId = requestAnimationFrame(() => {
-        let rect = el.getBoundingClientRect();
-        el.style.width = `${rect.width}px`;
-        el.style.minWidth = `${rect.width}px`;
-        el.style.height = `${rect.height}px`;
-        el.style.minHeight = `${rect.height}px`;
-        el.style.contain = 'strict';
-        i++;
+        let rects = group.map(entry => entry.element.getBoundingClientRect());
+        for (let i = 0; i < group.length; i++) {
+          let entry = group[i];
+          let rect = rects[i];
+          let el = entry.element;
+          el.style.width = `${rect.width}px`;
+          el.style.minWidth = `${rect.width}px`;
+          el.style.maxWidth = `${rect.width}px`;
+          el.style.maxHeight = `${rect.height}px`;
+          if (entry.isHead) {
+            el.style.height = `${rect.height}px`;
+            el.style.minHeight = `${rect.height}px`;
+            el.style.contain = 'strict';
+          } else {
+            el.style.setProperty('content-visibility', 'auto');
+            el.style.containIntrinsicWidth = `${rect.width}px`;
+            el.style.containIntrinsicHeight = `${rect.height}px`;
+          }
+        }
+        g++;
         this._refreshRAFId = requestAnimationFrame(step);
       });
     };
@@ -1256,7 +1354,7 @@ export class DockPanel extends Widget {
    * elements.
    */
   private _unfreezeElements(): void {
-    console.log(`[DockPanel] unfreezing ${this._frozenElements.length} elements`);
+    console.log(`[DockPanel] unfreezing ${this._frozenGroups.length} groups`);
     if (this._refreshTimerId !== 0) {
       clearTimeout(this._refreshTimerId);
       this._refreshTimerId = 0;
@@ -1269,19 +1367,28 @@ export class DockPanel extends Widget {
       clearInterval(this._intervalId);
       this._intervalId = 0;
     }
-    for (let entry of this._frozenElements) {
-      entry.element.style.contain = entry.prevContain;
-      entry.element.style.width = entry.prevWidth;
-      entry.element.style.minWidth = entry.prevMinWidth;
-      entry.element.style.height = entry.prevHeight;
-      entry.element.style.minHeight = entry.prevMinHeight;
-      entry.element.classList.remove('lm-layout-frozen');
+    for (let group of this._frozenGroups) {
+      for (let entry of group) {
+        entry.element.style.contain = entry.prevContain;
+        entry.element.style.width = entry.prevWidth;
+        entry.element.style.minWidth = entry.prevMinWidth;
+        entry.element.style.maxWidth = entry.prevMaxWidth;
+        entry.element.style.height = entry.prevHeight;
+        entry.element.style.minHeight = entry.prevMinHeight;
+        entry.element.style.maxHeight = entry.prevMaxHeight;
+        entry.element.style.setProperty('content-visibility', entry.prevContentVisibility);
+        entry.element.style.containIntrinsicWidth = entry.prevContainIntrinsicWidth;
+        entry.element.style.containIntrinsicHeight = entry.prevContainIntrinsicHeight;
+        if (entry.isHead) {
+          entry.element.classList.remove('lm-layout-frozen');
+        }
+      }
     }
-    this._frozenElements = [];
+    this._frozenGroups = [];
   }
 
   private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
-  private _frozenElements: Private.IFrozenElement[] = [];
+  private _frozenGroups: Private.IFrozenElement[][] = [];
   private _refreshTimerId = 0;
   private _refreshRAFId = 0;
   private _intervalId = 0;
@@ -1666,11 +1773,17 @@ namespace Private {
    */
   export interface IFrozenElement {
     element: HTMLElement;
+    isHead: boolean;
     prevContain: string;
     prevWidth: string;
     prevMinWidth: string;
+    prevMaxWidth: string;
     prevHeight: string;
     prevMinHeight: string;
+    prevMaxHeight: string;
+    prevContentVisibility: string;
+    prevContainIntrinsicWidth: string;
+    prevContainIntrinsicHeight: string;
   }
 
   /**
@@ -1688,7 +1801,7 @@ namespace Private {
    * The periodic interval (in ms) for refreshing frozen element
    * sizes during long continuous drags.
    */
-  export const REFRESH_INTERVAL_MS = 5000;
+  export const REFRESH_INTERVAL_MS = 3000;
 
   /**
    * An object which holds mouse press data.

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -58,6 +58,9 @@ export class DockPanel extends Widget {
     if (options.addButtonEnabled !== undefined) {
       this._addButtonEnabled = options.addButtonEnabled;
     }
+    if (options.nodeCountThreshold !== undefined) {
+      this._nodeCountThreshold = options.nodeCountThreshold;
+    }
 
     // Toggle the CSS mode attribute.
     this.dataset['mode'] = this._mode;
@@ -730,6 +733,9 @@ export class DockPanel extends Widget {
     let style = window.getComputedStyle(handle);
     let override = Drag.overrideCursor(style.cursor!, this._document);
     this._pressData = { handle, deltaX, deltaY, override };
+
+    // Start observing for long tasks to reactively apply containment.
+    this._observeSlowLayout();
   }
 
   /**
@@ -750,7 +756,9 @@ export class DockPanel extends Widget {
     let xPos = event.clientX - rect.left - this._pressData.deltaX;
     let yPos = event.clientY - rect.top - this._pressData.deltaY;
 
-    // Set the handle as close to the desired position as possible.
+    // Move the handle. The actual layout update is deferred via
+    // the lumino message loop; the PerformanceObserver set up on
+    // pointerdown will detect if the resulting frame is slow.
     let layout = this.layout as DockLayout;
     layout.moveHandle(this._pressData.handle, xPos, yPos);
   }
@@ -783,6 +791,12 @@ export class DockPanel extends Widget {
     if (!this._pressData) {
       return;
     }
+
+    // Stop observing long tasks.
+    this._disconnectObserver();
+
+    // Unfreeze all contained elements.
+    this._unfreezeElements();
 
     // Clear the override cursor.
     this._pressData.override.dispose();
@@ -1075,6 +1089,151 @@ export class DockPanel extends Widget {
   private _layoutModified = new Signal<this, void>(this);
 
   private _addRequested = new Signal<this, TabBar<Widget>>(this);
+
+  /**
+   * Start a PerformanceObserver to detect slow frames during drag.
+   * Prefers `long-animation-frame` (includes rendering cost) and
+   * falls back to `longtask` (script-only, >50 ms threshold).
+   */
+  private _observeSlowLayout(): void {
+    if (typeof PerformanceObserver === 'undefined') {
+      return;
+    }
+    try {
+      this._performanceObserver = new PerformanceObserver(() => {
+        if (this._frozenElements.length === 0) {
+          console.log('[DockPanel] long task detected during drag, freezing heavy leaf widgets');
+          this._freezeHeavyLeaves();
+        }
+      });
+      try {
+        this._performanceObserver.observe({ type: 'long-animation-frame' });
+      } catch {
+        try {
+          this._performanceObserver.observe({ type: 'longtask' });
+        } catch {
+          this._performanceObserver = null;
+        }
+      }
+    } catch {
+      // PerformanceObserver not supported.
+    }
+  }
+
+  /**
+   * Disconnect the PerformanceObserver if active.
+   */
+  private _disconnectObserver(): void {
+    if (this._performanceObserver) {
+      this._performanceObserver.disconnect();
+      this._performanceObserver = null;
+    }
+  }
+
+  private _performanceObserver: PerformanceObserver | null = null;
+
+  /**
+   * Walk the widget tree to find leaf widgets, then apply
+   * `contain: strict` with pinned width/height on those whose
+   * subtree exceeds the node count threshold.
+   */
+  private _freezeHeavyLeaves(): void {
+    if (this._frozenElements.length > 0) {
+      return;
+    }
+
+    // Find deepest heavy widgets in the tree.
+    let targets: Widget[] = [];
+    for (let child of this.widgets()) {
+      Private.collectHeavyWidgets(child, this._nodeCountThreshold, targets);
+    }
+
+    // Pass 1: read all dimensions before mutations.
+    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
+    for (let target of targets) {
+      let el = target.node;
+      if (el.style.contain === 'strict') {
+        console.log(`[DockPanel] "${target.title.label}" already has contain:strict, skipping`);
+        continue;
+      }
+      console.log(`[DockPanel] freezing "${target.title.label}" (${el.querySelectorAll('*').length} nodes)`);
+      entries.push({
+        el,
+        rect: el.getBoundingClientRect(),
+        prevContain: el.style.contain,
+        prevWidth: el.style.width,
+        prevHeight: el.style.height
+      });
+    }
+
+    // Pass 2: apply containment and pinned sizes.
+    for (let entry of entries) {
+      this._frozenElements.push({
+        element: entry.el,
+        prevContain: entry.prevContain,
+        prevWidth: entry.prevWidth,
+        prevHeight: entry.prevHeight
+      });
+      entry.el.style.width = `${entry.rect.width}px`;
+      entry.el.style.height = `${entry.rect.height}px`;
+      entry.el.style.contain = 'strict';
+    }
+
+    console.log(`[DockPanel] froze ${this._frozenElements.length} heavy widget nodes`);
+
+    if (this._frozenElements.length > 0 && this._intervalId === 0) {
+      this._intervalId = window.setInterval(() => {
+        this._refreshFrozenElements();
+      }, Private.REFRESH_INTERVAL_MS);
+    }
+  }
+
+  /**
+   * Temporarily lift containment, let the browser reflow, then
+   * re-apply with updated sizes.
+   */
+  private _refreshFrozenElements(): void {
+    console.log(`[DockPanel] refreshing ${this._frozenElements.length} frozen elements`);
+    for (let entry of this._frozenElements) {
+      let el = entry.element;
+      el.style.contain = entry.prevContain;
+      el.style.width = '';
+      el.style.height = '';
+    }
+    for (let entry of this._frozenElements) {
+      entry.element.offsetHeight;
+    }
+    let rects = this._frozenElements.map(entry => entry.element.getBoundingClientRect());
+    for (let i = 0; i < this._frozenElements.length; i++) {
+      let el = this._frozenElements[i].element;
+      el.style.width = `${rects[i].width}px`;
+      el.style.height = `${rects[i].height}px`;
+      el.style.contain = 'strict';
+    }
+  }
+
+  /**
+   * Remove containment and restore original styles on all frozen
+   * elements.
+   */
+  private _unfreezeElements(): void {
+    console.log(`[DockPanel] unfreezing ${this._frozenElements.length} elements`);
+    if (this._intervalId !== 0) {
+      clearInterval(this._intervalId);
+      this._intervalId = 0;
+    }
+    for (let entry of this._frozenElements) {
+      let el = entry.element;
+      el.style.contain = entry.prevContain;
+      el.style.width = entry.prevWidth;
+      el.style.height = entry.prevHeight;
+    }
+    this._frozenElements = [];
+  }
+
+  private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
+  private _frozenElements: Private.IFrozenElement[] = [];
+  private _intervalId = 0;
 }
 
 /**
@@ -1153,6 +1312,14 @@ export namespace DockPanel {
      * The default is `'false'`.
      */
     addButtonEnabled?: boolean;
+
+    /**
+     * The number of DOM nodes in a child widget above which the
+     * panel will throttle resize updates during handle dragging.
+     *
+     * The default is `5000`.
+     */
+    nodeCountThreshold?: number;
   }
 
   /**
@@ -1444,6 +1611,27 @@ namespace Private {
   export const LayoutModified = new ConflatableMessage('layout-modified');
 
   /**
+   * An object which holds the original styles for a frozen element.
+   */
+  export interface IFrozenElement {
+    element: HTMLElement;
+    prevContain: string;
+    prevWidth: string;
+    prevHeight: string;
+  }
+
+  /**
+   * The default node count threshold for content isolation.
+   */
+  export const DEFAULT_NODE_COUNT_THRESHOLD = 100;
+
+  /**
+   * The interval (in ms) at which frozen elements have their sizes
+   * refreshed during handle dragging.
+   */
+  export const REFRESH_INTERVAL_MS = 5000;
+
+  /**
    * An object which holds mouse press data.
    */
   export interface IPressData {
@@ -1580,6 +1768,47 @@ namespace Private {
 
     // Return the single document config.
     return { main: { type: 'tab-area', widgets, currentIndex } };
+  }
+
+  /**
+   * Recursively find the deepest widgets whose subtree is heavy
+   * (node count >= threshold) but whose child widgets are all
+   * individually light. This places containment as low in the
+   * DOM tree as possible.
+   */
+  export function collectHeavyWidgets(
+    widget: Widget,
+    threshold: number,
+    result: Widget[]
+  ): void {
+    let nodeCount = widget.node.querySelectorAll('*').length;
+    if (nodeCount < threshold) {
+      return;
+    }
+    let layout = widget.layout;
+    if (!layout) {
+      // Leaf widget that is heavy — freeze it.
+      result.push(widget);
+      return;
+    }
+    // Check if any child widget is individually heavy.
+    let anyChildHeavy = false;
+    for (let child of layout) {
+      if (child.node.querySelectorAll('*').length >= threshold) {
+        anyChildHeavy = true;
+        break;
+      }
+    }
+    if (anyChildHeavy) {
+      // Recurse into children — we can push containment deeper.
+      for (let child of layout) {
+        collectHeavyWidgets(child, threshold, result);
+      }
+    } else {
+      // No child is individually heavy, but this widget is.
+      // This is the deepest heavy boundary — freeze here.
+      result.push(widget);
+    }
   }
 
   /**

--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -734,8 +734,8 @@ export class DockPanel extends Widget {
     let override = Drag.overrideCursor(style.cursor!, this._document);
     this._pressData = { handle, deltaX, deltaY, override };
 
-    // Start observing for long tasks to reactively apply containment.
-    this._observeSlowLayout();
+    // Freeze heavy leaf widgets immediately when drag starts.
+    this._freezeHeavyLeaves();
   }
 
   /**
@@ -794,9 +794,6 @@ export class DockPanel extends Widget {
     if (!this._pressData) {
       return;
     }
-
-    // Stop observing long tasks.
-    this._disconnectObserver();
 
     // Unfreeze all contained elements.
     this._unfreezeElements();
@@ -1093,47 +1090,7 @@ export class DockPanel extends Widget {
 
   private _addRequested = new Signal<this, TabBar<Widget>>(this);
 
-  /**
-   * Start a PerformanceObserver to detect slow frames during drag.
-   * Prefers `long-animation-frame` (includes rendering cost) and
-   * falls back to `longtask` (script-only, >50 ms threshold).
-   */
-  private _observeSlowLayout(): void {
-    if (typeof PerformanceObserver === 'undefined') {
-      return;
-    }
-    try {
-      this._performanceObserver = new PerformanceObserver(() => {
-        if (this._frozenGroups.length === 0) {
-          console.log('[DockPanel] long task detected during drag, freezing heavy leaf widgets');
-          this._freezeHeavyLeaves();
-        }
-      });
-      try {
-        this._performanceObserver.observe({ type: 'long-animation-frame' });
-      } catch {
-        try {
-          this._performanceObserver.observe({ type: 'longtask' });
-        } catch {
-          this._performanceObserver = null;
-        }
-      }
-    } catch {
-      // PerformanceObserver not supported.
-    }
-  }
 
-  /**
-   * Disconnect the PerformanceObserver if active.
-   */
-  private _disconnectObserver(): void {
-    if (this._performanceObserver) {
-      this._performanceObserver.disconnect();
-      this._performanceObserver = null;
-    }
-  }
-
-  private _performanceObserver: PerformanceObserver | null = null;
 
   /**
    * Walk the widget tree to find leaf widgets, then apply

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -306,6 +306,9 @@ export class SplitPanel extends Panel {
     // the lumino message loop; the PerformanceObserver set up on
     // pointerdown will detect if the resulting frame is slow.
     layout.moveHandle(this._pressData!.index, pos);
+
+    // Debounce: refresh frozen elements after the user stops moving.
+    this._scheduleRefresh();
   }
 
   /**
@@ -370,15 +373,22 @@ export class SplitPanel extends Panel {
       Private.collectHeavyWidgets(this.widgets[i], this._nodeCountThreshold, targets);
     }
 
-    // Pass 1: read all dimensions before mutations.
-    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
+    // Collect widget nodes and their direct DOM children.
+    let elements: HTMLElement[] = [];
     for (let target of targets) {
       let el = target.node;
+      elements.push(el);
+      for (let i = 0; i < el.children.length; i++) {
+        elements.push(el.children[i] as HTMLElement);
+      }
+    }
+
+    // Pass 1: read all dimensions before mutations.
+    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
+    for (let el of elements) {
       if (el.style.contain === 'strict') {
-        console.log(`[SplitPanel] "${target.title.label}" already has contain:strict, skipping`);
         continue;
       }
-      console.log(`[SplitPanel] freezing "${target.title.label}" (${el.querySelectorAll('*').length} nodes)`);
       entries.push({
         el,
         rect: el.getBoundingClientRect(),
@@ -403,12 +413,31 @@ export class SplitPanel extends Panel {
 
     console.log(`[SplitPanel] froze ${this._frozenElements.length} heavy widget nodes`);
 
-    // Start periodic interval to refresh frozen sizes.
+    // Start periodic interval to keep sizes roughly correct
+    // during long continuous drags.
     if (this._frozenElements.length > 0 && this._intervalId === 0) {
       this._intervalId = window.setInterval(() => {
         this._refreshFrozenElements();
       }, Private.REFRESH_INTERVAL_MS);
     }
+  }
+
+  /**
+   * Schedule a debounced refresh of frozen elements. Resets on
+   * each call so the refresh only fires after the user stops
+   * moving the handle.
+   */
+  private _scheduleRefresh(): void {
+    if (this._frozenElements.length === 0) {
+      return;
+    }
+    if (this._refreshTimerId !== 0) {
+      clearTimeout(this._refreshTimerId);
+    }
+    this._refreshTimerId = window.setTimeout(() => {
+      this._refreshTimerId = 0;
+      this._refreshFrozenElements();
+    }, Private.REFRESH_DEBOUNCE_MS);
   }
 
   /**
@@ -445,6 +474,10 @@ export class SplitPanel extends Panel {
    */
   private _unfreezeElements(): void {
     console.log(`[SplitPanel] unfreezing ${this._frozenElements.length} elements`);
+    if (this._refreshTimerId !== 0) {
+      clearTimeout(this._refreshTimerId);
+      this._refreshTimerId = 0;
+    }
     if (this._intervalId !== 0) {
       clearInterval(this._intervalId);
       this._intervalId = 0;
@@ -503,6 +536,7 @@ export class SplitPanel extends Panel {
   private _performanceObserver: PerformanceObserver | null = null;
   private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
   private _frozenElements: Private.IFrozenElement[] = [];
+  private _refreshTimerId = 0;
   private _intervalId = 0;
 }
 
@@ -680,24 +714,53 @@ namespace Private {
   export const DEFAULT_NODE_COUNT_THRESHOLD = 5000;
 
   /**
-   * The interval (in ms) at which frozen elements have their sizes
-   * refreshed during handle dragging.
+   * The delay (in ms) after the last pointer move before refreshing
+   * frozen element sizes.
    */
-  export const REFRESH_INTERVAL_MS = 5000;
+  export const REFRESH_DEBOUNCE_MS = 300;
+
+  /**
+   * The periodic interval (in ms) for refreshing frozen element
+   * sizes during long continuous drags.
+   */
+  export const REFRESH_INTERVAL_MS = 2000;
+
+  /**
+   * The minimum total text length in a widget's subtree to
+   * consider it heavy, independent of node count.
+   */
+  export const DEFAULT_TEXT_LENGTH_THRESHOLD = 25000;
+
+  /**
+   * Determine whether a DOM subtree is heavy enough to warrant
+   * containment. A subtree is heavy if it has many nodes or a
+   * large amount of text content.
+   */
+  export function isDOMHeavy(
+    el: HTMLElement,
+    nodeCountThreshold: number,
+    textLengthThreshold: number = DEFAULT_TEXT_LENGTH_THRESHOLD
+  ): boolean {
+    if (el.querySelectorAll('*').length >= nodeCountThreshold) {
+      return true;
+    }
+    if ((el.textContent?.length ?? 0) >= textLengthThreshold) {
+      return true;
+    }
+    return false;
+  }
 
   /**
    * Recursively find the deepest widgets whose subtree is heavy
-   * (node count >= threshold) but whose child widgets are all
-   * individually light. This places containment as low in the
-   * DOM tree as possible.
+   * but whose child widgets are all individually light. This
+   * places containment as low in the DOM tree as possible.
    */
   export function collectHeavyWidgets(
     widget: Widget,
     threshold: number,
     result: Widget[]
   ): void {
-    let nodeCount = widget.node.querySelectorAll('*').length;
-    if (nodeCount < threshold) {
+    if (!isDOMHeavy(widget.node, threshold)) {
       return;
     }
     let layout = widget.layout;
@@ -709,7 +772,7 @@ namespace Private {
     // Check if any child widget is individually heavy.
     let anyChildHeavy = false;
     for (let child of layout) {
-      if (child.node.querySelectorAll('*').length >= threshold) {
+      if (isDOMHeavy(child.node, threshold)) {
         anyChildHeavy = true;
         break;
       }

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -38,6 +38,9 @@ export class SplitPanel extends Panel {
   constructor(options: SplitPanel.IOptions = {}) {
     super({ layout: Private.createLayout(options) });
     this.addClass('lm-SplitPanel');
+    if (options.nodeCountThreshold !== undefined) {
+      this._nodeCountThreshold = options.nodeCountThreshold;
+    }
   }
 
   /**
@@ -276,6 +279,9 @@ export class SplitPanel extends Panel {
     let style = window.getComputedStyle(handle);
     let override = Drag.overrideCursor(style.cursor!);
     this._pressData = { index, delta, override };
+
+    // Start observing for long tasks to reactively apply containment.
+    this._observeSlowLayout();
   }
 
   /**
@@ -296,7 +302,9 @@ export class SplitPanel extends Panel {
       pos = event.clientY - rect.top - this._pressData!.delta;
     }
 
-    // Move the handle as close to the desired position as possible.
+    // Move the handle. The actual layout update is deferred via
+    // the lumino message loop; the PerformanceObserver set up on
+    // pointerdown will detect if the resulting frame is slow.
     layout.moveHandle(this._pressData!.index, pos);
   }
 
@@ -326,6 +334,12 @@ export class SplitPanel extends Panel {
       return;
     }
 
+    // Stop observing long tasks.
+    this._disconnectObserver();
+
+    // Unfreeze all contained elements.
+    this._unfreezeElements();
+
     // Clear the override cursor.
     this._pressData.override.dispose();
     this._pressData = null;
@@ -340,8 +354,156 @@ export class SplitPanel extends Panel {
     document.removeEventListener('contextmenu', this, true);
   }
 
+  /**
+   * Walk the widget tree to find leaf widgets, then apply
+   * `contain: strict` with pinned width/height on those whose
+   * subtree exceeds the node count threshold.
+   */
+  private _freezeHeavyLeaves(): void {
+    if (this._frozenElements.length > 0) {
+      return;
+    }
+
+    // Find deepest heavy widgets in the tree.
+    let targets: Widget[] = [];
+    for (let i = 0; i < this.widgets.length; i++) {
+      Private.collectHeavyWidgets(this.widgets[i], this._nodeCountThreshold, targets);
+    }
+
+    // Pass 1: read all dimensions before mutations.
+    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
+    for (let target of targets) {
+      let el = target.node;
+      if (el.style.contain === 'strict') {
+        console.log(`[SplitPanel] "${target.title.label}" already has contain:strict, skipping`);
+        continue;
+      }
+      console.log(`[SplitPanel] freezing "${target.title.label}" (${el.querySelectorAll('*').length} nodes)`);
+      entries.push({
+        el,
+        rect: el.getBoundingClientRect(),
+        prevContain: el.style.contain,
+        prevWidth: el.style.width,
+        prevHeight: el.style.height
+      });
+    }
+
+    // Pass 2: apply containment and pinned sizes.
+    for (let entry of entries) {
+      this._frozenElements.push({
+        element: entry.el,
+        prevContain: entry.prevContain,
+        prevWidth: entry.prevWidth,
+        prevHeight: entry.prevHeight
+      });
+      entry.el.style.width = `${entry.rect.width}px`;
+      entry.el.style.height = `${entry.rect.height}px`;
+      entry.el.style.contain = 'strict';
+    }
+
+    console.log(`[SplitPanel] froze ${this._frozenElements.length} heavy widget nodes`);
+
+    // Start periodic interval to refresh frozen sizes.
+    if (this._frozenElements.length > 0 && this._intervalId === 0) {
+      this._intervalId = window.setInterval(() => {
+        this._refreshFrozenElements();
+      }, Private.REFRESH_INTERVAL_MS);
+    }
+  }
+
+  /**
+   * Temporarily lift containment, let the browser reflow, then
+   * re-apply with updated sizes.
+   */
+  private _refreshFrozenElements(): void {
+    console.log(`[SplitPanel] refreshing ${this._frozenElements.length} frozen elements`);
+    // Lift containment and clear pinned sizes.
+    for (let entry of this._frozenElements) {
+      let el = entry.element;
+      el.style.contain = entry.prevContain;
+      el.style.width = '';
+      el.style.height = '';
+    }
+    // Force a synchronous reflow so elements settle.
+    // Reading offsetHeight triggers layout.
+    for (let entry of this._frozenElements) {
+      entry.element.offsetHeight;
+    }
+    // Re-pin with updated sizes (read all, then write all).
+    let rects = this._frozenElements.map(entry => entry.element.getBoundingClientRect());
+    for (let i = 0; i < this._frozenElements.length; i++) {
+      let el = this._frozenElements[i].element;
+      el.style.width = `${rects[i].width}px`;
+      el.style.height = `${rects[i].height}px`;
+      el.style.contain = 'strict';
+    }
+  }
+
+  /**
+   * Remove containment and restore original styles on all frozen
+   * elements.
+   */
+  private _unfreezeElements(): void {
+    console.log(`[SplitPanel] unfreezing ${this._frozenElements.length} elements`);
+    if (this._intervalId !== 0) {
+      clearInterval(this._intervalId);
+      this._intervalId = 0;
+    }
+    for (let entry of this._frozenElements) {
+      let el = entry.element;
+      el.style.contain = entry.prevContain;
+      el.style.width = entry.prevWidth;
+      el.style.height = entry.prevHeight;
+    }
+    this._frozenElements = [];
+  }
+
+  /**
+   * Start a PerformanceObserver to detect slow frames during drag.
+   * Prefers `long-animation-frame` (includes rendering cost) and
+   * falls back to `longtask` (script-only, >50 ms threshold).
+   */
+  private _observeSlowLayout(): void {
+    if (typeof PerformanceObserver === 'undefined') {
+      return;
+    }
+    try {
+      this._performanceObserver = new PerformanceObserver(() => {
+        if (this._frozenElements.length === 0) {
+          console.log('[SplitPanel] long task detected during drag, freezing heavy leaf widgets');
+          this._freezeHeavyLeaves();
+        }
+      });
+      try {
+        this._performanceObserver.observe({ type: 'long-animation-frame' });
+      } catch {
+        try {
+          this._performanceObserver.observe({ type: 'longtask' });
+        } catch {
+          this._performanceObserver = null;
+        }
+      }
+    } catch {
+      // PerformanceObserver not supported.
+    }
+  }
+
+  /**
+   * Disconnect the PerformanceObserver if active.
+   */
+  private _disconnectObserver(): void {
+    if (this._performanceObserver) {
+      this._performanceObserver.disconnect();
+      this._performanceObserver = null;
+    }
+  }
+
   private _handleMoved = new Signal<any, void>(this);
   private _pressData: Private.IPressData | null = null;
+  private _performanceObserver: PerformanceObserver | null = null;
+  private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
+  private _frozenElements: Private.IFrozenElement[] = [];
+  private _intervalId = 0;
 }
 
 /**
@@ -403,6 +565,19 @@ export namespace SplitPanel {
      * The default is a new `SplitLayout`.
      */
     layout?: SplitLayout;
+
+    /**
+     * The number of DOM nodes in a child widget above which the
+     * panel will apply CSS containment during handle dragging to
+     * prevent expensive child relayout.
+     *
+     * Additionally, if a layout update takes longer than 16ms,
+     * containment is applied reactively for all children regardless
+     * of this threshold.
+     *
+     * The default is `5000`.
+     */
+    nodeCountThreshold?: number;
   }
 
   /**
@@ -447,6 +622,7 @@ export namespace SplitPanel {
   export function setStretch(widget: Widget, value: number): void {
     SplitLayout.setStretch(widget, value);
   }
+
 }
 
 /**
@@ -471,6 +647,83 @@ namespace Private {
      * The disposable which will clear the override cursor.
      */
     override: IDisposable;
+  }
+
+  /**
+   * An object which holds the original styles for a frozen element.
+   */
+  export interface IFrozenElement {
+    /**
+     * The frozen DOM element.
+     */
+    element: HTMLElement;
+
+    /**
+     * The original `contain` style value.
+     */
+    prevContain: string;
+
+    /**
+     * The original `width` style value.
+     */
+    prevWidth: string;
+
+    /**
+     * The original `height` style value.
+     */
+    prevHeight: string;
+  }
+
+  /**
+   * The default node count threshold for content isolation.
+   */
+  export const DEFAULT_NODE_COUNT_THRESHOLD = 5000;
+
+  /**
+   * The interval (in ms) at which frozen elements have their sizes
+   * refreshed during handle dragging.
+   */
+  export const REFRESH_INTERVAL_MS = 5000;
+
+  /**
+   * Recursively find the deepest widgets whose subtree is heavy
+   * (node count >= threshold) but whose child widgets are all
+   * individually light. This places containment as low in the
+   * DOM tree as possible.
+   */
+  export function collectHeavyWidgets(
+    widget: Widget,
+    threshold: number,
+    result: Widget[]
+  ): void {
+    let nodeCount = widget.node.querySelectorAll('*').length;
+    if (nodeCount < threshold) {
+      return;
+    }
+    let layout = widget.layout;
+    if (!layout) {
+      // Leaf widget that is heavy — freeze it.
+      result.push(widget);
+      return;
+    }
+    // Check if any child widget is individually heavy.
+    let anyChildHeavy = false;
+    for (let child of layout) {
+      if (child.node.querySelectorAll('*').length >= threshold) {
+        anyChildHeavy = true;
+        break;
+      }
+    }
+    if (anyChildHeavy) {
+      // Recurse into children — we can push containment deeper.
+      for (let child of layout) {
+        collectHeavyWidgets(child, threshold, result);
+      }
+    } else {
+      // No child is individually heavy, but this widget is.
+      // This is the deepest heavy boundary — freeze here.
+      result.push(widget);
+    }
   }
 
   /**

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -280,8 +280,8 @@ export class SplitPanel extends Panel {
     let override = Drag.overrideCursor(style.cursor!);
     this._pressData = { index, delta, override };
 
-    // Start observing for long tasks to reactively apply containment.
-    this._observeSlowLayout();
+    // Freeze heavy leaf widgets immediately when drag starts.
+    this._freezeHeavyLeaves();
   }
 
   /**
@@ -336,9 +336,6 @@ export class SplitPanel extends Panel {
     if (!this._pressData) {
       return;
     }
-
-    // Stop observing long tasks.
-    this._disconnectObserver();
 
     // Unfreeze all contained elements.
     this._unfreezeElements();
@@ -608,49 +605,8 @@ export class SplitPanel extends Panel {
     this._frozenGroups = [];
   }
 
-  /**
-   * Start a PerformanceObserver to detect slow frames during drag.
-   * Prefers `long-animation-frame` (includes rendering cost) and
-   * falls back to `longtask` (script-only, >50 ms threshold).
-   */
-  private _observeSlowLayout(): void {
-    if (typeof PerformanceObserver === 'undefined') {
-      return;
-    }
-    try {
-      this._performanceObserver = new PerformanceObserver(() => {
-        if (this._frozenGroups.length === 0) {
-          console.log('[SplitPanel] long task detected during drag, freezing heavy leaf widgets');
-          this._freezeHeavyLeaves();
-        }
-      });
-      try {
-        this._performanceObserver.observe({ type: 'long-animation-frame' });
-      } catch {
-        try {
-          this._performanceObserver.observe({ type: 'longtask' });
-        } catch {
-          this._performanceObserver = null;
-        }
-      }
-    } catch {
-      // PerformanceObserver not supported.
-    }
-  }
-
-  /**
-   * Disconnect the PerformanceObserver if active.
-   */
-  private _disconnectObserver(): void {
-    if (this._performanceObserver) {
-      this._performanceObserver.disconnect();
-      this._performanceObserver = null;
-    }
-  }
-
   private _handleMoved = new Signal<any, void>(this);
   private _pressData: Private.IPressData | null = null;
-  private _performanceObserver: PerformanceObserver | null = null;
   private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
   private _frozenGroups: Private.IFrozenElement[][] = [];
   private _refreshTimerId = 0;

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -363,7 +363,7 @@ export class SplitPanel extends Panel {
    * subtree exceeds the node count threshold.
    */
   private _freezeHeavyLeaves(): void {
-    if (this._frozenGroups.length > 0) {
+    if (this._frozenElements.length > 0) {
       return;
     }
 
@@ -373,55 +373,46 @@ export class SplitPanel extends Panel {
       Private.collectHeavyWidgets(this.widgets[i], this._nodeCountThreshold, targets);
     }
 
-    // Collect elements grouped by target widget.
-    let groups: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[][] = [];
+    // Read dimensions before mutations.
+    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevMinWidth: string; prevHeight: string; prevMinHeight: string }[] = [];
     for (let target of targets) {
       let el = target.node;
-      let elements: HTMLElement[] = [el];
-      for (let i = 0; i < el.children.length; i++) {
-        elements.push(el.children[i] as HTMLElement);
+      if (el.style.contain === 'strict') {
+        continue;
       }
-      // Read dimensions for this group.
-      let group: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
-      for (let elem of elements) {
-        if (elem.style.contain === 'strict') {
-          continue;
-        }
-        group.push({
-          el: elem,
-          rect: elem.getBoundingClientRect(),
-          prevContain: elem.style.contain,
-          prevWidth: elem.style.width,
-          prevHeight: elem.style.height
-        });
-      }
-      if (group.length > 0) {
-        groups.push(group);
-      }
+      entries.push({
+        el,
+        rect: el.getBoundingClientRect(),
+        prevContain: el.style.contain,
+        prevWidth: el.style.width,
+        prevMinWidth: el.style.minWidth,
+        prevHeight: el.style.height,
+        prevMinHeight: el.style.minHeight
+      });
     }
 
     // Apply containment and pinned sizes.
-    for (let group of groups) {
-      let frozenGroup: Private.IFrozenElement[] = [];
-      for (let entry of group) {
-        frozenGroup.push({
-          element: entry.el,
-          prevContain: entry.prevContain,
-          prevWidth: entry.prevWidth,
-          prevHeight: entry.prevHeight
-        });
-        entry.el.style.width = `${entry.rect.width}px`;
-        entry.el.style.height = `${entry.rect.height}px`;
-        entry.el.style.contain = 'strict';
-      }
-      this._frozenGroups.push(frozenGroup);
+    for (let entry of entries) {
+      this._frozenElements.push({
+        element: entry.el,
+        prevContain: entry.prevContain,
+        prevWidth: entry.prevWidth,
+        prevMinWidth: entry.prevMinWidth,
+        prevHeight: entry.prevHeight,
+        prevMinHeight: entry.prevMinHeight
+      });
+      entry.el.style.width = `${entry.rect.width}px`;
+      entry.el.style.minWidth = `${entry.rect.width}px`;
+      entry.el.style.height = `${entry.rect.height}px`;
+      entry.el.style.minHeight = `${entry.rect.height}px`;
+      entry.el.style.contain = 'strict';
     }
 
-    console.log(`[SplitPanel] froze ${this._frozenGroups.length} groups`);
+    console.log(`[SplitPanel] froze ${this._frozenElements.length} elements`);
 
     // Start periodic interval to keep sizes roughly correct
     // during long continuous drags.
-    if (this._frozenGroups.length > 0 && this._intervalId === 0) {
+    if (this._frozenElements.length > 0 && this._intervalId === 0) {
       this._intervalId = window.setInterval(() => {
         this._refreshFrozenElements();
       }, Private.REFRESH_INTERVAL_MS);
@@ -434,7 +425,7 @@ export class SplitPanel extends Panel {
    * moving the handle.
    */
   private _scheduleRefresh(): void {
-    if (this._frozenGroups.length === 0) {
+    if (this._frozenElements.length === 0) {
       return;
     }
     if (this._refreshTimerId !== 0) {
@@ -447,33 +438,36 @@ export class SplitPanel extends Panel {
   }
 
   /**
-   * Refresh frozen groups one at a time, spreading the reflow
+   * Refresh frozen elements one at a time, spreading the reflow
    * cost across multiple animation frames.
    */
   private _refreshFrozenElements(): void {
-    console.log(`[SplitPanel] refreshing ${this._frozenGroups.length} frozen groups (staggered)`);
-    let g = 0;
+    console.log(`[SplitPanel] refreshing ${this._frozenElements.length} frozen elements (staggered)`);
+    let i = 0;
     const step = () => {
-      if (g >= this._frozenGroups.length) {
+      if (i >= this._frozenElements.length) {
         this._refreshRAFId = 0;
         return;
       }
-      let group = this._frozenGroups[g];
-      // Lift containment for all elements in this group.
-      for (let entry of group) {
-        entry.element.style.contain = entry.prevContain;
-        entry.element.style.width = '';
-        entry.element.style.height = '';
-      }
-      // Read all rects, then re-pin.
-      let rects = group.map(entry => entry.element.getBoundingClientRect());
-      for (let i = 0; i < group.length; i++) {
-        group[i].element.style.width = `${rects[i].width}px`;
-        group[i].element.style.height = `${rects[i].height}px`;
-        group[i].element.style.contain = 'strict';
-      }
-      g++;
-      this._refreshRAFId = requestAnimationFrame(step);
+      let entry = this._frozenElements[i];
+      let el = entry.element;
+      // Frame 1: lift containment to let the browser settle layout.
+      el.style.contain = entry.prevContain;
+      el.style.width = '';
+      el.style.minWidth = '';
+      el.style.height = '';
+      el.style.minHeight = '';
+      // Frame 2: read the settled rect and re-pin.
+      this._refreshRAFId = requestAnimationFrame(() => {
+        let rect = el.getBoundingClientRect();
+        el.style.width = `${rect.width}px`;
+        el.style.minWidth = `${rect.width}px`;
+        el.style.height = `${rect.height}px`;
+        el.style.minHeight = `${rect.height}px`;
+        el.style.contain = 'strict';
+        i++;
+        this._refreshRAFId = requestAnimationFrame(step);
+      });
     };
     this._refreshRAFId = requestAnimationFrame(step);
   }
@@ -483,7 +477,7 @@ export class SplitPanel extends Panel {
    * elements.
    */
   private _unfreezeElements(): void {
-    console.log(`[SplitPanel] unfreezing ${this._frozenGroups.length} groups`);
+    console.log(`[SplitPanel] unfreezing ${this._frozenElements.length} elements`);
     if (this._refreshTimerId !== 0) {
       clearTimeout(this._refreshTimerId);
       this._refreshTimerId = 0;
@@ -496,14 +490,14 @@ export class SplitPanel extends Panel {
       clearInterval(this._intervalId);
       this._intervalId = 0;
     }
-    for (let group of this._frozenGroups) {
-      for (let entry of group) {
-        entry.element.style.contain = entry.prevContain;
-        entry.element.style.width = entry.prevWidth;
-        entry.element.style.height = entry.prevHeight;
-      }
+    for (let entry of this._frozenElements) {
+      entry.element.style.contain = entry.prevContain;
+      entry.element.style.width = entry.prevWidth;
+      entry.element.style.minWidth = entry.prevMinWidth;
+      entry.element.style.height = entry.prevHeight;
+      entry.element.style.minHeight = entry.prevMinHeight;
     }
-    this._frozenGroups = [];
+    this._frozenElements = [];
   }
 
   /**
@@ -517,7 +511,7 @@ export class SplitPanel extends Panel {
     }
     try {
       this._performanceObserver = new PerformanceObserver(() => {
-        if (this._frozenGroups.length === 0) {
+        if (this._frozenElements.length === 0) {
           console.log('[SplitPanel] long task detected during drag, freezing heavy leaf widgets');
           this._freezeHeavyLeaves();
         }
@@ -550,7 +544,7 @@ export class SplitPanel extends Panel {
   private _pressData: Private.IPressData | null = null;
   private _performanceObserver: PerformanceObserver | null = null;
   private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
-  private _frozenGroups: Private.IFrozenElement[][] = [];
+  private _frozenElements: Private.IFrozenElement[] = [];
   private _refreshTimerId = 0;
   private _refreshRAFId = 0;
   private _intervalId = 0;
@@ -719,9 +713,19 @@ namespace Private {
     prevWidth: string;
 
     /**
+     * The original `minWidth` style value.
+     */
+    prevMinWidth: string;
+
+    /**
      * The original `height` style value.
      */
     prevHeight: string;
+
+    /**
+     * The original `minHeight` style value.
+     */
+    prevMinHeight: string;
   }
 
   /**

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -363,7 +363,7 @@ export class SplitPanel extends Panel {
    * subtree exceeds the node count threshold.
    */
   private _freezeHeavyLeaves(): void {
-    if (this._frozenElements.length > 0) {
+    if (this._frozenGroups.length > 0) {
       return;
     }
 
@@ -374,46 +374,123 @@ export class SplitPanel extends Panel {
     }
 
     // Read dimensions before mutations.
-    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevMinWidth: string; prevHeight: string; prevMinHeight: string }[] = [];
+    let groups: {
+      el: HTMLElement;
+      rect: DOMRect;
+      isHead: boolean;
+      prevContain: string;
+      prevWidth: string;
+      prevMinWidth: string;
+      prevMaxWidth: string;
+      prevHeight: string;
+      prevMinHeight: string;
+      prevMaxHeight: string;
+      prevContentVisibility: string;
+      prevContainIntrinsicWidth: string;
+      prevContainIntrinsicHeight: string;
+    }[][] = [];
     for (let target of targets) {
-      let el = target.node;
-      if (el.style.contain === 'strict') {
+      let head = target.node;
+      if (head.style.contain === 'strict') {
         continue;
       }
-      entries.push({
-        el,
-        rect: el.getBoundingClientRect(),
-        prevContain: el.style.contain,
-        prevWidth: el.style.width,
-        prevMinWidth: el.style.minWidth,
-        prevHeight: el.style.height,
-        prevMinHeight: el.style.minHeight
+      let group: {
+        el: HTMLElement;
+        rect: DOMRect;
+        isHead: boolean;
+        prevContain: string;
+        prevWidth: string;
+        prevMinWidth: string;
+        prevMaxWidth: string;
+        prevHeight: string;
+        prevMinHeight: string;
+        prevMaxHeight: string;
+        prevContentVisibility: string;
+        prevContainIntrinsicWidth: string;
+        prevContainIntrinsicHeight: string;
+      }[] = [];
+
+      group.push({
+        el: head,
+        rect: head.getBoundingClientRect(),
+        isHead: true,
+        prevContain: head.style.contain,
+        prevWidth: head.style.width,
+        prevMinWidth: head.style.minWidth,
+        prevMaxWidth: head.style.maxWidth,
+        prevHeight: head.style.height,
+        prevMinHeight: head.style.minHeight,
+        prevMaxHeight: head.style.maxHeight,
+        prevContentVisibility: head.style.getPropertyValue('content-visibility'),
+        prevContainIntrinsicWidth: head.style.containIntrinsicWidth,
+        prevContainIntrinsicHeight: head.style.containIntrinsicHeight
       });
+
+      for (let i = 0; i < head.children.length; i++) {
+        let child = head.children[i] as HTMLElement;
+        group.push({
+          el: child,
+          rect: child.getBoundingClientRect(),
+          isHead: false,
+          prevContain: child.style.contain,
+          prevWidth: child.style.width,
+          prevMinWidth: child.style.minWidth,
+          prevMaxWidth: child.style.maxWidth,
+          prevHeight: child.style.height,
+          prevMinHeight: child.style.minHeight,
+          prevMaxHeight: child.style.maxHeight,
+          prevContentVisibility: child.style.getPropertyValue('content-visibility'),
+          prevContainIntrinsicWidth: child.style.containIntrinsicWidth,
+          prevContainIntrinsicHeight: child.style.containIntrinsicHeight
+        });
+      }
+
+      groups.push(group);
     }
 
     // Apply containment and pinned sizes.
-    for (let entry of entries) {
-      this._frozenElements.push({
-        element: entry.el,
-        prevContain: entry.prevContain,
-        prevWidth: entry.prevWidth,
-        prevMinWidth: entry.prevMinWidth,
-        prevHeight: entry.prevHeight,
-        prevMinHeight: entry.prevMinHeight
-      });
-      entry.el.style.width = `${entry.rect.width}px`;
-      entry.el.style.minWidth = `${entry.rect.width}px`;
-      entry.el.style.height = `${entry.rect.height}px`;
-      entry.el.style.minHeight = `${entry.rect.height}px`;
-      entry.el.style.contain = 'strict';
-      entry.el.classList.add('lm-layout-frozen');
+    for (let group of groups) {
+      let frozenGroup: Private.IFrozenElement[] = [];
+      for (let entry of group) {
+        frozenGroup.push({
+          element: entry.el,
+          isHead: entry.isHead,
+          prevContain: entry.prevContain,
+          prevWidth: entry.prevWidth,
+          prevMinWidth: entry.prevMinWidth,
+          prevMaxWidth: entry.prevMaxWidth,
+          prevHeight: entry.prevHeight,
+          prevMinHeight: entry.prevMinHeight,
+          prevMaxHeight: entry.prevMaxHeight,
+          prevContentVisibility: entry.prevContentVisibility,
+          prevContainIntrinsicWidth: entry.prevContainIntrinsicWidth,
+          prevContainIntrinsicHeight: entry.prevContainIntrinsicHeight
+        });
+
+        entry.el.style.width = `${entry.rect.width}px`;
+        entry.el.style.minWidth = `${entry.rect.width}px`;
+        entry.el.style.maxWidth = `${entry.rect.width}px`;
+        entry.el.style.maxHeight = `${entry.rect.height}px`;
+
+        if (entry.isHead) {
+          entry.el.style.height = `${entry.rect.height}px`;
+          entry.el.style.minHeight = `${entry.rect.height}px`;
+          entry.el.style.contain = 'strict';
+          entry.el.classList.add('lm-layout-frozen');
+        } else {
+          entry.el.style.setProperty('content-visibility', 'auto');
+          entry.el.style.containIntrinsicWidth = `${entry.rect.width}px`;
+          entry.el.style.containIntrinsicHeight = `${entry.rect.height}px`;
+        }
+      }
+      this._frozenGroups.push(frozenGroup);
     }
 
-    console.log(`[SplitPanel] froze ${this._frozenElements.length} elements`);
+    console.log(`[SplitPanel] froze ${this._frozenGroups.length} groups`);
 
     // Start periodic interval to keep sizes roughly correct
     // during long continuous drags.
-    if (this._frozenElements.length > 0 && this._intervalId === 0) {
+    if (this._frozenGroups.length > 0 && this._intervalId === 0) {
       this._intervalId = window.setInterval(() => {
         this._refreshFrozenElements();
       }, Private.REFRESH_INTERVAL_MS);
@@ -426,7 +503,7 @@ export class SplitPanel extends Panel {
    * moving the handle.
    */
   private _scheduleRefresh(): void {
-    if (this._frozenElements.length === 0) {
+    if (this._frozenGroups.length === 0) {
       return;
     }
     if (this._refreshTimerId !== 0) {
@@ -439,34 +516,54 @@ export class SplitPanel extends Panel {
   }
 
   /**
-   * Refresh frozen elements one at a time, spreading the reflow
+   * Refresh frozen groups one at a time, spreading the reflow
    * cost across multiple animation frames.
    */
   private _refreshFrozenElements(): void {
-    console.log(`[SplitPanel] refreshing ${this._frozenElements.length} frozen elements (staggered)`);
-    let i = 0;
+    console.log(`[SplitPanel] refreshing ${this._frozenGroups.length} frozen groups (staggered)`);
+    let g = 0;
     const step = () => {
-      if (i >= this._frozenElements.length) {
+      if (g >= this._frozenGroups.length) {
         this._refreshRAFId = 0;
         return;
       }
-      let entry = this._frozenElements[i];
-      let el = entry.element;
+      let group = this._frozenGroups[g];
       // Frame 1: lift containment to let the browser settle layout.
-      el.style.contain = entry.prevContain;
-      el.style.width = '';
-      el.style.minWidth = '';
-      el.style.height = '';
-      el.style.minHeight = '';
+      for (let entry of group) {
+        let el = entry.element;
+        el.style.contain = entry.prevContain;
+        el.style.width = '';
+        el.style.minWidth = '';
+        el.style.maxWidth = '';
+        el.style.height = '';
+        el.style.minHeight = '';
+        el.style.maxHeight = '';
+        el.style.setProperty('content-visibility', entry.prevContentVisibility);
+        el.style.containIntrinsicWidth = entry.prevContainIntrinsicWidth;
+        el.style.containIntrinsicHeight = entry.prevContainIntrinsicHeight;
+      }
       // Frame 2: read the settled rect and re-pin.
       this._refreshRAFId = requestAnimationFrame(() => {
-        let rect = el.getBoundingClientRect();
-        el.style.width = `${rect.width}px`;
-        el.style.minWidth = `${rect.width}px`;
-        el.style.height = `${rect.height}px`;
-        el.style.minHeight = `${rect.height}px`;
-        el.style.contain = 'strict';
-        i++;
+        let rects = group.map(entry => entry.element.getBoundingClientRect());
+        for (let i = 0; i < group.length; i++) {
+          let entry = group[i];
+          let rect = rects[i];
+          let el = entry.element;
+          el.style.width = `${rect.width}px`;
+          el.style.minWidth = `${rect.width}px`;
+          el.style.maxWidth = `${rect.width}px`;
+          el.style.maxHeight = `${rect.height}px`;
+          if (entry.isHead) {
+            el.style.height = `${rect.height}px`;
+            el.style.minHeight = `${rect.height}px`;
+            el.style.contain = 'strict';
+          } else {
+            el.style.setProperty('content-visibility', 'auto');
+            el.style.containIntrinsicWidth = `${rect.width}px`;
+            el.style.containIntrinsicHeight = `${rect.height}px`;
+          }
+        }
+        g++;
         this._refreshRAFId = requestAnimationFrame(step);
       });
     };
@@ -478,7 +575,7 @@ export class SplitPanel extends Panel {
    * elements.
    */
   private _unfreezeElements(): void {
-    console.log(`[SplitPanel] unfreezing ${this._frozenElements.length} elements`);
+    console.log(`[SplitPanel] unfreezing ${this._frozenGroups.length} groups`);
     if (this._refreshTimerId !== 0) {
       clearTimeout(this._refreshTimerId);
       this._refreshTimerId = 0;
@@ -491,15 +588,24 @@ export class SplitPanel extends Panel {
       clearInterval(this._intervalId);
       this._intervalId = 0;
     }
-    for (let entry of this._frozenElements) {
-      entry.element.style.contain = entry.prevContain;
-      entry.element.style.width = entry.prevWidth;
-      entry.element.style.minWidth = entry.prevMinWidth;
-      entry.element.style.height = entry.prevHeight;
-      entry.element.style.minHeight = entry.prevMinHeight;
-      entry.element.classList.remove('lm-layout-frozen');
+    for (let group of this._frozenGroups) {
+      for (let entry of group) {
+        entry.element.style.contain = entry.prevContain;
+        entry.element.style.width = entry.prevWidth;
+        entry.element.style.minWidth = entry.prevMinWidth;
+        entry.element.style.maxWidth = entry.prevMaxWidth;
+        entry.element.style.height = entry.prevHeight;
+        entry.element.style.minHeight = entry.prevMinHeight;
+        entry.element.style.maxHeight = entry.prevMaxHeight;
+        entry.element.style.setProperty('content-visibility', entry.prevContentVisibility);
+        entry.element.style.containIntrinsicWidth = entry.prevContainIntrinsicWidth;
+        entry.element.style.containIntrinsicHeight = entry.prevContainIntrinsicHeight;
+        if (entry.isHead) {
+          entry.element.classList.remove('lm-layout-frozen');
+        }
+      }
     }
-    this._frozenElements = [];
+    this._frozenGroups = [];
   }
 
   /**
@@ -513,7 +619,7 @@ export class SplitPanel extends Panel {
     }
     try {
       this._performanceObserver = new PerformanceObserver(() => {
-        if (this._frozenElements.length === 0) {
+        if (this._frozenGroups.length === 0) {
           console.log('[SplitPanel] long task detected during drag, freezing heavy leaf widgets');
           this._freezeHeavyLeaves();
         }
@@ -546,7 +652,7 @@ export class SplitPanel extends Panel {
   private _pressData: Private.IPressData | null = null;
   private _performanceObserver: PerformanceObserver | null = null;
   private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
-  private _frozenElements: Private.IFrozenElement[] = [];
+  private _frozenGroups: Private.IFrozenElement[][] = [];
   private _refreshTimerId = 0;
   private _refreshRAFId = 0;
   private _intervalId = 0;
@@ -705,6 +811,11 @@ namespace Private {
     element: HTMLElement;
 
     /**
+     * Whether this entry is a frozen group head.
+     */
+    isHead: boolean;
+
+    /**
      * The original `contain` style value.
      */
     prevContain: string;
@@ -720,6 +831,11 @@ namespace Private {
     prevMinWidth: string;
 
     /**
+     * The original `maxWidth` style value.
+     */
+    prevMaxWidth: string;
+
+    /**
      * The original `height` style value.
      */
     prevHeight: string;
@@ -728,6 +844,26 @@ namespace Private {
      * The original `minHeight` style value.
      */
     prevMinHeight: string;
+
+    /**
+     * The original `maxHeight` style value.
+     */
+    prevMaxHeight: string;
+
+    /**
+     * The original `contentVisibility` style value.
+     */
+    prevContentVisibility: string;
+
+    /**
+     * The original `containIntrinsicWidth` style value.
+     */
+    prevContainIntrinsicWidth: string;
+
+    /**
+     * The original `containIntrinsicHeight` style value.
+     */
+    prevContainIntrinsicHeight: string;
   }
 
   /**
@@ -745,7 +881,7 @@ namespace Private {
    * The periodic interval (in ms) for refreshing frozen element
    * sizes during long continuous drags.
    */
-  export const REFRESH_INTERVAL_MS = 5000;
+  export const REFRESH_INTERVAL_MS = 3000;
 
   /**
    * The minimum total text length in a widget's subtree to

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -363,7 +363,7 @@ export class SplitPanel extends Panel {
    * subtree exceeds the node count threshold.
    */
   private _freezeHeavyLeaves(): void {
-    if (this._frozenElements.length > 0) {
+    if (this._frozenGroups.length > 0) {
       return;
     }
 
@@ -373,49 +373,55 @@ export class SplitPanel extends Panel {
       Private.collectHeavyWidgets(this.widgets[i], this._nodeCountThreshold, targets);
     }
 
-    // Collect widget nodes and their direct DOM children.
-    let elements: HTMLElement[] = [];
+    // Collect elements grouped by target widget.
+    let groups: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[][] = [];
     for (let target of targets) {
       let el = target.node;
-      elements.push(el);
+      let elements: HTMLElement[] = [el];
       for (let i = 0; i < el.children.length; i++) {
         elements.push(el.children[i] as HTMLElement);
       }
-    }
-
-    // Pass 1: read all dimensions before mutations.
-    let entries: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
-    for (let el of elements) {
-      if (el.style.contain === 'strict') {
-        continue;
+      // Read dimensions for this group.
+      let group: { el: HTMLElement; rect: DOMRect; prevContain: string; prevWidth: string; prevHeight: string }[] = [];
+      for (let elem of elements) {
+        if (elem.style.contain === 'strict') {
+          continue;
+        }
+        group.push({
+          el: elem,
+          rect: elem.getBoundingClientRect(),
+          prevContain: elem.style.contain,
+          prevWidth: elem.style.width,
+          prevHeight: elem.style.height
+        });
       }
-      entries.push({
-        el,
-        rect: el.getBoundingClientRect(),
-        prevContain: el.style.contain,
-        prevWidth: el.style.width,
-        prevHeight: el.style.height
-      });
+      if (group.length > 0) {
+        groups.push(group);
+      }
     }
 
-    // Pass 2: apply containment and pinned sizes.
-    for (let entry of entries) {
-      this._frozenElements.push({
-        element: entry.el,
-        prevContain: entry.prevContain,
-        prevWidth: entry.prevWidth,
-        prevHeight: entry.prevHeight
-      });
-      entry.el.style.width = `${entry.rect.width}px`;
-      entry.el.style.height = `${entry.rect.height}px`;
-      entry.el.style.contain = 'strict';
+    // Apply containment and pinned sizes.
+    for (let group of groups) {
+      let frozenGroup: Private.IFrozenElement[] = [];
+      for (let entry of group) {
+        frozenGroup.push({
+          element: entry.el,
+          prevContain: entry.prevContain,
+          prevWidth: entry.prevWidth,
+          prevHeight: entry.prevHeight
+        });
+        entry.el.style.width = `${entry.rect.width}px`;
+        entry.el.style.height = `${entry.rect.height}px`;
+        entry.el.style.contain = 'strict';
+      }
+      this._frozenGroups.push(frozenGroup);
     }
 
-    console.log(`[SplitPanel] froze ${this._frozenElements.length} heavy widget nodes`);
+    console.log(`[SplitPanel] froze ${this._frozenGroups.length} groups`);
 
     // Start periodic interval to keep sizes roughly correct
     // during long continuous drags.
-    if (this._frozenElements.length > 0 && this._intervalId === 0) {
+    if (this._frozenGroups.length > 0 && this._intervalId === 0) {
       this._intervalId = window.setInterval(() => {
         this._refreshFrozenElements();
       }, Private.REFRESH_INTERVAL_MS);
@@ -428,7 +434,7 @@ export class SplitPanel extends Panel {
    * moving the handle.
    */
   private _scheduleRefresh(): void {
-    if (this._frozenElements.length === 0) {
+    if (this._frozenGroups.length === 0) {
       return;
     }
     if (this._refreshTimerId !== 0) {
@@ -441,31 +447,35 @@ export class SplitPanel extends Panel {
   }
 
   /**
-   * Temporarily lift containment, let the browser reflow, then
-   * re-apply with updated sizes.
+   * Refresh frozen groups one at a time, spreading the reflow
+   * cost across multiple animation frames.
    */
   private _refreshFrozenElements(): void {
-    console.log(`[SplitPanel] refreshing ${this._frozenElements.length} frozen elements`);
-    // Lift containment and clear pinned sizes.
-    for (let entry of this._frozenElements) {
-      let el = entry.element;
-      el.style.contain = entry.prevContain;
-      el.style.width = '';
-      el.style.height = '';
-    }
-    // Force a synchronous reflow so elements settle.
-    // Reading offsetHeight triggers layout.
-    for (let entry of this._frozenElements) {
-      entry.element.offsetHeight;
-    }
-    // Re-pin with updated sizes (read all, then write all).
-    let rects = this._frozenElements.map(entry => entry.element.getBoundingClientRect());
-    for (let i = 0; i < this._frozenElements.length; i++) {
-      let el = this._frozenElements[i].element;
-      el.style.width = `${rects[i].width}px`;
-      el.style.height = `${rects[i].height}px`;
-      el.style.contain = 'strict';
-    }
+    console.log(`[SplitPanel] refreshing ${this._frozenGroups.length} frozen groups (staggered)`);
+    let g = 0;
+    const step = () => {
+      if (g >= this._frozenGroups.length) {
+        this._refreshRAFId = 0;
+        return;
+      }
+      let group = this._frozenGroups[g];
+      // Lift containment for all elements in this group.
+      for (let entry of group) {
+        entry.element.style.contain = entry.prevContain;
+        entry.element.style.width = '';
+        entry.element.style.height = '';
+      }
+      // Read all rects, then re-pin.
+      let rects = group.map(entry => entry.element.getBoundingClientRect());
+      for (let i = 0; i < group.length; i++) {
+        group[i].element.style.width = `${rects[i].width}px`;
+        group[i].element.style.height = `${rects[i].height}px`;
+        group[i].element.style.contain = 'strict';
+      }
+      g++;
+      this._refreshRAFId = requestAnimationFrame(step);
+    };
+    this._refreshRAFId = requestAnimationFrame(step);
   }
 
   /**
@@ -473,22 +483,27 @@ export class SplitPanel extends Panel {
    * elements.
    */
   private _unfreezeElements(): void {
-    console.log(`[SplitPanel] unfreezing ${this._frozenElements.length} elements`);
+    console.log(`[SplitPanel] unfreezing ${this._frozenGroups.length} groups`);
     if (this._refreshTimerId !== 0) {
       clearTimeout(this._refreshTimerId);
       this._refreshTimerId = 0;
+    }
+    if (this._refreshRAFId !== 0) {
+      cancelAnimationFrame(this._refreshRAFId);
+      this._refreshRAFId = 0;
     }
     if (this._intervalId !== 0) {
       clearInterval(this._intervalId);
       this._intervalId = 0;
     }
-    for (let entry of this._frozenElements) {
-      let el = entry.element;
-      el.style.contain = entry.prevContain;
-      el.style.width = entry.prevWidth;
-      el.style.height = entry.prevHeight;
+    for (let group of this._frozenGroups) {
+      for (let entry of group) {
+        entry.element.style.contain = entry.prevContain;
+        entry.element.style.width = entry.prevWidth;
+        entry.element.style.height = entry.prevHeight;
+      }
     }
-    this._frozenElements = [];
+    this._frozenGroups = [];
   }
 
   /**
@@ -502,7 +517,7 @@ export class SplitPanel extends Panel {
     }
     try {
       this._performanceObserver = new PerformanceObserver(() => {
-        if (this._frozenElements.length === 0) {
+        if (this._frozenGroups.length === 0) {
           console.log('[SplitPanel] long task detected during drag, freezing heavy leaf widgets');
           this._freezeHeavyLeaves();
         }
@@ -535,8 +550,9 @@ export class SplitPanel extends Panel {
   private _pressData: Private.IPressData | null = null;
   private _performanceObserver: PerformanceObserver | null = null;
   private _nodeCountThreshold = Private.DEFAULT_NODE_COUNT_THRESHOLD;
-  private _frozenElements: Private.IFrozenElement[] = [];
+  private _frozenGroups: Private.IFrozenElement[][] = [];
   private _refreshTimerId = 0;
+  private _refreshRAFId = 0;
   private _intervalId = 0;
 }
 

--- a/packages/widgets/src/splitpanel.ts
+++ b/packages/widgets/src/splitpanel.ts
@@ -406,6 +406,7 @@ export class SplitPanel extends Panel {
       entry.el.style.height = `${entry.rect.height}px`;
       entry.el.style.minHeight = `${entry.rect.height}px`;
       entry.el.style.contain = 'strict';
+      entry.el.classList.add('lm-layout-frozen');
     }
 
     console.log(`[SplitPanel] froze ${this._frozenElements.length} elements`);
@@ -496,6 +497,7 @@ export class SplitPanel extends Panel {
       entry.element.style.minWidth = entry.prevMinWidth;
       entry.element.style.height = entry.prevHeight;
       entry.element.style.minHeight = entry.prevMinHeight;
+      entry.element.classList.remove('lm-layout-frozen');
     }
     this._frozenElements = [];
   }
@@ -743,7 +745,7 @@ namespace Private {
    * The periodic interval (in ms) for refreshing frozen element
    * sizes during long continuous drags.
    */
-  export const REFRESH_INTERVAL_MS = 2000;
+  export const REFRESH_INTERVAL_MS = 5000;
 
   /**
    * The minimum total text length in a widget's subtree to

--- a/packages/widgets/style/widget.css
+++ b/packages/widgets/style/widget.css
@@ -20,3 +20,8 @@
 .lm-Widget.lm-mod-hidden {
   display: none !important;
 }
+
+.lm-layout-frozen * {
+  content-visibility: auto;
+  contain-intrinsic-size: auto;
+}

--- a/packages/widgets/style/widget.css
+++ b/packages/widgets/style/widget.css
@@ -23,5 +23,5 @@
 
 .lm-layout-frozen * {
   content-visibility: auto;
-  contain-intrinsic-size: auto;
+  contain-intrinsic-size: auto none;
 }


### PR DESCRIPTION
### Description

- tackles #505 
- this is an early draft; I plan to resolve duplication and drop some changes to reduce diff later on

#### Trigger condition

- using the Performance API works but we can detect the `longtask` or `long-animation-frame` but it comes after user already saw a freeze for a few seconds; I think this is not the right approach - the Performance API was designed primarily as a measurement tool, not to make the rendering system reactive.

#### Freeze implementation
- using `contain: strict` alone is not enough because it tells the layout engine that when considering layout of _parents_ it can use the size as given in `width`/`height` but the browser still needs to relay all the text nodes inside the widget, which is more expensive
- we can address this by using `minWidth`/`maxWidth` on the widgets with many children; it works but it is still not as fast as it could be; we know that it could be faster because resizing the same panels top-down is super smooth (without tricks) since we enabled strict containment. I believe that the difference is that the leaf layout, including text reflow, is never touched in top-down resize because the content is just scrolled rather than re-laid
- freezing the sizes of all leaves of heavy widgets does give a smooth resizing experience; this allows the rendering pipeline to skip layout of the contents altogether when resizing
- I was also experimenting with applying `content-visibility: auto` to DOM children of heavy widgets, I am yet to confirm if this is warranted in the final form

Freezing the width means that the `Widget` in panels which have `overflow: auto` enabled get scrollbars, which you can see on the recordings below.

#### Throttled/delayed updates
- we can update periodically to ensure user gets some idea of how the content will look like; the more often we perform the update, the more jittery the resize is. In recordings below I am using updates once every 3 seconds
- we can update when user pauses resizing; currently I wait 300ms to decide if user paused resizing
- the updates are staggered, doing things one panel (group) at a time, spread across frames to avoid any long tasks/dropped frames

### Before

[Screencast From 2026-04-21 15-21-43.webm](https://github.com/user-attachments/assets/2776d939-209a-4313-a214-73d057d24fbb)

### After (active on pointer down, no long animation frame detection)

[Screencast From 2026-04-21 15-11-26.webm](https://github.com/user-attachments/assets/b7550824-f4fe-4ff2-8570-c34bdb0caafc)

### After (activates only after long frame/task detection)

[Screencast From 2026-04-21 14-52-24.webm](https://github.com/user-attachments/assets/f34cb5cf-7512-401d-a4b7-f4430ca1cdc2)