### PR TITLE
Apply opacity together with content visibility if enabled via `hiddenMode` setting

### DIFF
--- a/packages/widgets/src/widget.ts
+++ b/packages/widgets/src/widget.ts
@@ -771,6 +771,10 @@ export class Widget implements IMessageHandler, IObservableDisposable {
           // @ts-expect-error content-visibility unknown by DOM lib types
           this.node.style.contentVisibility = 'hidden';
           this.node.style.zIndex = '-1';
+          // Set opacity to 0 so that the widget's box (e.g. borders or
+          // background) does not shine through despite the content being
+          // skipped by `content-visibility`.
+          this.node.style.opacity = '0';
           break;
       }
     } else {
@@ -786,6 +790,7 @@ export class Widget implements IMessageHandler, IObservableDisposable {
           // @ts-expect-error content-visibility unknown by DOM lib types
           this.node.style.contentVisibility = '';
           this.node.style.zIndex = '';
+          this.node.style.opacity = '';
           break;
       }
     }

--- a/packages/widgets/tests/src/widget.spec.ts
+++ b/packages/widgets/tests/src/widget.spec.ts
@@ -773,6 +773,8 @@ describe('@lumino/widgets', () => {
         expect(widget.hasClass('lm-mod-hidden')).to.equal(false);
         // @ts-expect-error content-visibility unknown by DOM lib types
         expect(widget.node.style.contentVisibility).to.equal('hidden');
+        expect(widget.node.style.zIndex).to.equal('-1');
+        expect(widget.node.style.opacity).to.equal('0');
         expect(widget.node.style.willChange).to.equal('auto');
         widget.dispose();
       });
@@ -785,6 +787,10 @@ describe('@lumino/widgets', () => {
         widget.hiddenMode = Widget.HiddenMode.Display;
         expect(widget.hasClass('lm-mod-hidden')).to.equal(true);
         expect(widget.node.style.transform).to.equal('');
+        // @ts-expect-error content-visibility unknown by DOM lib types
+        expect(widget.node.style.contentVisibility).to.equal('');
+        expect(widget.node.style.zIndex).to.equal('');
+        expect(widget.node.style.opacity).to.equal('');
         expect(widget.node.style.willChange).to.equal('auto');
         widget.dispose();
       });


### PR DESCRIPTION
- Required for https://github.com/jupyterlab/jupyterlab/pull/18879
- Follow-up to https://github.com/jupyterlab/lumino/pull/497

Before, the content-visibility mode was mostly working, except that the widgets were shining through the "borders" of JupyterLab shell - this is because it only disables their contents painting, and does not hide the container itself; adding the opacity is a simple solution. I benchmarked it and the performance advantage now is more pronounced than before.