### PR TITLE
Fix touch click handling for menus and tab close actions

### DIFF
--- a/packages/widgets/src/menu.ts
+++ b/packages/widgets/src/menu.ts
@@ -30,6 +30,8 @@ import {
   VirtualElement
 } from '@lumino/virtualdom';
 
+import Utils from './utils';
+
 import { Widget } from './widget';
 
 interface IWindowData {
@@ -504,6 +506,9 @@ export class Menu extends Widget {
       case 'keydown':
         this._evtKeyDown(event as KeyboardEvent);
         break;
+      case 'click':
+        this._evtClick(event as MouseEvent);
+        break;
       case 'pointerup':
         this._evtPointerUp(event as PointerEvent);
         break;
@@ -531,6 +536,7 @@ export class Menu extends Widget {
    */
   protected onBeforeAttach(msg: Message): void {
     this.node.addEventListener('keydown', this);
+    this.node.addEventListener('click', this);
     this.node.addEventListener('pointerup', this);
     this.node.addEventListener('pointermove', this);
     this.node.addEventListener('pointerenter', this);
@@ -544,12 +550,14 @@ export class Menu extends Widget {
    */
   protected onAfterDetach(msg: Message): void {
     this.node.removeEventListener('keydown', this);
+    this.node.removeEventListener('click', this);
     this.node.removeEventListener('pointerup', this);
     this.node.removeEventListener('pointermove', this);
     this.node.removeEventListener('pointerenter', this);
     this.node.removeEventListener('pointerleave', this);
     this.node.removeEventListener('contextmenu', this);
     document.removeEventListener('pointerdown', this, true);
+    this._pendingTouchActivation = false;
   }
 
   /**
@@ -596,6 +604,7 @@ export class Menu extends Widget {
 
     // Reset the active index.
     this.activeIndex = -1;
+    this._pendingTouchActivation = false;
 
     // Close any open child menu.
     let childMenu = this._childMenu;
@@ -719,8 +728,36 @@ export class Menu extends Widget {
     if (event.button !== 0) {
       return;
     }
+
+    if (Utils.isTouchEvent(event)) {
+      this._pendingTouchActivation = this._activateItemFromEvent(event);
+      event.stopPropagation();
+      return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
+    this._activateItemFromEvent(event);
+    this.triggerActiveItem();
+  }
+
+  /**
+   * Handle the `'click'` event for the menu.
+   *
+   * #### Notes
+   * This listener is attached to the menu node.
+   */
+  private _evtClick(event: MouseEvent): void {
+    if (!this._pendingTouchActivation) {
+      return;
+    }
+
+    this._pendingTouchActivation = false;
+    event.preventDefault();
+    event.stopPropagation();
+    if (!this._activateItemFromEvent(event)) {
+      return;
+    }
     this.triggerActiveItem();
   }
 
@@ -731,6 +768,10 @@ export class Menu extends Widget {
    * This listener is attached to the menu node.
    */
   private _evtPointerMove(event: PointerEvent): void {
+    if (Utils.isTouchEvent(event)) {
+      return;
+    }
+
     // Hit test the item nodes for the item under the mouse.
     let index = ArrayExt.findFirstIndex(this.contentNode.children, node => {
       return ElementExt.hitTest(node, event.clientX, event.clientY);
@@ -777,6 +818,10 @@ export class Menu extends Widget {
    * This listener is attached to the menu node.
    */
   private _evtPointerEnter(event: PointerEvent): void {
+    if (Utils.isTouchEvent(event)) {
+      return;
+    }
+
     // Synchronize the active ancestor items.
     for (let menu = this._parentMenu; menu; menu = menu._parentMenu) {
       menu._cancelOpenTimer();
@@ -792,6 +837,10 @@ export class Menu extends Widget {
    * This listener is attached to the menu node.
    */
   private _evtPointerLeave(event: PointerEvent): void {
+    if (Utils.isTouchEvent(event)) {
+      return;
+    }
+
     // Cancel any pending submenu opening.
     this._cancelOpenTimer();
 
@@ -820,6 +869,8 @@ export class Menu extends Widget {
    * This listener is attached to the document node.
    */
   private _evtPointerDown(event: PointerEvent): void {
+    this._pendingTouchActivation = false;
+
     // Bail if the menu is not a root menu.
     if (this._parentMenu) {
       return;
@@ -830,7 +881,9 @@ export class Menu extends Widget {
     // is allowed to propagate. This allows other code to act on the
     // event, such as focusing the clicked element.
     if (Private.hitTestMenus(this, event.clientX, event.clientY)) {
-      event.preventDefault();
+      if (!Utils.isTouchEvent(event)) {
+        event.preventDefault();
+      }
       event.stopPropagation();
     } else {
       this.close();
@@ -885,6 +938,20 @@ export class Menu extends Widget {
 
     // Activate the child menu.
     submenu.activate();
+  }
+
+  /**
+   * Activate the menu item under an event.
+   */
+  private _activateItemFromEvent(event: PointerEvent | MouseEvent): boolean {
+    let index = ArrayExt.findFirstIndex(this.contentNode.children, node => {
+      return ElementExt.hitTest(node, event.clientX, event.clientY);
+    });
+    if (index === -1) {
+      return false;
+    }
+    this.activeIndex = index;
+    return true;
   }
 
   /**
@@ -959,6 +1026,7 @@ export class Menu extends Widget {
   private _activeIndex = -1;
   private _openTimerID = 0;
   private _closeTimerID = 0;
+  private _pendingTouchActivation = false;
   private _items: Menu.IItem[] = [];
   private _childMenu: Menu | null = null;
   private _parentMenu: Menu | null = null;

--- a/packages/widgets/src/menubar.ts
+++ b/packages/widgets/src/menubar.ts
@@ -29,6 +29,8 @@ import { Menu } from './menu';
 
 import { Title } from './title';
 
+import Utils from './utils';
+
 import { Widget } from './widget';
 
 /**
@@ -701,6 +703,10 @@ export class MenuBar extends Widget {
    * Handle the `'pointermove'` event for the menu bar.
    */
   private _evtPointerMove(event: PointerEvent): void {
+    if (Utils.isTouchEvent(event)) {
+      return;
+    }
+
     // Check if the mouse is over one of the menu items.
     let index = ArrayExt.findFirstIndex(this.contentNode.children, node => {
       return ElementExt.hitTest(node, event.clientX, event.clientY);

--- a/packages/widgets/src/tabbar.ts
+++ b/packages/widgets/src/tabbar.ts
@@ -31,6 +31,8 @@ import {
 
 import { Title } from './title';
 
+import Utils from './utils';
+
 import { Widget } from './widget';
 
 const ARROW_KEYS = [
@@ -625,6 +627,9 @@ export class TabBar<T> extends Widget {
       case 'pointerleave':
         this._evtPointerLeave(event as PointerEvent);
         break;
+      case 'click':
+        this._evtClick(event as MouseEvent);
+        break;
       case 'dblclick':
         this._evtDblClick(event as MouseEvent);
         break;
@@ -646,6 +651,7 @@ export class TabBar<T> extends Widget {
   protected onBeforeAttach(msg: Message): void {
     this.node.addEventListener('pointerdown', this);
     this.node.addEventListener('pointerleave', this);
+    this.node.addEventListener('click', this);
     this.node.addEventListener('dblclick', this);
     this.node.addEventListener('keydown', this);
   }
@@ -656,10 +662,12 @@ export class TabBar<T> extends Widget {
   protected onAfterDetach(msg: Message): void {
     this.node.removeEventListener('pointerdown', this);
     this.node.removeEventListener('pointerleave', this);
+    this.node.removeEventListener('click', this);
     this.node.removeEventListener('dblclick', this);
     this.node.removeEventListener('keydown', this);
     this._clearUnfreezeTransitionState();
     this._clearTabSizeFreezeState();
+    this._pendingTouchCloseRequest = null;
     this._releaseMouse();
   }
 
@@ -900,6 +908,8 @@ export class TabBar<T> extends Widget {
    * Handle the `'pointerdown'` event for the tab bar.
    */
   private _evtPointerDown(event: PointerEvent | MouseEvent): void {
+    this._pendingTouchCloseRequest = null;
+
     // Do nothing if it's not a left or middle mouse press.
     if (event.button !== 0 && event.button !== 1) {
       return;
@@ -935,8 +945,17 @@ export class TabBar<T> extends Widget {
       return;
     }
 
+    // Check if the close icon was pressed.
+    let icon =
+      index !== -1
+        ? tabs[index].querySelector(this.renderer.closeIconSelector)
+        : null;
+    let closeIconPressed = !!icon && icon.contains(event.target as HTMLElement);
+
     // Pressing on a tab stops the event propagation.
-    event.preventDefault();
+    if (!closeIconPressed || !Utils.isTouchEvent(event)) {
+      event.preventDefault();
+    }
     event.stopPropagation();
 
     // Initialize the non-measured parts of the drag data.
@@ -966,8 +985,7 @@ export class TabBar<T> extends Widget {
     }
 
     // Do nothing else if the close icon is clicked.
-    let icon = tabs[index].querySelector(this.renderer.closeIconSelector);
-    if (icon && icon.contains(event.target as HTMLElement)) {
+    if (closeIconPressed) {
       return;
     }
 
@@ -1095,8 +1113,12 @@ export class TabBar<T> extends Widget {
       return;
     }
 
+    const isTouch = Utils.isTouchEvent(event);
+
     // Stop the event propagation.
-    event.preventDefault();
+    if (!isTouch) {
+      event.preventDefault();
+    }
     event.stopPropagation();
 
     // Remove the extra mouse event listeners.
@@ -1148,6 +1170,10 @@ export class TabBar<T> extends Widget {
       let icon = tabs[index].querySelector(this.renderer.closeIconSelector);
       if (icon && icon.contains(event.target as HTMLElement)) {
         this._tabSizeFrozen = true;
+        if (isTouch) {
+          this._pendingTouchCloseRequest = { index, title };
+          return;
+        }
         this._tabCloseRequested.emit({ index, title });
         return;
       }
@@ -1285,6 +1311,33 @@ export class TabBar<T> extends Widget {
     if (ci >= i) {
       this._currentIndex++;
     }
+  }
+
+  /**
+   * Handle the `'click'` event for the tab bar.
+   */
+  private _evtClick(event: MouseEvent): void {
+    const request = this._pendingTouchCloseRequest;
+    if (!request) {
+      return;
+    }
+
+    this._pendingTouchCloseRequest = null;
+    event.preventDefault();
+    event.stopPropagation();
+
+    const tab = this.contentNode.children[request.index];
+    const icon = tab?.querySelector(this.renderer.closeIconSelector);
+    if (
+      this._titles[request.index] !== request.title ||
+      !icon ||
+      !icon.contains(event.target as HTMLElement)
+    ) {
+      this._clearTabSizeFreezeState();
+      return;
+    }
+
+    this._tabCloseRequested.emit(request);
   }
 
   /**
@@ -1519,6 +1572,8 @@ export class TabBar<T> extends Widget {
   private _unfreezeRunID = 0;
   private _unfreezeFallbackTimerID = 0;
   private _unfreezeTransitionListener: ((event: Event) => void) | null = null;
+  private _pendingTouchCloseRequest: TabBar.ITabCloseRequestedArgs<T> | null =
+    null;
   private _addButtonEnabled: boolean = false;
   private _tabMoved = new Signal<this, TabBar.ITabMovedArgs<T>>(this);
   private _currentChanged = new Signal<this, TabBar.ICurrentChangedArgs<T>>(

--- a/packages/widgets/src/utils.ts
+++ b/packages/widgets/src/utils.ts
@@ -10,6 +10,13 @@ export namespace Utils {
   export function clampDimension(value: number): number {
     return Math.max(0, Math.floor(value));
   }
+
+  /**
+   * Whether a pointer event came from touch input.
+   */
+  export function isTouchEvent(event: PointerEvent | MouseEvent): boolean {
+    return 'pointerType' in event && event.pointerType === 'touch';
+  }
 }
 
 export default Utils;

--- a/packages/widgets/tests/src/menu.spec.ts
+++ b/packages/widgets/tests/src/menu.spec.ts
@@ -835,6 +835,42 @@ describe('@lumino/widgets', () => {
           expect(executed).to.equal('test');
         });
 
+        it('should trigger the touch item under the pointer on click', () => {
+          menu.addItem({ command: 'test' });
+          menu.open(0, 0);
+          let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
+          let rect = node.getBoundingClientRect();
+          node.dispatchEvent(
+            new PointerEvent('pointerup', {
+              bubbles,
+              button: 0,
+              clientX: rect.left + 1,
+              clientY: rect.top + 1,
+              pointerType: 'touch'
+            })
+          );
+          expect(executed).to.equal('');
+          let bubbled = false;
+          let listener = () => {
+            bubbled = true;
+          };
+          document.body.addEventListener('click', listener);
+          try {
+            node.dispatchEvent(
+              new MouseEvent('click', {
+                bubbles,
+                button: 0,
+                clientX: rect.left + 1,
+                clientY: rect.top + 1
+              })
+            );
+            expect(executed).to.equal('test');
+            expect(bubbled).to.equal(false);
+          } finally {
+            document.body.removeEventListener('click', listener);
+          }
+        });
+
         it('should bail if not a left mouse button', () => {
           menu.addItem({ command: 'test' });
           menu.activeIndex = 0;
@@ -913,6 +949,38 @@ describe('@lumino/widgets', () => {
             done();
           }, 500);
         });
+
+        it('should ignore touch pointer moves', () => {
+          menu.addItem({ command: 'test' });
+          menu.open(0, 0);
+          let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
+          let rect = node.getBoundingClientRect();
+          menu.node.dispatchEvent(
+            new PointerEvent('pointermove', {
+              bubbles,
+              clientX: rect.left + 1,
+              clientY: rect.top + 1,
+              pointerType: 'touch'
+            })
+          );
+          expect(menu.activeIndex).to.equal(-1);
+        });
+
+        it('should not ignore pen pointer moves', () => {
+          menu.addItem({ command: 'test' });
+          menu.open(0, 0);
+          let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
+          let rect = node.getBoundingClientRect();
+          menu.node.dispatchEvent(
+            new PointerEvent('pointermove', {
+              bubbles,
+              clientX: rect.left + 1,
+              clientY: rect.top + 1,
+              pointerType: 'pen'
+            })
+          );
+          expect(menu.activeIndex).to.equal(0);
+        });
       });
 
       context('pointerleave', () => {
@@ -941,6 +1009,45 @@ describe('@lumino/widgets', () => {
           );
           expect(menu.activeIndex).to.equal(-1);
           menu.dispose();
+        });
+
+        it('should not close a submenu on touch leave', done => {
+          let submenu = new Menu({ commands });
+          submenu.addItem({ command: 'test' });
+          submenu.title.label = 'Test Label';
+          menu.addItem({ type: 'submenu', submenu });
+          menu.open(0, 0);
+          let node = menu.node.getElementsByClassName('lm-Menu-item')[0];
+          let rect = node.getBoundingClientRect();
+          node.dispatchEvent(
+            new PointerEvent('pointerup', {
+              bubbles,
+              button: 0,
+              clientX: rect.left + 1,
+              clientY: rect.top + 1,
+              pointerType: 'touch'
+            })
+          );
+          node.dispatchEvent(
+            new MouseEvent('click', {
+              bubbles,
+              button: 0,
+              clientX: rect.left + 1,
+              clientY: rect.top + 1
+            })
+          );
+          expect(submenu.isAttached).to.equal(true);
+          menu.node.dispatchEvent(
+            new PointerEvent('pointerleave', {
+              bubbles,
+              pointerType: 'touch'
+            })
+          );
+          setTimeout(() => {
+            expect(submenu.isAttached).to.equal(true);
+            submenu.dispose();
+            done();
+          }, 500);
         });
       });
 

--- a/packages/widgets/tests/src/menubar.spec.ts
+++ b/packages/widgets/tests/src/menubar.spec.ts
@@ -855,6 +855,25 @@ describe('@lumino/widgets', () => {
           expect(bar.activeIndex).to.equal(0);
           expect(menu.isAttached).to.equal(true);
         });
+
+        it('should ignore touch pointer moves', () => {
+          bar.openActiveMenu();
+          let menu = bar.activeMenu!;
+          let node = bar.node.getElementsByClassName(
+            'lm-MenuBar-item'
+          )[1] as HTMLElement;
+          let rect = node.getBoundingClientRect();
+          bar.node.dispatchEvent(
+            new PointerEvent('pointermove', {
+              bubbles,
+              clientX: rect.left + 1,
+              clientY: rect.top + 1,
+              pointerType: 'touch'
+            })
+          );
+          expect(bar.activeIndex).to.equal(0);
+          expect(menu.isAttached).to.equal(true);
+        });
       });
 
       context('focusout', () => {

--- a/packages/widgets/tests/src/tabbar.spec.ts
+++ b/packages/widgets/tests/src/tabbar.spec.ts
@@ -372,6 +372,55 @@ describe('@lumino/widgets', () => {
         expect(called).to.equal(true);
       });
 
+      it('should be emitted on click after touching a tab close icon', () => {
+        let called = false;
+        let rect = closeIcon.getBoundingClientRect();
+        bar.tabCloseRequested.connect((sender, args) => {
+          expect(sender).to.equal(bar);
+          expect(args.index).to.equal(0);
+          expect(args.title).to.equal(bar.titles[0]);
+          called = true;
+        });
+        closeIcon.dispatchEvent(
+          new PointerEvent('pointerdown', {
+            clientX: rect.left + 1,
+            clientY: rect.top + 1,
+            button: 0,
+            bubbles: true,
+            pointerType: 'touch'
+          })
+        );
+        closeIcon.dispatchEvent(
+          new PointerEvent('pointerup', {
+            clientX: rect.left + 1,
+            clientY: rect.top + 1,
+            button: 0,
+            bubbles: true,
+            pointerType: 'touch'
+          })
+        );
+        expect(called).to.equal(false);
+        let bubbled = false;
+        let listener = () => {
+          bubbled = true;
+        };
+        document.body.addEventListener('click', listener);
+        try {
+          closeIcon.dispatchEvent(
+            new MouseEvent('click', {
+              clientX: rect.left + 1,
+              clientY: rect.top + 1,
+              button: 0,
+              bubbles: true
+            })
+          );
+          expect(called).to.equal(true);
+          expect(bubbled).to.equal(false);
+        } finally {
+          document.body.removeEventListener('click', listener);
+        }
+      });
+
       it('should be emitted when a tab is middle clicked', () => {
         let called = false;
         let rect = tab.getBoundingClientRect();


### PR DESCRIPTION
Refs: https://github.com/jupyterlab/jupyterlab/issues/19124

This fixes touch interactions where menu item clicks or tab close clicks could be lost or immediately dismissed by the browser’s follow-up `click` event. The change lets touch `pointerup` record the intended action, handles the matching click, stops that click from bubbling into surrounding UI, ignores touch hover-style pointer movement for menus, and clears stale pending touch state on close, detach, or a new pointer press. Tests cover touch menu activation, touch tab close, click bubbling suppression, and touch pointer-move behavior

### Before 

https://github.com/user-attachments/assets/0a6d1a1c-845b-4577-bdd9-29354d1f1f6c

### After

https://github.com/user-attachments/assets/ce3655c1-a993-4bce-afec-031539386f75
