### PR TITLE
Disable scripts and telemetry in `.yarnrc.yml`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,7 @@
+enableScripts: false
+
+enableTelemetry: false
+
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-3.6.0.cjs


### PR DESCRIPTION
Some hardening in for todays reality. Aligns it with settings used by https://github.com/jupyterlab/jupyterlab/blob/main/.yarnrc.yml