### PR TITLE
Document the use of `PluginRegistry` on the server

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -15,3 +15,12 @@ Rendered static examples
 `DockPanel <examples/dockpanel/index.html>`_
 
 `MenuBar <examples/menubar/index.html>`_
+
+.. seealso::
+
+   Not every example renders to a page: the :doc:`server-side plugin registry example <plugin-registry-server>` runs the Lumino plugin system in Node.
+
+.. toctree::
+   :hidden:
+
+   plugin-registry-server

--- a/docs/source/plugin-registry-server.md
+++ b/docs/source/plugin-registry-server.md
@@ -1,0 +1,58 @@
+# Running the plugin registry on the server
+
+Lumino's [`PluginRegistry`](https://github.com/jupyterlab/lumino/blob/main/packages/coreutils/src/plugins.ts), the plugin system behind JupyterLab, lives in `@lumino/coreutils` and has no DOM dependency, so it runs in Node as-is. You don't need `@lumino/application` or `@lumino/widgets` to use it.
+
+The `example-plugin-registry-server` example (in the repo's `examples/` directory) shows this with two plugins that the registry wires together through a shared service token, without importing each other:
+
+- `hello` _provides_ an `IGreeting` service.
+- `greeter` _requires_ `IGreeting` and uses it.
+
+## The shared token
+
+A `Token` identifies the service. The provider and the consumer both refer to this token; neither imports the other.
+
+```{literalinclude} ../../examples/example-plugin-registry-server/src/tokens.ts
+:language: typescript
+:start-after: Modified BSD License.
+```
+
+## Providing and requiring a service
+
+The `hello` plugin lists the token in `provides` and returns the service from `activate`:
+
+```{literalinclude} ../../examples/example-plugin-registry-server/src/hello.ts
+:language: typescript
+:start-after: Modified BSD License.
+```
+
+The `greeter` plugin lists the token in `requires`; the registry passes the resolved service as an argument to `activate`:
+
+```{literalinclude} ../../examples/example-plugin-registry-server/src/greeter.ts
+:language: typescript
+:start-after: Modified BSD License.
+```
+
+## Running it
+
+Register the plugins and activate them:
+
+```{literalinclude} ../../examples/example-plugin-registry-server/src/index.ts
+:language: typescript
+:start-after: Modified BSD License.
+```
+
+From the root of the repository, build the packages and then the example:
+
+```bash
+yarn install
+yarn run build
+yarn workspace @lumino/example-plugin-registry-server build
+yarn workspace @lumino/example-plugin-registry-server start
+```
+
+```text
+[hello] providing IGreeting
+[greeter] Hello! (from the hello plugin)
+```
+
+The `[greeter]` line is produced by the consumer plugin calling the service the provider returned. The two are connected only through the shared `IGreeting` token, never by importing each other.

--- a/examples/example-plugin-registry-server/README.md
+++ b/examples/example-plugin-registry-server/README.md
@@ -1,7 +1,7 @@
 # example-plugin-registry-server
 
-Run the Lumino [`PluginRegistry`](../../packages/coreutils/src/plugins.ts) — the
-plugin system behind JupyterLab — on the server with Node.
+Run the Lumino [`PluginRegistry`](../../packages/coreutils/src/plugins.ts), the
+plugin system behind JupyterLab, on the server with Node.
 
 `PluginRegistry` lives in `@lumino/coreutils` and has no DOM dependency, so it
 runs in Node as-is: `@lumino/application` and `@lumino/widgets` are not needed.
@@ -30,9 +30,9 @@ yarn workspace @lumino/example-plugin-registry-server start
 
 ```text
 [hello] providing IGreeting
-[greeter] Hello, Jupyter! (from the hello plugin)
+[greeter] Hello! (from the hello plugin)
 ```
 
 The `[greeter]` line is produced by the consumer plugin calling the service the
-provider plugin returned — the two are connected only through the shared
+provider plugin returned. The two are connected only through the shared
 `IGreeting` token, never by importing each other.

--- a/examples/example-plugin-registry-server/README.md
+++ b/examples/example-plugin-registry-server/README.md
@@ -1,0 +1,38 @@
+# example-plugin-registry-server
+
+Run the Lumino [`PluginRegistry`](../../packages/coreutils/src/plugins.ts) — the
+plugin system behind JupyterLab — on the server with Node.
+
+`PluginRegistry` lives in `@lumino/coreutils` and has no DOM dependency, so it
+runs in Node as-is: `@lumino/application` and `@lumino/widgets` are not needed.
+
+Two plugins are wired together by the registry through a shared service token,
+without importing each other:
+
+- [`hello`](src/hello.ts) _provides_ an `IGreeting` service.
+- [`greeter`](src/greeter.ts) _requires_ `IGreeting` and uses it.
+
+## Prerequisites
+
+From the root lumino folder, build the packages this example depends on:
+
+```bash
+yarn install
+yarn run build
+```
+
+## Usage
+
+```bash
+yarn workspace @lumino/example-plugin-registry-server build
+yarn workspace @lumino/example-plugin-registry-server start
+```
+
+```text
+[hello] providing IGreeting
+[greeter] Hello, Jupyter! (from the hello plugin)
+```
+
+The `[greeter]` line is produced by the consumer plugin calling the service the
+provider plugin returned — the two are connected only through the shared
+`IGreeting` token, never by importing each other.

--- a/examples/example-plugin-registry-server/package.json
+++ b/examples/example-plugin-registry-server/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "clean": "rimraf lib",
     "start": "node lib/index.js",
-    "test": "tsc && node test/runner.js"
+    "test": "node --test test/runner.js"
   },
   "dependencies": {
     "@lumino/coreutils": "^2.2.2"

--- a/examples/example-plugin-registry-server/package.json
+++ b/examples/example-plugin-registry-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@lumino/example-plugin-registry-server",
+  "version": "2.0.0",
+  "private": true,
+  "description": "Run the Lumino PluginRegistry on the server with Node.",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "start": "node lib/index.js",
+    "test": "tsc && node test/runner.js"
+  },
+  "dependencies": {
+    "@lumino/coreutils": "^2.2.2"
+  },
+  "devDependencies": {
+    "@types/node": "^12.12.17",
+    "rimraf": "^5.0.1",
+    "typescript": "~5.1.3"
+  }
+}

