### PR TITLE
Fix touch resizing for split and dock panel handles

### DIFF
--- a/packages/widgets/style/dockpanel.css
+++ b/packages/widgets/style/dockpanel.css
@@ -26,6 +26,7 @@
 
 .lm-DockPanel-handle {
   z-index: 2;
+  touch-action: none;
 }
 
 .lm-DockPanel-handle.lm-mod-hidden {

--- a/packages/widgets/style/splitpanel.css
+++ b/packages/widgets/style/splitpanel.css
@@ -18,6 +18,7 @@
 
 .lm-SplitPanel-handle {
   z-index: 1;
+  touch-action: none;
 }
 
 .lm-SplitPanel-handle.lm-mod-hidden {


### PR DESCRIPTION
Closes #254 , #247 

Add `touch-action: none` to Lumino split and dock panel resize handles so touch browsers do not claim resize drags for native gestures. This keeps pointer events flowing reliably during panel resizing while leaving normal touch behavior inside panel content unchanged.

### Playing around to check:

https://github.com/user-attachments/assets/8107293e-3f4f-4196-983a-dd2ba5bf020a

