### PR TITLE
Assign `menuitemcheckbox` role to toggleable menu items

### DIFF
--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1152,7 +1152,7 @@ export namespace Menu {
     /**
      * Whether the menu item is toggleable.
      */
-    readonly isToggleable: boolean;
+    readonly isToggleable?: boolean;
 
     /**
      * Whether the menu item is visible.
@@ -1378,7 +1378,7 @@ export namespace Menu {
           if (!data.item.isEnabled) {
             aria['aria-disabled'] = 'true';
           }
-          if (data.item.isToggleable) {
+          if (data.item.isToggleable || data.item.isToggled) {
             aria.role = 'menuitemcheckbox';
             aria['aria-checked'] = `${data.item.isToggled}`;
           } else {

--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -1150,6 +1150,11 @@ export namespace Menu {
     readonly isToggled: boolean;
 
     /**
+     * Whether the menu item is toggleable.
+     */
+    readonly isToggleable: boolean;
+
+    /**
      * Whether the menu item is visible.
      */
     readonly isVisible: boolean;
@@ -1373,9 +1378,9 @@ export namespace Menu {
           if (!data.item.isEnabled) {
             aria['aria-disabled'] = 'true';
           }
-          if (data.item.isToggled) {
+          if (data.item.isToggleable) {
             aria.role = 'menuitemcheckbox';
-            aria['aria-checked'] = 'true';
+            aria['aria-checked'] = `${data.item.isToggled}`;
           } else {
             aria.role = 'menuitem';
           }
@@ -1944,6 +1949,16 @@ namespace Private {
     get isToggled(): boolean {
       if (this.type === 'command') {
         return this._commands.isToggled(this.command, this.args);
+      }
+      return false;
+    }
+
+    /**
+     * Whether the menu item is toggleable.
+     */
+    get isToggleable(): boolean {
+      if (this.type === 'command') {
+        return this._commands.isToggleable(this.command, this.args);
       }
       return false;
     }

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -95,6 +95,16 @@ describe('@lumino/widgets', () => {
       isToggled: (args: JSONObject) => true,
       mnemonic: 6
     });
+    commands.addCommand('test-toggleable', {
+      execute: (args: JSONObject) => {
+        executed = 'test-toggleable';
+      },
+      label: 'Test Toggleable Label',
+      icon: iconRenderer,
+      className: 'testClass',
+      isToggleable: true,
+      mnemonic: 5
+    });
     commands.addCommand('test-disabled', {
       execute: (args: JSONObject) => {
         executed = 'test-disabled';
@@ -1309,6 +1319,26 @@ describe('@lumino/widgets', () => {
         });
       });
 
+      describe('#isToggleable', () => {
+        it('should get whether the command is toggleable for a `command` type', () => {
+          let item = menu.addItem({ command: 'test-toggleable' });
+          expect(item.isToggleable).to.equal(true);
+          item = menu.addItem({ command: 'test-toggled' });
+          expect(item.isToggleable).to.equal(true);
+          item = menu.addItem({ command: 'test' });
+          expect(item.isToggleable).to.equal(false);
+          item = menu.addItem({ type: 'command' });
+          expect(item.isToggleable).to.equal(false);
+        });
+
+        it('should be `false` for other item types', () => {
+          let item = menu.addItem({ type: 'separator' });
+          expect(item.isToggleable).to.equal(false);
+          item = menu.addItem({ type: 'submenu' });
+          expect(item.isToggleable).to.equal(false);
+        });
+      });
+
       describe('#isVisible', () => {
         it('should get whether the command is visible for a `command` type', () => {
           let item = menu.addItem({ command: 'test-hidden' });
@@ -1587,6 +1617,59 @@ describe('@lumino/widgets', () => {
             collapsed: false
           });
           expect(dataset).to.deep.equal({ type: 'submenu' });
+        });
+      });
+
+      describe('#createItemARIA()', () => {
+        it('should create aria attributes for the item', () => {
+          let item = menu.addItem({ command: 'test' });
+          let aria = renderer.createItemARIA({
+            item,
+            active: false,
+            collapsed: false
+          });
+          expect(aria).to.deep.equal({ role: 'menuitem' });
+
+          item = menu.addItem({ command: 'test-toggleable' });
+          aria = renderer.createItemARIA({
+            item,
+            active: false,
+            collapsed: false
+          });
+          expect(aria).to.deep.equal({
+            role: 'menuitemcheckbox',
+            'aria-checked': 'false'
+          });
+
+          item = menu.addItem({ command: 'test-toggled' });
+          aria = renderer.createItemARIA({
+            item,
+            active: false,
+            collapsed: false
+          });
+          expect(aria).to.deep.equal({
+            role: 'menuitemcheckbox',
+            'aria-checked': 'true'
+          });
+
+          item = menu.addItem({ type: 'separator' });
+          aria = renderer.createItemARIA({
+            item,
+            active: false,
+            collapsed: false
+          });
+          expect(aria).to.deep.equal({ role: 'presentation' });
+
+          item = menu.addItem({ type: 'submenu' });
+          aria = renderer.createItemARIA({
+            item,
+            active: false,
+            collapsed: false
+          });
+          expect(aria).to.deep.equal({
+            'aria-haspopup': 'true',
+            'aria-disabled': 'true'
+          });
         });
       });
 

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -724,6 +724,7 @@ export namespace Menu {
         readonly iconClass: string;
         readonly iconLabel: string;
         readonly isEnabled: boolean;
+        readonly isToggleable?: boolean;
         readonly isToggled: boolean;
         readonly isVisible: boolean;
         readonly keyBinding: CommandRegistry.IKeyBinding | null;


### PR DESCRIPTION
Closes #755 

This updates the menu `ARIA` behavior so any toggleable command item is always rendered with `role="menuitemcheckbox"` (not only when toggled), while non-toggleable items remain `menuitem`. It also sets `aria-checked` to the current `true`/`false` state.