--- a/examples/example-plugin-registry-server/src/greeter.ts
+++ b/examples/example-plugin-registry-server/src/greeter.ts
@@ -12,7 +12,7 @@ const plugin: IPlugin<IApp, void> = {
   autoStart: true,
   requires: [IGreeting],
   activate: (app: IApp, greeting: IGreeting): void => {
-    app.log(`[greeter] ${greeting.greet('Jupyter')}`);
+    app.log(`[greeter] ${greeting.greet()}`);
   }
 };
 

--- a/examples/example-plugin-registry-server/src/greeter.ts
+++ b/examples/example-plugin-registry-server/src/greeter.ts
@@ -6,7 +6,6 @@ import { IApp, IGreeting } from './tokens';
 
 /**
  * A plugin that *requires* the `IGreeting` service.
- *
  */
 const plugin: IPlugin<IApp, void> = {
   id: '@lumino/example-plugin-registry-server:greeter',

--- a/examples/example-plugin-registry-server/src/greeter.ts
+++ b/examples/example-plugin-registry-server/src/greeter.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import type { IPlugin } from '@lumino/coreutils';
+
+import { IApp, IGreeting } from './tokens';
+
+/**
+ * A plugin that *requires* the `IGreeting` service.
+ *
+ */
+const plugin: IPlugin<IApp, void> = {
+  id: '@lumino/example-plugin-registry-server:greeter',
+  autoStart: true,
+  requires: [IGreeting],
+  activate: (app: IApp, greeting: IGreeting): void => {
+    app.log(`[greeter] ${greeting.greet('Jupyter')}`);
+  }
+};
+
+export default plugin;

--- a/examples/example-plugin-registry-server/src/hello.ts
+++ b/examples/example-plugin-registry-server/src/hello.ts
@@ -14,7 +14,7 @@ const plugin: IPlugin<IApp, IGreeting> = {
   activate: (app: IApp): IGreeting => {
     app.log('[hello] providing IGreeting');
     return {
-      greet: (name: string) => `Hello, ${name}! (from the hello plugin)`
+      greet: () => 'Hello! (from the hello plugin)'
     };
   }
 };

--- a/examples/example-plugin-registry-server/src/hello.ts
+++ b/examples/example-plugin-registry-server/src/hello.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import type { IPlugin } from '@lumino/coreutils';
+
+import { IApp, IGreeting } from './tokens';
+
+/**
+ * A plugin that *provides* the `IGreeting` service.
+ *
+ */
+const plugin: IPlugin<IApp, IGreeting> = {
+  id: '@lumino/example-plugin-registry-server:hello',
+  autoStart: true,
+  provides: IGreeting,
+  activate: (app: IApp): IGreeting => {
+    app.log('[hello] providing IGreeting');
+    return {
+      greet: (name: string) => `Hello, ${name}! (from the hello plugin)`
+    };
+  }
+};
+
+export default plugin;

--- a/examples/example-plugin-registry-server/src/hello.ts
+++ b/examples/example-plugin-registry-server/src/hello.ts
@@ -6,7 +6,6 @@ import { IApp, IGreeting } from './tokens';
 
 /**
  * A plugin that *provides* the `IGreeting` service.
- *
  */
 const plugin: IPlugin<IApp, IGreeting> = {
   id: '@lumino/example-plugin-registry-server:hello',

--- a/examples/example-plugin-registry-server/src/index.ts
+++ b/examples/example-plugin-registry-server/src/index.ts
@@ -8,7 +8,6 @@ import { IApp } from './tokens';
 
 /**
  * Run the Lumino `PluginRegistry` on the server.
- *
  */
 async function main(): Promise<void> {
   const registry = new PluginRegistry<IApp>();

--- a/examples/example-plugin-registry-server/src/index.ts
+++ b/examples/example-plugin-registry-server/src/index.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import { PluginRegistry } from '@lumino/coreutils';
+
+import greeter from './greeter';
+import hello from './hello';
+import { IApp } from './tokens';
+
+/**
+ * Run the Lumino `PluginRegistry` on the server.
+ *
+ */
+async function main(): Promise<void> {
+  const registry = new PluginRegistry<IApp>();
+  registry.application = { log: message => console.log(message) };
+  registry.registerPlugins([hello, greeter]);
+  await registry.activatePlugins('startUp');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/example-plugin-registry-server/src/tokens.ts
+++ b/examples/example-plugin-registry-server/src/tokens.ts
@@ -17,9 +17,9 @@ export interface IApp {
  */
 export interface IGreeting {
   /**
-   * Greet the given name.
+   * Return a greeting.
    */
-  greet(name: string): string;
+  greet(): string;
 }
 
 /**

--- a/examples/example-plugin-registry-server/src/tokens.ts
+++ b/examples/example-plugin-registry-server/src/tokens.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import { Token } from '@lumino/coreutils';
+
+/**
+ * The application object passed to every plugin's `activate()`.
+ */
+export interface IApp {
+  /**
+   * Log a message.
+   */
+  log(message: string): void;
+}
+
+/**
+ * A service that one plugin provides and another consumes.
+ */
+export interface IGreeting {
+  /**
+   * Greet the given name.
+   */
+  greet(name: string): string;
+}
+
+/**
+ * The token used to provide and require the {@link IGreeting} service.
+ *
+ */
+export const IGreeting = new Token<IGreeting>(
+  '@lumino/example-plugin-registry-server:IGreeting'
+);

--- a/examples/example-plugin-registry-server/test/runner.js
+++ b/examples/example-plugin-registry-server/test/runner.js
@@ -1,25 +1,24 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// Smoke test: the built example runs in Node and the two plugins activate,
-// with the consumer printing the greeting provided by the producer.
 const assert = require('node:assert');
-const { execFileSync } = require('node:child_process');
+const { spawnSync } = require('node:child_process');
 const { resolve } = require('node:path');
+const { test } = require('node:test');
 
-const entry = resolve(__dirname, '..', 'lib', 'index.js');
-const output = execFileSync(process.execPath, [entry], { encoding: 'utf8' });
+test('runs the plugin registry on the server', () => {
+  const entry = resolve(__dirname, '..', 'lib', 'index.js');
+  const result = spawnSync(process.execPath, [entry], { encoding: 'utf8' });
 
-const expected = [
-  '[hello] providing IGreeting',
-  '[greeter] Hello, Jupyter! (from the hello plugin)'
-];
-
-for (const line of expected) {
-  assert.ok(
-    output.includes(line),
-    `Expected output to include ${JSON.stringify(line)}, got:\n${output}`
+  assert.ifError(result.error);
+  assert.strictEqual(
+    result.status,
+    0,
+    `Expected exit code 0, got ${result.status}. stderr:\n${result.stderr}`
   );
-}
-
-console.log('example-plugin-registry-server: smoke test passed');
+  assert.strictEqual(result.stderr, '');
+  assert.deepStrictEqual(result.stdout.trim().split(/\r?\n/), [
+    '[hello] providing IGreeting',
+    '[greeter] Hello, Jupyter! (from the hello plugin)'
+  ]);
+});

--- a/examples/example-plugin-registry-server/test/runner.js
+++ b/examples/example-plugin-registry-server/test/runner.js
@@ -19,6 +19,6 @@ test('runs the plugin registry on the server', () => {
   assert.strictEqual(result.stderr, '');
   assert.deepStrictEqual(result.stdout.trim().split(/\r?\n/), [
     '[hello] providing IGreeting',
-    '[greeter] Hello, Jupyter! (from the hello plugin)'
+    '[greeter] Hello! (from the hello plugin)'
   ]);
 });

--- a/examples/example-plugin-registry-server/test/runner.js
+++ b/examples/example-plugin-registry-server/test/runner.js
@@ -1,0 +1,25 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+// Smoke test: the built example runs in Node and the two plugins activate,
+// with the consumer printing the greeting provided by the producer.
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const { resolve } = require('node:path');
+
+const entry = resolve(__dirname, '..', 'lib', 'index.js');
+const output = execFileSync(process.execPath, [entry], { encoding: 'utf8' });
+
+const expected = [
+  '[hello] providing IGreeting',
+  '[greeter] Hello, Jupyter! (from the hello plugin)'
+];
+
+for (const line of expected) {
+  assert.ok(
+    output.includes(line),
+    `Expected output to include ${JSON.stringify(line)}, got:\n${output}`
+  );
+}
+
+console.log('example-plugin-registry-server: smoke test passed');

--- a/examples/example-plugin-registry-server/tsconfig.json
+++ b/examples/example-plugin-registry-server/tsconfig.json
@@ -12,7 +12,7 @@
     "target": "ES2018",
     "outDir": "./lib",
     "lib": ["ES2018"],
-    "types": ["node"]
+    "types": ["@types/node"]
   },
   "include": ["src/*"]
 }

--- a/examples/example-plugin-registry-server/tsconfig.json
+++ b/examples/example-plugin-registry-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": false,
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "strictNullChecks": true,
+    "sourceMap": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2018",
+    "outDir": "./lib",
+    "lib": ["ES2018"],
+    "types": ["node"]
+  },
+  "include": ["src/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,6 +639,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@lumino/example-plugin-registry-server@workspace:examples/example-plugin-registry-server":
+  version: 0.0.0-use.local
+  resolution: "@lumino/example-plugin-registry-server@workspace:examples/example-plugin-registry-server"
+  dependencies:
+    "@lumino/coreutils": ^2.2.2
+    "@types/node": ^12.12.17
+    rimraf: ^5.0.1
+    typescript: ~5.1.3
+  languageName: unknown
+  linkType: soft
+
 "@lumino/keyboard@^2.0.4, @lumino/keyboard@workspace:packages/keyboard":
   version: 0.0.0-use.local
   resolution: "@lumino/keyboard@workspace:packages/keyboard"


### PR DESCRIPTION
Add a new example to demonstrate how the `PluginRegistry` can be used in a node application.

Documentation: https://lumino--827.org.readthedocs.build/en/827/plugin-registry-server.html