### PR TITLE
Fix incorrect accordion title state on widget move

### DIFF
--- a/packages/widgets/src/accordionlayout.ts
+++ b/packages/widgets/src/accordionlayout.ts
@@ -114,7 +114,11 @@ export class AccordionLayout extends SplitLayout {
    * @param widget - The widget to attach to the parent.
    */
   protected attachWidget(index: number, widget: Widget): void {
-    const title = Private.createTitle(this.renderer, widget.title, !widget.isHidden);
+    const title = Private.createTitle(
+      this.renderer,
+      widget.title,
+      !widget.isHidden
+    );
 
     ArrayExt.insert(this._titles, index, title);
 

--- a/packages/widgets/src/accordionlayout.ts
+++ b/packages/widgets/src/accordionlayout.ts
@@ -114,7 +114,7 @@ export class AccordionLayout extends SplitLayout {
    * @param widget - The widget to attach to the parent.
    */
   protected attachWidget(index: number, widget: Widget): void {
-    const title = Private.createTitle(this.renderer, widget.title);
+    const title = Private.createTitle(this.renderer, widget.title, !widget.isHidden);
 
     ArrayExt.insert(this._titles, index, title);
 


### PR DESCRIPTION
## References https://github.com/jupyterlab/jupyterlab/pull/18703#issuecomment-4460091092

### Description
`attachWidget` always created a new title with `expanded: true`, so moved hidden widgets appeared expanded in the new panel.
Now we pass `!widget.isHidden` so the title correctly reflects the widget’s actual state.

#### Before
https://github.com/user-attachments/assets/2d453371-8c18-40cd-8040-db6933525675

#### After
https://github.com/user-attachments/assets/2a24bb90-e591-45a2-beec-65a145f5e42e