### PR TITLE
Fix menu not closing when clicking tabs

### DIFF
--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -504,20 +504,20 @@ export class Menu extends Widget {
       case 'keydown':
         this._evtKeyDown(event as KeyboardEvent);
         break;
-      case 'mouseup':
-        this._evtMouseUp(event as MouseEvent);
+      case 'pointerup':
+        this._evtPointerUp(event as PointerEvent);
         break;
-      case 'mousemove':
-        this._evtMouseMove(event as MouseEvent);
+      case 'pointermove':
+        this._evtPointerMove(event as PointerEvent);
         break;
-      case 'mouseenter':
-        this._evtMouseEnter(event as MouseEvent);
+      case 'pointerenter':
+        this._evtPointerEnter(event as PointerEvent);
         break;
-      case 'mouseleave':
-        this._evtMouseLeave(event as MouseEvent);
+      case 'pointerleave':
+        this._evtPointerLeave(event as PointerEvent);
         break;
       case 'pointerdown':
-        this._evtMouseDown(event as MouseEvent);
+        this._evtPointerDown(event as PointerEvent);
         break;
       case 'contextmenu':
         event.preventDefault();
@@ -531,10 +531,10 @@ export class Menu extends Widget {
    */
   protected onBeforeAttach(msg: Message): void {
     this.node.addEventListener('keydown', this);
-    this.node.addEventListener('mouseup', this);
-    this.node.addEventListener('mousemove', this);
-    this.node.addEventListener('mouseenter', this);
-    this.node.addEventListener('mouseleave', this);
+    this.node.addEventListener('pointerup', this);
+    this.node.addEventListener('pointermove', this);
+    this.node.addEventListener('pointerenter', this);
+    this.node.addEventListener('pointerleave', this);
     this.node.addEventListener('contextmenu', this);
     document.addEventListener('pointerdown', this, true);
   }
@@ -544,10 +544,10 @@ export class Menu extends Widget {
    */
   protected onAfterDetach(msg: Message): void {
     this.node.removeEventListener('keydown', this);
-    this.node.removeEventListener('mouseup', this);
-    this.node.removeEventListener('mousemove', this);
-    this.node.removeEventListener('mouseenter', this);
-    this.node.removeEventListener('mouseleave', this);
+    this.node.removeEventListener('pointerup', this);
+    this.node.removeEventListener('pointermove', this);
+    this.node.removeEventListener('pointerenter', this);
+    this.node.removeEventListener('pointerleave', this);
     this.node.removeEventListener('contextmenu', this);
     document.removeEventListener('pointerdown', this, true);
   }
@@ -710,12 +710,12 @@ export class Menu extends Widget {
   }
 
   /**
-   * Handle the `'mouseup'` event for the menu.
+   * Handle the `'pointerup'` event for the menu.
    *
    * #### Notes
    * This listener is attached to the menu node.
    */
-  private _evtMouseUp(event: MouseEvent): void {
+  private _evtPointerUp(event: PointerEvent): void {
     if (event.button !== 0) {
       return;
     }
@@ -725,12 +725,12 @@ export class Menu extends Widget {
   }
 
   /**
-   * Handle the `'mousemove'` event for the menu.
+   * Handle the `'pointermove'` event for the menu.
    *
    * #### Notes
    * This listener is attached to the menu node.
    */
-  private _evtMouseMove(event: MouseEvent): void {
+  private _evtPointerMove(event: PointerEvent): void {
     // Hit test the item nodes for the item under the mouse.
     let index = ArrayExt.findFirstIndex(this.contentNode.children, node => {
       return ElementExt.hitTest(node, event.clientX, event.clientY);
@@ -771,12 +771,12 @@ export class Menu extends Widget {
   }
 
   /**
-   * Handle the `'mouseenter'` event for the menu.
+   * Handle the `'pointerenter'` event for the menu.
    *
    * #### Notes
    * This listener is attached to the menu node.
    */
-  private _evtMouseEnter(event: MouseEvent): void {
+  private _evtPointerEnter(event: PointerEvent): void {
     // Synchronize the active ancestor items.
     for (let menu = this._parentMenu; menu; menu = menu._parentMenu) {
       menu._cancelOpenTimer();
@@ -786,12 +786,12 @@ export class Menu extends Widget {
   }
 
   /**
-   * Handle the `'mouseleave'` event for the menu.
+   * Handle the `'pointerleave'` event for the menu.
    *
    * #### Notes
    * This listener is attached to the menu node.
    */
-  private _evtMouseLeave(event: MouseEvent): void {
+  private _evtPointerLeave(event: PointerEvent): void {
     // Cancel any pending submenu opening.
     this._cancelOpenTimer();
 
@@ -814,12 +814,12 @@ export class Menu extends Widget {
   }
 
   /**
-   * Handle the `'mousedown'` event for the menu.
+   * Handle the `'pointerdown'` event for the menu.
    *
    * #### Notes
    * This listener is attached to the document node.
    */
-  private _evtMouseDown(event: MouseEvent): void {
+  private _evtPointerDown(event: PointerEvent): void {
     // Bail if the menu is not a root menu.
     if (this._parentMenu) {
       return;

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -516,7 +516,7 @@ export class Menu extends Widget {
       case 'mouseleave':
         this._evtMouseLeave(event as MouseEvent);
         break;
-      case 'mousedown':
+      case 'pointerdown':
         this._evtMouseDown(event as MouseEvent);
         break;
       case 'contextmenu':
@@ -536,7 +536,7 @@ export class Menu extends Widget {
     this.node.addEventListener('mouseenter', this);
     this.node.addEventListener('mouseleave', this);
     this.node.addEventListener('contextmenu', this);
-    document.addEventListener('mousedown', this, true);
+    document.addEventListener('pointerdown', this, true);
   }
 
   /**
@@ -549,7 +549,7 @@ export class Menu extends Widget {
     this.node.removeEventListener('mouseenter', this);
     this.node.removeEventListener('mouseleave', this);
     this.node.removeEventListener('contextmenu', this);
-    document.removeEventListener('mousedown', this, true);
+    document.removeEventListener('pointerdown', this, true);
   }
 
   /**

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -360,12 +360,12 @@ export class MenuBar extends Widget {
       case 'keydown':
         this._evtKeyDown(event as KeyboardEvent);
         break;
-      case 'mousedown':
-        this._evtMouseDown(event as MouseEvent);
+      case 'pointerdown':
+        this._evtPointerDown(event as PointerEvent);
         break;
-      case 'mousemove':
-      case 'mouseleave':
-        this._evtMouseMove(event as MouseEvent);
+      case 'pointermove':
+      case 'pointerleave':
+        this._evtPointerMove(event as PointerEvent);
         break;
       case 'focusout':
         this._evtFocusOut(event as FocusEvent);
@@ -382,9 +382,9 @@ export class MenuBar extends Widget {
    */
   protected onBeforeAttach(msg: Message): void {
     this.node.addEventListener('keydown', this);
-    this.node.addEventListener('mousedown', this);
-    this.node.addEventListener('mousemove', this);
-    this.node.addEventListener('mouseleave', this);
+    this.node.addEventListener('pointerdown', this);
+    this.node.addEventListener('pointermove', this);
+    this.node.addEventListener('pointerleave', this);
     this.node.addEventListener('focusout', this);
     this.node.addEventListener('contextmenu', this);
   }
@@ -394,9 +394,9 @@ export class MenuBar extends Widget {
    */
   protected onAfterDetach(msg: Message): void {
     this.node.removeEventListener('keydown', this);
-    this.node.removeEventListener('mousedown', this);
-    this.node.removeEventListener('mousemove', this);
-    this.node.removeEventListener('mouseleave', this);
+    this.node.removeEventListener('pointerdown', this);
+    this.node.removeEventListener('pointermove', this);
+    this.node.removeEventListener('pointerleave', this);
     this.node.removeEventListener('focusout', this);
     this.node.removeEventListener('contextmenu', this);
     this._closeChildMenu();
@@ -651,9 +651,9 @@ export class MenuBar extends Widget {
   }
 
   /**
-   * Handle the `'mousedown'` event for the menu bar.
+   * Handle the `'pointerdown'` event for the menu bar.
    */
-  private _evtMouseDown(event: MouseEvent): void {
+  private _evtPointerDown(event: PointerEvent): void {
     // Bail if the mouse press was not on the menu bar. This can occur
     // when the document listener is installed for an active menu bar.
     if (!ElementExt.hitTest(this.node, event.clientX, event.clientY)) {
@@ -698,9 +698,9 @@ export class MenuBar extends Widget {
   }
 
   /**
-   * Handle the `'mousemove'` event for the menu bar.
+   * Handle the `'pointermove'` event for the menu bar.
    */
-  private _evtMouseMove(event: MouseEvent): void {
+  private _evtPointerMove(event: PointerEvent): void {
     // Check if the mouse is over one of the menu items.
     let index = ArrayExt.findFirstIndex(this.contentNode.children, node => {
       return ElementExt.hitTest(node, event.clientX, event.clientY);
@@ -802,7 +802,7 @@ export class MenuBar extends Widget {
     if (oldMenu) {
       oldMenu.close();
     } else {
-      document.addEventListener('mousedown', this, true);
+      document.addEventListener('pointerdown', this, true);
     }
 
     // Update the tab focus index and ensure the menu bar is updated.
@@ -841,7 +841,7 @@ export class MenuBar extends Widget {
     this.removeClass('lm-mod-active');
 
     // Remove the document listeners.
-    document.removeEventListener('mousedown', this, true);
+    document.removeEventListener('pointerdown', this, true);
 
     // Clear the internal menu reference.
     let menu = this._childMenu;
@@ -867,7 +867,7 @@ export class MenuBar extends Widget {
     this.removeClass('lm-mod-active');
 
     // Remove the document listeners.
-    document.removeEventListener('mousedown', this, true);
+    document.removeEventListener('pointerdown', this, true);
 
     // Clear the internal menu reference.
     this._childMenu = null;

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -816,12 +816,12 @@ describe('@lumino/widgets', () => {
         });
       });
 
-      context('mouseup', () => {
+      context('pointerup', () => {
         it('should trigger the active item', () => {
           menu.addItem({ command: 'test' });
           menu.activeIndex = 0;
           menu.open(0, 0);
-          menu.node.dispatchEvent(new MouseEvent('mouseup', { bubbles }));
+          menu.node.dispatchEvent(new PointerEvent('pointerup', { bubbles }));
           expect(executed).to.equal('test');
         });
 
@@ -830,7 +830,7 @@ describe('@lumino/widgets', () => {
           menu.activeIndex = 0;
           menu.open(0, 0);
           menu.node.dispatchEvent(
-            new MouseEvent('mouseup', {
+            new PointerEvent('pointerup', {
               bubbles,
               button: 1
             })
@@ -839,14 +839,14 @@ describe('@lumino/widgets', () => {
         });
       });
 
-      context('mousemove', () => {
+      context('pointermove', () => {
         it('should set the active index', () => {
           menu.addItem({ command: 'test' });
           menu.open(0, 0);
           let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
           let rect = node.getBoundingClientRect();
           menu.node.dispatchEvent(
-            new MouseEvent('mousemove', {
+            new PointerEvent('pointermove', {
               bubbles,
               clientX: rect.left + 1,
               clientY: rect.top + 1
@@ -864,7 +864,7 @@ describe('@lumino/widgets', () => {
           let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
           let rect = node.getBoundingClientRect();
           menu.node.dispatchEvent(
-            new MouseEvent('mousemove', {
+            new PointerEvent('pointermove', {
               bubbles,
               clientX: rect.left + 1,
               clientY: rect.top + 1
@@ -890,7 +890,7 @@ describe('@lumino/widgets', () => {
           let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
           let rect = node.getBoundingClientRect();
           menu.node.dispatchEvent(
-            new MouseEvent('mousemove', {
+            new PointerEvent('pointermove', {
               bubbles,
               clientX: rect.left,
               clientY: rect.top
@@ -905,7 +905,7 @@ describe('@lumino/widgets', () => {
         });
       });
 
-      context('mouseleave', () => {
+      context('pointerleave', () => {
         it('should reset the active index', () => {
           let submenu = new Menu({ commands });
           submenu.addItem({ command: 'test' });
@@ -915,7 +915,7 @@ describe('@lumino/widgets', () => {
           let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
           let rect = node.getBoundingClientRect();
           menu.node.dispatchEvent(
-            new MouseEvent('mousemove', {
+            new PointerEvent('pointermove', {
               bubbles,
               clientX: rect.left + 1,
               clientY: rect.top + 1
@@ -923,7 +923,7 @@ describe('@lumino/widgets', () => {
           );
           expect(menu.activeIndex).to.equal(0);
           menu.node.dispatchEvent(
-            new MouseEvent('mouseleave', {
+            new PointerEvent('pointerleave', {
               bubbles,
               clientX: rect.left,
               clientY: rect.top
@@ -941,7 +941,7 @@ describe('@lumino/widgets', () => {
           expect(menu.isAttached).to.equal(true);
           let rect = menu.node.getBoundingClientRect();
           menu.node.dispatchEvent(
-            new MouseEvent('pointerdown', {
+            new PointerEvent('pointerdown', {
               bubbles,
               clientX: rect.left + 1,
               clientY: rect.top + 1
@@ -955,7 +955,7 @@ describe('@lumino/widgets', () => {
           menu.open(0, 0);
           expect(menu.isAttached).to.equal(true);
           menu.node.dispatchEvent(
-            new MouseEvent('pointerdown', {
+            new PointerEvent('pointerdown', {
               bubbles,
               clientX: -10
             })
@@ -972,17 +972,17 @@ describe('@lumino/widgets', () => {
         expect(logMenu.methods).to.contain('onBeforeAttach');
         node.dispatchEvent(new KeyboardEvent('keydown', { bubbles }));
         expect(logMenu.events).to.contain('keydown');
-        node.dispatchEvent(new MouseEvent('mouseup', { bubbles }));
-        expect(logMenu.events).to.contain('mouseup');
-        node.dispatchEvent(new MouseEvent('mousemove', { bubbles }));
-        expect(logMenu.events).to.contain('mousemove');
-        node.dispatchEvent(new MouseEvent('mouseenter', { bubbles }));
-        expect(logMenu.events).to.contain('mouseenter');
-        node.dispatchEvent(new MouseEvent('mouseleave', { bubbles }));
-        expect(logMenu.events).to.contain('mouseleave');
+        node.dispatchEvent(new PointerEvent('pointerup', { bubbles }));
+        expect(logMenu.events).to.contain('pointerup');
+        node.dispatchEvent(new PointerEvent('pointermove', { bubbles }));
+        expect(logMenu.events).to.contain('pointermove');
+        node.dispatchEvent(new PointerEvent('pointerenter', { bubbles }));
+        expect(logMenu.events).to.contain('pointerenter');
+        node.dispatchEvent(new PointerEvent('pointerleave', { bubbles }));
+        expect(logMenu.events).to.contain('pointerleave');
         node.dispatchEvent(new MouseEvent('contextmenu', { bubbles }));
         expect(logMenu.events).to.contain('contextmenu');
-        document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles }));
+        document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles }));
         expect(logMenu.events).to.contain('pointerdown');
       });
     });
@@ -995,17 +995,17 @@ describe('@lumino/widgets', () => {
         expect(logMenu.methods).to.contain('onAfterDetach');
         node.dispatchEvent(new KeyboardEvent('keydown', { bubbles }));
         expect(logMenu.events).to.not.contain('keydown');
-        node.dispatchEvent(new MouseEvent('mouseup', { bubbles }));
-        expect(logMenu.events).to.not.contain('mouseup');
-        node.dispatchEvent(new MouseEvent('mousemove', { bubbles }));
-        expect(logMenu.events).to.not.contain('mousemove');
-        node.dispatchEvent(new MouseEvent('mouseenter', { bubbles }));
-        expect(logMenu.events).to.not.contain('mouseenter');
-        node.dispatchEvent(new MouseEvent('mouseleave', { bubbles }));
-        expect(logMenu.events).to.not.contain('mouseleave');
+        node.dispatchEvent(new PointerEvent('pointerup', { bubbles }));
+        expect(logMenu.events).to.not.contain('pointerup');
+        node.dispatchEvent(new PointerEvent('pointermove', { bubbles }));
+        expect(logMenu.events).to.not.contain('pointermove');
+        node.dispatchEvent(new PointerEvent('pointerenter', { bubbles }));
+        expect(logMenu.events).to.not.contain('pointerenter');
+        node.dispatchEvent(new PointerEvent('pointerleave', { bubbles }));
+        expect(logMenu.events).to.not.contain('pointerleave');
         node.dispatchEvent(new MouseEvent('contextmenu', { bubbles }));
         expect(logMenu.events).to.not.contain('contextmenu');
-        document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles }));
+        document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles }));
         expect(logMenu.events).to.not.contain('pointerdown');
       });
     });

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -982,7 +982,9 @@ describe('@lumino/widgets', () => {
         expect(logMenu.events).to.contain('pointerleave');
         node.dispatchEvent(new MouseEvent('contextmenu', { bubbles }));
         expect(logMenu.events).to.contain('contextmenu');
-        document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles }));
+        document.body.dispatchEvent(
+          new PointerEvent('pointerdown', { bubbles })
+        );
         expect(logMenu.events).to.contain('pointerdown');
       });
     });
@@ -1005,7 +1007,9 @@ describe('@lumino/widgets', () => {
         expect(logMenu.events).to.not.contain('pointerleave');
         node.dispatchEvent(new MouseEvent('contextmenu', { bubbles }));
         expect(logMenu.events).to.not.contain('contextmenu');
-        document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles }));
+        document.body.dispatchEvent(
+          new PointerEvent('pointerdown', { bubbles })
+        );
         expect(logMenu.events).to.not.contain('pointerdown');
       });
     });

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -934,14 +934,14 @@ describe('@lumino/widgets', () => {
         });
       });
 
-      context('mousedown', () => {
+      context('pointerdown', () => {
         it('should not close the menu if on a child node', () => {
           menu.addItem({ command: 'test' });
           menu.open(0, 0);
           expect(menu.isAttached).to.equal(true);
           let rect = menu.node.getBoundingClientRect();
           menu.node.dispatchEvent(
-            new MouseEvent('mousedown', {
+            new MouseEvent('pointerdown', {
               bubbles,
               clientX: rect.left + 1,
               clientY: rect.top + 1
@@ -955,7 +955,7 @@ describe('@lumino/widgets', () => {
           menu.open(0, 0);
           expect(menu.isAttached).to.equal(true);
           menu.node.dispatchEvent(
-            new MouseEvent('mousedown', {
+            new MouseEvent('pointerdown', {
               bubbles,
               clientX: -10
             })
@@ -982,8 +982,8 @@ describe('@lumino/widgets', () => {
         expect(logMenu.events).to.contain('mouseleave');
         node.dispatchEvent(new MouseEvent('contextmenu', { bubbles }));
         expect(logMenu.events).to.contain('contextmenu');
-        document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles }));
-        expect(logMenu.events).to.contain('mousedown');
+        document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles }));
+        expect(logMenu.events).to.contain('pointerdown');
       });
     });
 
@@ -1005,8 +1005,8 @@ describe('@lumino/widgets', () => {
         expect(logMenu.events).to.not.contain('mouseleave');
         node.dispatchEvent(new MouseEvent('contextmenu', { bubbles }));
         expect(logMenu.events).to.not.contain('contextmenu');
-        document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles }));
-        expect(logMenu.events).to.not.contain('mousedown');
+        document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles }));
+        expect(logMenu.events).to.not.contain('pointerdown');
       });
     });
 

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -705,9 +705,9 @@ describe('@lumino/widgets', () => {
         });
       });
 
-      context('mousedown', () => {
+      context('pointerdown', () => {
         it('should bail if the mouse press was not on the menu bar', () => {
-          let event = new MouseEvent('mousedown', {
+          let event = new PointerEvent('pointerdown', {
             bubbles,
             cancelable: true,
             clientX: -10
@@ -731,7 +731,7 @@ describe('@lumino/widgets', () => {
             'lm-MenuBar-item'
           )[0] as HTMLElement;
           let rect = firstItemNode.getBoundingClientRect();
-          let mouseEvent = new MouseEvent('mousedown', {
+          let mouseEvent = new PointerEvent('pointerdown', {
             bubbles,
             cancelable: true,
             clientX: rect.left + 1,
@@ -741,7 +741,7 @@ describe('@lumino/widgets', () => {
           bar.node.dispatchEvent(mouseEvent);
           expect(bar.activeIndex).to.equal(0);
           expect(menu.isAttached).to.equal(false);
-          // Ensure that mousedown default is not prevented, to allow browser
+          // Ensure that pointerdown default is not prevented, to allow browser
           // focus to go to an item that a user clicks in the menu bar.
           expect(mouseEvent.defaultPrevented).to.equal(false);
         });
@@ -752,7 +752,7 @@ describe('@lumino/widgets', () => {
             'lm-MenuBar-item'
           )[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
-          let mouseEvent = new MouseEvent('mousedown', {
+          let mouseEvent = new PointerEvent('pointerdown', {
             bubbles,
             cancelable: true,
             clientX: rect.left + 1,
@@ -762,7 +762,7 @@ describe('@lumino/widgets', () => {
           expect(bar.activeIndex).to.equal(0);
           expect(menu.isAttached).to.equal(true);
           // When opening a menu, be sure to prevent default during the
-          // mousedown so that the item being clicked in the menu bar does not
+          // pointerdown so that the item being clicked in the menu bar does not
           // "steal" focus from the menu being opened.
           mouseEvent.preventDefault();
           expect(mouseEvent.defaultPrevented).to.equal(true);
@@ -776,7 +776,7 @@ describe('@lumino/widgets', () => {
           )[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           bar.node.dispatchEvent(
-            new MouseEvent('mousedown', {
+            new PointerEvent('pointerdown', {
               bubbles,
               button: 1,
               clientX: rect.left + 1,
@@ -790,7 +790,7 @@ describe('@lumino/widgets', () => {
         it('should not work on a menu bar item whose menu is empty', () => {
           let emptyMenu = new Menu({ commands });
           // Add title to empty menu, otherwise it will have zero width in the
-          // menu bar, which makes it impossible to test with mousedown.
+          // menu bar, which makes it impossible to test with pointerdown.
           emptyMenu.title.label = 'Empty Menu';
           bar.insertMenu(0, emptyMenu);
           let node = bar.node.getElementsByClassName(
@@ -798,7 +798,7 @@ describe('@lumino/widgets', () => {
           )[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           bar.node.dispatchEvent(
-            new MouseEvent('mousedown', {
+            new PointerEvent('pointerdown', {
               bubbles,
               button: 0,
               clientX: rect.left + 1,
@@ -810,7 +810,7 @@ describe('@lumino/widgets', () => {
         });
       });
 
-      context('mousemove', () => {
+      context('pointermove', () => {
         it('should open a new menu if a menu is already open', () => {
           bar.openActiveMenu();
           let menu = bar.activeMenu!;
@@ -819,7 +819,7 @@ describe('@lumino/widgets', () => {
           )[1] as HTMLElement;
           let rect = node.getBoundingClientRect();
           bar.node.dispatchEvent(
-            new MouseEvent('mousemove', {
+            new PointerEvent('pointermove', {
               bubbles,
               clientX: rect.left + 1,
               clientY: rect.top + 1
@@ -838,7 +838,7 @@ describe('@lumino/widgets', () => {
           )[0] as HTMLElement;
           let rect = node.getBoundingClientRect();
           bar.node.dispatchEvent(
-            new MouseEvent('mousemove', {
+            new PointerEvent('pointermove', {
               bubbles,
               clientX: rect.left,
               clientY: rect.top + 1
@@ -851,7 +851,7 @@ describe('@lumino/widgets', () => {
         it('should be a no-op if the mouse is not over an item and there is a menu open', () => {
           bar.openActiveMenu();
           let menu = bar.activeMenu!;
-          bar.node.dispatchEvent(new MouseEvent('mousemove', { bubbles }));
+          bar.node.dispatchEvent(new PointerEvent('pointermove', { bubbles }));
           expect(bar.activeIndex).to.equal(0);
           expect(menu.isAttached).to.equal(true);
         });
@@ -921,10 +921,10 @@ describe('@lumino/widgets', () => {
         expect(bar.methods.indexOf('onBeforeAttach')).to.not.equal(-1);
         node.dispatchEvent(new KeyboardEvent('keydown', { bubbles }));
         expect(bar.events.indexOf('keydown')).to.not.equal(-1);
-        node.dispatchEvent(new MouseEvent('mousedown', { bubbles }));
-        expect(bar.events.indexOf('mousedown')).to.not.equal(-1);
-        node.dispatchEvent(new MouseEvent('mousemove', { bubbles }));
-        expect(bar.events.indexOf('mousemove')).to.not.equal(-1);
+        node.dispatchEvent(new PointerEvent('pointerdown', { bubbles }));
+        expect(bar.events.indexOf('pointerdown')).to.not.equal(-1);
+        node.dispatchEvent(new PointerEvent('pointermove', { bubbles }));
+        expect(bar.events.indexOf('pointermove')).to.not.equal(-1);
         node.dispatchEvent(new FocusEvent('focusout', { bubbles }));
         expect(bar.events.indexOf('focusout')).to.not.equal(-1);
         node.dispatchEvent(new MouseEvent('contextmenu', { bubbles }));
@@ -942,10 +942,10 @@ describe('@lumino/widgets', () => {
         expect(bar.methods.indexOf('onBeforeAttach')).to.not.equal(-1);
         node.dispatchEvent(new KeyboardEvent('keydown', { bubbles }));
         expect(bar.events.indexOf('keydown')).to.equal(-1);
-        node.dispatchEvent(new MouseEvent('mousedown', { bubbles }));
-        expect(bar.events.indexOf('mousedown')).to.equal(-1);
-        node.dispatchEvent(new MouseEvent('mousemove', { bubbles }));
-        expect(bar.events.indexOf('mousemove')).to.equal(-1);
+        node.dispatchEvent(new PointerEvent('pointerdown', { bubbles }));
+        expect(bar.events.indexOf('pointerdown')).to.equal(-1);
+        node.dispatchEvent(new PointerEvent('pointermove', { bubbles }));
+        expect(bar.events.indexOf('pointermove')).to.equal(-1);
         node.dispatchEvent(new FocusEvent('focusout', { bubbles }));
         expect(bar.events.indexOf('focusout')).to.equal(-1);
         node.dispatchEvent(new MouseEvent('contextmenu', { bubbles }));

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -719,7 +719,7 @@ describe('@lumino/widgets', () => {
         it('should close an open menu if the press was not on an item', () => {
           bar.openActiveMenu();
           let menu = bar.activeMenu!;
-          bar.node.dispatchEvent(new MouseEvent('mousedown', { bubbles }));
+          bar.node.dispatchEvent(new PointerEvent('pointerdown', { bubbles }));
           expect(bar.activeIndex).to.equal(-1);
           expect(menu.isAttached).to.equal(false);
         });


### PR DESCRIPTION
## Fixes https://github.com/jupyterlab/jupyterlab/issues/18851

### Description

Switch document listener from `mousedown` to `pointerdown` so outside clicks are detected even when tab clicks call 
`preventDefault()`, which was blocking the old event flow.

#### Before:
https://github.com/user-attachments/assets/4ef2e319-ffb4-4894-98d6-25120a4c509d

#### After:
https://github.com/user-attachments/assets/702d03dd-846e-499f-9e75-3870da55e735