### PR TITLE
Add extension points for customizing command palette search results

### DIFF
--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -301,7 +301,7 @@ function main(): void {
   bar.addMenu(emptyMenu);
   bar.id = 'menuBar';
 
-  let palette = new CommandPalette({ commands });
+  let palette = new CommandPalette({ commands, maxRecentCommands: 3 });
   palette.addItem({ command: 'example:cut', category: 'Edit' });
   palette.addItem({ command: 'example:copy', category: 'Edit' });
   palette.addItem({ command: 'example:paste', category: 'Edit' });

--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -301,7 +301,7 @@ function main(): void {
   bar.addMenu(emptyMenu);
   bar.id = 'menuBar';
 
-  let palette = new CommandPalette({ commands, maxRecentCommands: 3 });
+  let palette = new CommandPalette({ commands });
   palette.addItem({ command: 'example:cut', category: 'Edit' });
   palette.addItem({ command: 'example:copy', category: 'Edit' });
   palette.addItem({ command: 'example:paste', category: 'Edit' });

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -41,6 +41,7 @@ export class CommandPalette extends Widget {
     this.setFlag(Widget.Flag.DisallowLayout);
     this.commands = options.commands;
     this.renderer = options.renderer || CommandPalette.defaultRenderer;
+    this.maxRecentCommands = options.maxRecentCommands ?? 0;
     this.commands.commandChanged.connect(this._onGenericChange, this);
     this.commands.keyBindingChanged.connect(this._onGenericChange, this);
   }
@@ -50,6 +51,7 @@ export class CommandPalette extends Widget {
    */
   dispose(): void {
     this._items.length = 0;
+    this._recentCommands.length = 0;
     this._results = null;
     super.dispose();
   }
@@ -107,6 +109,46 @@ export class CommandPalette extends Widget {
    */
   get items(): ReadonlyArray<CommandPalette.IItem> {
     return this._items;
+  }
+
+  /**
+   * The maximum number of recently executed commands to display.
+   *
+   * #### Notes
+   * When the limit is positive, the most recently executed commands
+   * are displayed at the top of the palette when the search query is
+   * empty. When searching, the results are ordered as usual and the
+   * recently executed commands are only marked as recent.
+   *
+   * Setting the limit to `0` disables the tracking and display of the
+   * recently executed commands, and clears the existing history.
+   *
+   * Setting the limit to a value smaller than the current history
+   * drops the oldest commands from the history.
+   */
+  get maxRecentCommands(): number {
+    return this._maxRecentCommands;
+  }
+
+  set maxRecentCommands(value: number) {
+    // Normalize the limit to a non-negative integer, coercing `NaN` to `0`.
+    value = Math.max(0, Math.floor(value)) || 0;
+
+    // Bail if the limit does not change.
+    if (this._maxRecentCommands === value) {
+      return;
+    }
+
+    // Update the limit.
+    this._maxRecentCommands = value;
+
+    // Drop the oldest commands which exceed the new limit.
+    if (this._recentCommands.length > value) {
+      this._recentCommands.length = value;
+    }
+
+    // Refresh the search results.
+    this.refresh();
   }
 
   /**
@@ -188,6 +230,22 @@ export class CommandPalette extends Widget {
 
     // Clear the array of items.
     this._items.length = 0;
+
+    // Refresh the search results.
+    this.refresh();
+  }
+
+  /**
+   * Clear the recently executed commands.
+   */
+  clearRecentCommands(): void {
+    // Bail if there is nothing to remove.
+    if (this._recentCommands.length === 0) {
+      return;
+    }
+
+    // Clear the array of recently executed commands.
+    this._recentCommands.length = 0;
 
     // Refresh the search results.
     this.refresh();
@@ -309,7 +367,11 @@ export class CommandPalette extends Widget {
     let results = this._results;
     if (!results) {
       // Generate and store the new search results.
-      results = this._results = Private.search(this._items, query);
+      results = this._results = Private.search(
+        this._items,
+        query,
+        this._recentCommands
+      );
 
       // Reset the active index.
       this._activeIndex = query
@@ -344,7 +406,8 @@ export class CommandPalette extends Widget {
         let item = result.item;
         let indices = result.indices;
         let active = i === activeIndex;
-        content[i] = renderer.renderItem({ item, indices, active });
+        let recent = result.recent;
+        content[i] = renderer.renderItem({ item, indices, active, recent });
       }
     }
 
@@ -502,11 +565,40 @@ export class CommandPalette extends Widget {
     // Execute the item.
     this.commands.execute(part.item.command, part.item.args);
 
+    // Add the item to the recently executed commands.
+    this._addRecentCommand(part.item);
+
     // Clear the query text.
     this.inputNode.value = '';
 
     // Refresh the search results.
     this.refresh();
+  }
+
+  /**
+   * Add a command item to the recently executed commands.
+   */
+  private _addRecentCommand(item: CommandPalette.IItem): void {
+    // Bail if recently executed commands are not tracked.
+    if (this._maxRecentCommands === 0) {
+      return;
+    }
+
+    // Remove any existing entry for the command.
+    ArrayExt.removeFirstWhere(this._recentCommands, recent => {
+      return (
+        recent.command === item.command &&
+        JSONExt.deepEqual(recent.args, item.args)
+      );
+    });
+
+    // Add the command to the front of the history.
+    this._recentCommands.unshift({ command: item.command, args: item.args });
+
+    // Drop the oldest command if the history exceeds the limit.
+    if (this._recentCommands.length > this._maxRecentCommands) {
+      this._recentCommands.length = this._maxRecentCommands;
+    }
   }
 
   /**
@@ -527,6 +619,8 @@ export class CommandPalette extends Widget {
   private _activeIndex = -1;
   private _items: CommandPalette.IItem[] = [];
   private _results: Private.SearchResult[] | null = null;
+  private _maxRecentCommands = 0;
+  private _recentCommands: Private.IRecentCommand[] = [];
 }
 
 /**
@@ -548,6 +642,22 @@ export namespace CommandPalette {
      * The default is a shared renderer instance.
      */
     renderer?: IRenderer;
+
+    /**
+     * The maximum number of recently executed commands to display.
+     *
+     * #### Notes
+     * When the limit is positive, the most recently executed commands
+     * are displayed at the top of the palette when the search query is
+     * empty. When searching, the results are ordered as usual and the
+     * recently executed commands are only marked as recent.
+     *
+     * When the limit is `0`, recently executed commands are neither
+     * tracked nor displayed.
+     *
+     * The default value is `0`.
+     */
+    maxRecentCommands?: number;
   }
 
   /**
@@ -707,6 +817,14 @@ export namespace CommandPalette {
      * Whether the item is the active item.
      */
     readonly active: boolean;
+
+    /**
+     * Whether the item is a recently executed command.
+     *
+     * #### Notes
+     * The default value is `false`.
+     */
+    readonly recent?: boolean;
   }
 
   /**
@@ -903,6 +1021,9 @@ export namespace CommandPalette {
       if (data.active) {
         name += ' lm-mod-active';
       }
+      if (data.recent) {
+        name += ' lm-mod-recent';
+      }
 
       // Add the extra class.
       let extra = data.item.className;
@@ -1048,6 +1169,21 @@ namespace Private {
   }
 
   /**
+   * An object which represents a recently executed command.
+   */
+  export interface IRecentCommand {
+    /**
+     * The command which was executed.
+     */
+    readonly command: string;
+
+    /**
+     * The arguments for the command.
+     */
+    readonly args: ReadonlyJSONObject;
+  }
+
+  /**
    * A search result object for a header label.
    */
   export interface IHeaderResult {
@@ -1085,6 +1221,11 @@ namespace Private {
      * The indices of the matched label characters.
      */
     readonly indices: ReadonlyArray<number> | null;
+
+    /**
+     * Whether the item is a recently executed command.
+     */
+    readonly recent?: boolean;
   }
 
   /**
@@ -1097,16 +1238,20 @@ namespace Private {
    */
   export function search(
     items: CommandPalette.IItem[],
-    query: string
+    query: string,
+    recentCommands: ReadonlyArray<IRecentCommand>
   ): SearchResult[] {
+    // Resolve the recently executed commands to their items.
+    let recentItems = resolveRecentItems(items, recentCommands);
+
     // Fuzzy match the items for the query.
-    let scores = matchItems(items, query);
+    let scores = matchItems(items, query, recentItems);
 
     // Sort the items based on their score.
     scores.sort(scoreCmp);
 
     // Create the results for the search.
-    return createResults(scores);
+    return createResults(scores, recentItems);
   }
 
   /**
@@ -1134,6 +1279,7 @@ namespace Private {
    * An enum of the supported match types.
    */
   const enum MatchType {
+    Recent,
     Label,
     Category,
     Split,
@@ -1171,14 +1317,66 @@ namespace Private {
   }
 
   /**
+   * Resolve recently executed commands to their command items.
+   */
+  function resolveRecentItems(
+    items: CommandPalette.IItem[],
+    recentCommands: ReadonlyArray<IRecentCommand>
+  ): CommandPalette.IItem[] {
+    // Set up the array of resolved items.
+    let recentItems: CommandPalette.IItem[] = [];
+
+    // Iterate over the recently executed commands.
+    for (let recent of recentCommands) {
+      // Find the item for the command, if any.
+      let item = ArrayExt.findFirstValue(items, candidate => {
+        return (
+          candidate.command === recent.command &&
+          JSONExt.deepEqual(candidate.args, recent.args)
+        );
+      });
+
+      // Ignore commands which do not resolve to a visible and enabled
+      // item. A disabled item cannot be executed again, so it is listed
+      // in its own category instead until it is enabled again.
+      if (item && item.isVisible && item.isEnabled) {
+        recentItems.push(item);
+      }
+    }
+
+    // Return the resolved items.
+    return recentItems;
+  }
+
+  /**
    * Perform a fuzzy match on an array of command items.
    */
-  function matchItems(items: CommandPalette.IItem[], query: string): IScore[] {
+  function matchItems(
+    items: CommandPalette.IItem[],
+    query: string,
+    recentItems: CommandPalette.IItem[]
+  ): IScore[] {
     // Normalize the query text to lower case with no whitespace.
     query = normalizeQuery(query);
 
     // Create the array to hold the scores.
     let scores: IScore[] = [];
+
+    // For an empty query, add a score for each of the recently executed
+    // commands, which are displayed before all other items. The score
+    // reflects the recency of the item, so that sorting the scores
+    // preserves the order of execution.
+    if (!query) {
+      for (let i = 0, n = recentItems.length; i < n; ++i) {
+        scores.push({
+          matchType: MatchType.Recent,
+          categoryIndices: null,
+          labelIndices: null,
+          score: i,
+          item: recentItems[i]
+        });
+      }
+    }
 
     // Iterate over the items and match against the query.
     for (let i = 0, n = items.length; i < n; ++i) {
@@ -1188,15 +1386,18 @@ namespace Private {
         continue;
       }
 
-      // If the query is empty, all items are matched by default.
+      // If the query is empty, all items are matched by default, except
+      // for the recently executed commands which are already scored.
       if (!query) {
-        scores.push({
-          matchType: MatchType.Default,
-          categoryIndices: null,
-          labelIndices: null,
-          score: 0,
-          item
-        });
+        if (recentItems.indexOf(item) === -1) {
+          scores.push({
+            matchType: MatchType.Default,
+            categoryIndices: null,
+            labelIndices: null,
+            score: 0,
+            item
+          });
+        }
         continue;
       }
 
@@ -1375,26 +1576,48 @@ namespace Private {
   /**
    * Create the results from an array of sorted scores.
    */
-  function createResults(scores: IScore[]): SearchResult[] {
+  function createResults(
+    scores: IScore[],
+    recentItems: CommandPalette.IItem[]
+  ): SearchResult[] {
     // Set up the search results array.
     let results: SearchResult[] = [];
 
     // Iterate over each score in the array.
     for (let i = 0, n = scores.length; i < n; ++i) {
       // Extract the current item and indices.
-      let { item, categoryIndices, labelIndices } = scores[i];
+      let { matchType, item, categoryIndices, labelIndices } = scores[i];
+
+      // Look up whether the item is a recently executed command.
+      let recent = recentItems.indexOf(item) !== -1;
+
+      // Handle the recently executed commands for an empty query, which
+      // sort before all other results and are displayed without a
+      // category header.
+      if (matchType === MatchType.Recent) {
+        // Create the item result for the score.
+        results.push({ type: 'item', item, indices: labelIndices, recent });
+        continue;
+      }
 
       // Extract the category for the current item.
       let category = item.category;
 
+      // Look up the preceding search result, if any.
+      let prev = i === 0 ? null : scores[i - 1];
+
       // Is this the same category as the preceding result?
-      if (i === 0 || category !== scores[i - 1].item.category) {
+      if (
+        !prev ||
+        prev.matchType === MatchType.Recent ||
+        category !== prev.item.category
+      ) {
         // Add the header result for the category.
         results.push({ type: 'header', category, indices: categoryIndices });
       }
 
       // Create the item result for the score.
-      results.push({ type: 'item', item, indices: labelIndices });
+      results.push({ type: 'item', item, indices: labelIndices, recent });
     }
 
     // Return the final results.

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -17,6 +17,8 @@ import { ElementExt } from '@lumino/domutils';
 
 import { Message } from '@lumino/messaging';
 
+import { ISignal, Signal } from '@lumino/signaling';
+
 import {
   ElementDataset,
   h,
@@ -41,7 +43,6 @@ export class CommandPalette extends Widget {
     this.setFlag(Widget.Flag.DisallowLayout);
     this.commands = options.commands;
     this.renderer = options.renderer || CommandPalette.defaultRenderer;
-    this.maxRecentCommands = options.maxRecentCommands ?? 0;
     this.commands.commandChanged.connect(this._onGenericChange, this);
     this.commands.keyBindingChanged.connect(this._onGenericChange, this);
   }
@@ -51,9 +52,29 @@ export class CommandPalette extends Widget {
    */
   dispose(): void {
     this._items.length = 0;
-    this._recentCommands.length = 0;
     this._results = null;
     super.dispose();
+  }
+
+  /**
+   * A signal emitted when a command item is executed from the palette.
+   *
+   * #### Notes
+   * This signal is emitted when the user executes an item which is
+   * displayed in the palette, either by clicking the item or by
+   * pressing `Enter` while the item is active.
+   *
+   * It is not emitted when a command is executed by any other means,
+   * such as a key binding, a menu, or a direct invocation of the
+   * command registry.
+   *
+   * The signal is emitted when the execution of the command has been
+   * requested. It does not wait for the command to complete, and it
+   * is emitted regardless of whether the command completes
+   * successfully.
+   */
+  get itemExecuted(): ISignal<this, CommandPalette.IItem> {
+    return this._itemExecuted;
   }
 
   /**
@@ -109,46 +130,6 @@ export class CommandPalette extends Widget {
    */
   get items(): ReadonlyArray<CommandPalette.IItem> {
     return this._items;
-  }
-
-  /**
-   * The maximum number of recently executed commands to display.
-   *
-   * #### Notes
-   * When the limit is positive, the most recently executed commands
-   * are displayed at the top of the palette when the search query is
-   * empty. When searching, the results are ordered as usual and the
-   * recently executed commands are only marked as recent.
-   *
-   * Setting the limit to `0` disables the tracking and display of the
-   * recently executed commands, and clears the existing history.
-   *
-   * Setting the limit to a value smaller than the current history
-   * drops the oldest commands from the history.
-   */
-  get maxRecentCommands(): number {
-    return this._maxRecentCommands;
-  }
-
-  set maxRecentCommands(value: number) {
-    // Normalize the limit to a non-negative integer, coercing `NaN` to `0`.
-    value = Math.max(0, Math.floor(value)) || 0;
-
-    // Bail if the limit does not change.
-    if (this._maxRecentCommands === value) {
-      return;
-    }
-
-    // Update the limit.
-    this._maxRecentCommands = value;
-
-    // Drop the oldest commands which exceed the new limit.
-    if (this._recentCommands.length > value) {
-      this._recentCommands.length = value;
-    }
-
-    // Refresh the search results.
-    this.refresh();
   }
 
   /**
@@ -236,22 +217,6 @@ export class CommandPalette extends Widget {
   }
 
   /**
-   * Clear the recently executed commands.
-   */
-  clearRecentCommands(): void {
-    // Bail if there is nothing to remove.
-    if (this._recentCommands.length === 0) {
-      return;
-    }
-
-    // Clear the array of recently executed commands.
-    this._recentCommands.length = 0;
-
-    // Refresh the search results.
-    this.refresh();
-  }
-
-  /**
    * Clear the search results and schedule an update.
    *
    * #### Notes
@@ -306,6 +271,36 @@ export class CommandPalette extends Widget {
         this._toggleFocused();
         break;
     }
+  }
+
+  /**
+   * Generate the search results for the given query text.
+   *
+   * @param query - The query text of the palette search input.
+   *
+   * @returns The array of search results to display.
+   *
+   * #### Notes
+   * The results are displayed in the order they are returned. The
+   * mouse and keyboard interactions of the palette operate on that
+   * same order.
+   *
+   * The default implementation of this method fuzzy matches the
+   * palette items against the query using `CommandPalette.search()`.
+   *
+   * A subclass may reimplement this method as needed to customize
+   * which results are displayed and in what order. For example, a
+   * subclass could pin selected items to the top of the palette.
+   *
+   * The results should only include items which are visible.
+   *
+   * The results are generated when the palette is updated and are
+   * cached until the next call to `refresh()`. A subclass which
+   * generates results from state outside of the palette should call
+   * `refresh()` when that state changes.
+   */
+  protected search(query: string): CommandPalette.SearchResult[] {
+    return CommandPalette.search(this.items, query);
   }
 
   /**
@@ -367,11 +362,7 @@ export class CommandPalette extends Widget {
     let results = this._results;
     if (!results) {
       // Generate and store the new search results.
-      results = this._results = Private.search(
-        this._items,
-        query,
-        this._recentCommands
-      );
+      results = this._results = this.search(query);
 
       // Reset the active index.
       this._activeIndex = query
@@ -406,8 +397,7 @@ export class CommandPalette extends Widget {
         let item = result.item;
         let indices = result.indices;
         let active = i === activeIndex;
-        let recent = result.recent;
-        content[i] = renderer.renderItem({ item, indices, active, recent });
+        content[i] = renderer.renderItem({ item, indices, active });
       }
     }
 
@@ -565,40 +555,14 @@ export class CommandPalette extends Widget {
     // Execute the item.
     this.commands.execute(part.item.command, part.item.args);
 
-    // Add the item to the recently executed commands.
-    this._addRecentCommand(part.item);
+    // Emit the item executed signal.
+    this._itemExecuted.emit(part.item);
 
     // Clear the query text.
     this.inputNode.value = '';
 
     // Refresh the search results.
     this.refresh();
-  }
-
-  /**
-   * Add a command item to the recently executed commands.
-   */
-  private _addRecentCommand(item: CommandPalette.IItem): void {
-    // Bail if recently executed commands are not tracked.
-    if (this._maxRecentCommands === 0) {
-      return;
-    }
-
-    // Remove any existing entry for the command.
-    ArrayExt.removeFirstWhere(this._recentCommands, recent => {
-      return (
-        recent.command === item.command &&
-        JSONExt.deepEqual(recent.args, item.args)
-      );
-    });
-
-    // Add the command to the front of the history.
-    this._recentCommands.unshift({ command: item.command, args: item.args });
-
-    // Drop the oldest command if the history exceeds the limit.
-    if (this._recentCommands.length > this._maxRecentCommands) {
-      this._recentCommands.length = this._maxRecentCommands;
-    }
   }
 
   /**
@@ -617,10 +581,9 @@ export class CommandPalette extends Widget {
   }
 
   private _activeIndex = -1;
+  private _itemExecuted = new Signal<this, CommandPalette.IItem>(this);
   private _items: CommandPalette.IItem[] = [];
-  private _results: Private.SearchResult[] | null = null;
-  private _maxRecentCommands = 0;
-  private _recentCommands: Private.IRecentCommand[] = [];
+  private _results: CommandPalette.SearchResult[] | null = null;
 }
 
 /**
@@ -642,22 +605,6 @@ export namespace CommandPalette {
      * The default is a shared renderer instance.
      */
     renderer?: IRenderer;
-
-    /**
-     * The maximum number of recently executed commands to display.
-     *
-     * #### Notes
-     * When the limit is positive, the most recently executed commands
-     * are displayed at the top of the palette when the search query is
-     * empty. When searching, the results are ordered as usual and the
-     * recently executed commands are only marked as recent.
-     *
-     * When the limit is `0`, recently executed commands are neither
-     * tracked nor displayed.
-     *
-     * The default value is `0`.
-     */
-    maxRecentCommands?: number;
   }
 
   /**
@@ -785,6 +732,51 @@ export namespace CommandPalette {
   }
 
   /**
+   * A search result object for a header label.
+   */
+  export interface IHeaderResult {
+    /**
+     * The discriminated type of the object.
+     */
+    readonly type: 'header';
+
+    /**
+     * The category for the header.
+     */
+    readonly category: string;
+
+    /**
+     * The indices of the matched category characters.
+     */
+    readonly indices: ReadonlyArray<number> | null;
+  }
+
+  /**
+   * A search result object for a command item.
+   */
+  export interface IItemResult {
+    /**
+     * The discriminated type of the object.
+     */
+    readonly type: 'item';
+
+    /**
+     * The command item which was matched.
+     */
+    readonly item: IItem;
+
+    /**
+     * The indices of the matched label characters.
+     */
+    readonly indices: ReadonlyArray<number> | null;
+  }
+
+  /**
+   * A type alias for a command palette search result.
+   */
+  export type SearchResult = IHeaderResult | IItemResult;
+
+  /**
    * The render data for a command palette header.
    */
   export interface IHeaderRenderData {
@@ -817,14 +809,6 @@ export namespace CommandPalette {
      * Whether the item is the active item.
      */
     readonly active: boolean;
-
-    /**
-     * Whether the item is a recently executed command.
-     *
-     * #### Notes
-     * The default value is `false`.
-     */
-    readonly recent?: boolean;
   }
 
   /**
@@ -1021,9 +1005,6 @@ export namespace CommandPalette {
       if (data.active) {
         name += ' lm-mod-active';
       }
-      if (data.recent) {
-        name += ' lm-mod-recent';
-      }
 
       // Add the extra class.
       let extra = data.item.className;
@@ -1126,6 +1107,37 @@ export namespace CommandPalette {
    * The default `Renderer` instance.
    */
   export const defaultRenderer = new Renderer();
+
+  /**
+   * Search an array of command items for fuzzy matches.
+   *
+   * @param items - The command items to search.
+   *
+   * @param query - The query text to match against the items.
+   *
+   * @returns The array of search results for the query.
+   *
+   * #### Notes
+   * For an empty query, all visible items are included in the results,
+   * ordered by category, rank, and label.
+   *
+   * For a non-empty query, the visible items are fuzzy matched against
+   * the query text and ordered by match quality.
+   *
+   * Each contiguous run of items which share the same category is
+   * preceded by a header result for that category.
+   *
+   * This is the function used by the default implementation of the
+   * protected `search()` method of a command palette. It is provided
+   * so that a subclass which reimplements that method can compose the
+   * default search behavior with its own custom results.
+   */
+  export function search(
+    items: ReadonlyArray<IItem>,
+    query: string
+  ): SearchResult[] {
+    return Private.search(items, query);
+  }
 }
 
 /**
@@ -1169,89 +1181,25 @@ namespace Private {
   }
 
   /**
-   * An object which represents a recently executed command.
+   * A type alias for a command palette search result.
    */
-  export interface IRecentCommand {
-    /**
-     * The command which was executed.
-     */
-    readonly command: string;
-
-    /**
-     * The arguments for the command.
-     */
-    readonly args: ReadonlyJSONObject;
-  }
-
-  /**
-   * A search result object for a header label.
-   */
-  export interface IHeaderResult {
-    /**
-     * The discriminated type of the object.
-     */
-    readonly type: 'header';
-
-    /**
-     * The category for the header.
-     */
-    readonly category: string;
-
-    /**
-     * The indices of the matched category characters.
-     */
-    readonly indices: ReadonlyArray<number> | null;
-  }
-
-  /**
-   * A search result object for a command item.
-   */
-  export interface IItemResult {
-    /**
-     * The discriminated type of the object.
-     */
-    readonly type: 'item';
-
-    /**
-     * The command item which was matched.
-     */
-    readonly item: CommandPalette.IItem;
-
-    /**
-     * The indices of the matched label characters.
-     */
-    readonly indices: ReadonlyArray<number> | null;
-
-    /**
-     * Whether the item is a recently executed command.
-     */
-    readonly recent?: boolean;
-  }
-
-  /**
-   * A type alias for a search result item.
-   */
-  export type SearchResult = IHeaderResult | IItemResult;
+  export type SearchResult = CommandPalette.SearchResult;
 
   /**
    * Search an array of command items for fuzzy matches.
    */
   export function search(
-    items: CommandPalette.IItem[],
-    query: string,
-    recentCommands: ReadonlyArray<IRecentCommand>
+    items: ReadonlyArray<CommandPalette.IItem>,
+    query: string
   ): SearchResult[] {
-    // Resolve the recently executed commands to their items.
-    let recentItems = resolveRecentItems(items, recentCommands);
-
     // Fuzzy match the items for the query.
-    let scores = matchItems(items, query, recentItems);
+    let scores = matchItems(items, query);
 
     // Sort the items based on their score.
     scores.sort(scoreCmp);
 
     // Create the results for the search.
-    return createResults(scores, recentItems);
+    return createResults(scores);
   }
 
   /**
@@ -1279,7 +1227,6 @@ namespace Private {
    * An enum of the supported match types.
    */
   const enum MatchType {
-    Recent,
     Label,
     Category,
     Split,
@@ -1317,66 +1264,17 @@ namespace Private {
   }
 
   /**
-   * Resolve recently executed commands to their command items.
-   */
-  function resolveRecentItems(
-    items: CommandPalette.IItem[],
-    recentCommands: ReadonlyArray<IRecentCommand>
-  ): CommandPalette.IItem[] {
-    // Set up the array of resolved items.
-    let recentItems: CommandPalette.IItem[] = [];
-
-    // Iterate over the recently executed commands.
-    for (let recent of recentCommands) {
-      // Find the item for the command, if any.
-      let item = ArrayExt.findFirstValue(items, candidate => {
-        return (
-          candidate.command === recent.command &&
-          JSONExt.deepEqual(candidate.args, recent.args)
-        );
-      });
-
-      // Ignore commands which do not resolve to a visible and enabled
-      // item. A disabled item cannot be executed again, so it is listed
-      // in its own category instead until it is enabled again.
-      if (item && item.isVisible && item.isEnabled) {
-        recentItems.push(item);
-      }
-    }
-
-    // Return the resolved items.
-    return recentItems;
-  }
-
-  /**
    * Perform a fuzzy match on an array of command items.
    */
   function matchItems(
-    items: CommandPalette.IItem[],
-    query: string,
-    recentItems: CommandPalette.IItem[]
+    items: ReadonlyArray<CommandPalette.IItem>,
+    query: string
   ): IScore[] {
     // Normalize the query text to lower case with no whitespace.
     query = normalizeQuery(query);
 
     // Create the array to hold the scores.
     let scores: IScore[] = [];
-
-    // For an empty query, add a score for each of the recently executed
-    // commands, which are displayed before all other items. The score
-    // reflects the recency of the item, so that sorting the scores
-    // preserves the order of execution.
-    if (!query) {
-      for (let i = 0, n = recentItems.length; i < n; ++i) {
-        scores.push({
-          matchType: MatchType.Recent,
-          categoryIndices: null,
-          labelIndices: null,
-          score: i,
-          item: recentItems[i]
-        });
-      }
-    }
 
     // Iterate over the items and match against the query.
     for (let i = 0, n = items.length; i < n; ++i) {
@@ -1386,18 +1284,15 @@ namespace Private {
         continue;
       }
 
-      // If the query is empty, all items are matched by default, except
-      // for the recently executed commands which are already scored.
+      // If the query is empty, all items are matched by default.
       if (!query) {
-        if (recentItems.indexOf(item) === -1) {
-          scores.push({
-            matchType: MatchType.Default,
-            categoryIndices: null,
-            labelIndices: null,
-            score: 0,
-            item
-          });
-        }
+        scores.push({
+          matchType: MatchType.Default,
+          categoryIndices: null,
+          labelIndices: null,
+          score: 0,
+          item
+        });
         continue;
       }
 
@@ -1576,48 +1471,26 @@ namespace Private {
   /**
    * Create the results from an array of sorted scores.
    */
-  function createResults(
-    scores: IScore[],
-    recentItems: CommandPalette.IItem[]
-  ): SearchResult[] {
+  function createResults(scores: IScore[]): SearchResult[] {
     // Set up the search results array.
     let results: SearchResult[] = [];
 
     // Iterate over each score in the array.
     for (let i = 0, n = scores.length; i < n; ++i) {
       // Extract the current item and indices.
-      let { matchType, item, categoryIndices, labelIndices } = scores[i];
-
-      // Look up whether the item is a recently executed command.
-      let recent = recentItems.indexOf(item) !== -1;
-
-      // Handle the recently executed commands for an empty query, which
-      // sort before all other results and are displayed without a
-      // category header.
-      if (matchType === MatchType.Recent) {
-        // Create the item result for the score.
-        results.push({ type: 'item', item, indices: labelIndices, recent });
-        continue;
-      }
+      let { item, categoryIndices, labelIndices } = scores[i];
 
       // Extract the category for the current item.
       let category = item.category;
 
-      // Look up the preceding search result, if any.
-      let prev = i === 0 ? null : scores[i - 1];
-
       // Is this the same category as the preceding result?
-      if (
-        !prev ||
-        prev.matchType === MatchType.Recent ||
-        category !== prev.item.category
-      ) {
+      if (i === 0 || category !== scores[i - 1].item.category) {
         // Add the header result for the category.
         results.push({ type: 'header', category, indices: categoryIndices });
       }
 
       // Create the item result for the score.
-      results.push({ type: 'item', item, indices: labelIndices, recent });
+      results.push({ type: 'item', item, indices: labelIndices });
     }
 
     // Return the final results.

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -57,10 +57,10 @@ export class CommandPalette extends Widget {
   }
 
   /**
-   * A signal emitted when a command item is executed from the palette.
+   * A signal emitted when a command item is triggered from the palette.
    *
    * #### Notes
-   * This signal is emitted when the user executes an item which is
+   * This signal is emitted when the user triggers an item which is
    * displayed in the palette, either by clicking the item or by
    * pressing `Enter` while the item is active.
    *
@@ -68,13 +68,14 @@ export class CommandPalette extends Widget {
    * such as a key binding, a menu, or a direct invocation of the
    * command registry.
    *
-   * The signal is emitted when the execution of the command has been
-   * requested. It does not wait for the command to complete, and it
-   * is emitted regardless of whether the command completes
-   * successfully.
+   * The signal is emitted before the execution of the item's command
+   * is requested, so a handler observes the state of the application
+   * as the user triggered the item. The signal does not report on the
+   * execution: the `commandExecuted` signal of the command registry
+   * can be used to observe the result of an execution.
    */
-  get itemExecuted(): ISignal<this, CommandPalette.IItem> {
-    return this._itemExecuted;
+  get itemTriggered(): ISignal<this, CommandPalette.IItem> {
+    return this._itemTriggered;
   }
 
   /**
@@ -552,11 +553,13 @@ export class CommandPalette extends Widget {
       return;
     }
 
+    // Emit the item triggered signal before requesting the execution,
+    // so that a handler observes the state of the application as the
+    // user triggered the item.
+    this._itemTriggered.emit(part.item);
+
     // Execute the item.
     this.commands.execute(part.item.command, part.item.args);
-
-    // Emit the item executed signal.
-    this._itemExecuted.emit(part.item);
 
     // Clear the query text.
     this.inputNode.value = '';
@@ -581,7 +584,7 @@ export class CommandPalette extends Widget {
   }
 
   private _activeIndex = -1;
-  private _itemExecuted = new Signal<this, CommandPalette.IItem>(this);
+  private _itemTriggered = new Signal<this, CommandPalette.IItem>(this);
   private _items: CommandPalette.IItem[] = [];
   private _results: CommandPalette.SearchResult[] | null = null;
 }

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -115,6 +115,278 @@ describe('@lumino/widgets', () => {
       });
     });
 
+    describe('#maxRecentCommands', () => {
+      it('should default to `0`', () => {
+        expect(palette.maxRecentCommands).to.equal(0);
+      });
+
+      it('should be initialized from the palette options', () => {
+        let palette = new CommandPalette({ commands, maxRecentCommands: 5 });
+        expect(palette.maxRecentCommands).to.equal(5);
+        palette.dispose();
+      });
+
+      it('should normalize invalid values', () => {
+        palette.maxRecentCommands = 2.7;
+        expect(palette.maxRecentCommands).to.equal(2);
+        palette.maxRecentCommands = -1;
+        expect(palette.maxRecentCommands).to.equal(0);
+        palette.maxRecentCommands = NaN;
+        expect(palette.maxRecentCommands).to.equal(0);
+      });
+
+      context('recent commands', () => {
+        let visibleFlag = true;
+
+        const executeItem = (label: string): void => {
+          MessageLoop.flush();
+          let labels = Array.from(
+            palette.contentNode.querySelectorAll('.lm-CommandPalette-itemLabel')
+          );
+          let labelNode = labels.find(node => node.textContent === label)!;
+          let itemNode = labelNode.closest('.lm-CommandPalette-item')!;
+          itemNode.dispatchEvent(new MouseEvent('click', { bubbles }));
+          MessageLoop.flush();
+        };
+
+        const headerLabels = (): (string | null)[] => {
+          MessageLoop.flush();
+          return Array.from(
+            palette.contentNode.querySelectorAll('.lm-CommandPalette-header')
+          ).map(node => node.textContent);
+        };
+
+        const itemLabels = (): (string | null)[] => {
+          MessageLoop.flush();
+          return Array.from(
+            palette.contentNode.querySelectorAll('.lm-CommandPalette-itemLabel')
+          ).map(node => node.textContent);
+        };
+
+        const recentLabels = (): (string | null)[] => {
+          MessageLoop.flush();
+          return Array.from(
+            palette.contentNode.querySelectorAll(
+              '.lm-CommandPalette-item.lm-mod-recent .lm-CommandPalette-itemLabel'
+            )
+          ).map(node => node.textContent);
+        };
+
+        beforeEach(() => {
+          visibleFlag = true;
+          palette.maxRecentCommands = 3;
+          ['One', 'Two', 'Three', 'Four'].forEach(label => {
+            let command = `test:${label.toLowerCase()}`;
+            commands.addCommand(command, { execute: () => {}, label });
+            palette.addItem({ command, category: 'Numbers' });
+          });
+          commands.addCommand('test:hidden', {
+            execute: () => {},
+            isVisible: () => visibleFlag,
+            label: 'Hidden'
+          });
+          palette.addItem({ command: 'test:hidden', category: 'Numbers' });
+        });
+
+        it('should display the recently executed commands at the top', () => {
+          expect(recentLabels()).to.deep.equal([]);
+          executeItem('Two');
+          expect(recentLabels()).to.deep.equal(['Two']);
+          expect(itemLabels()).to.deep.equal([
+            'Two',
+            'Four',
+            'Hidden',
+            'One',
+            'Three'
+          ]);
+          // The recent items are displayed before the category headers.
+          expect(headerLabels()).to.deep.equal(['Numbers']);
+          let first = palette.contentNode.firstElementChild!;
+          expect(first.classList.contains('lm-CommandPalette-item')).to.equal(
+            true
+          );
+          expect(first.classList.contains('lm-mod-recent')).to.equal(true);
+        });
+
+        it('should navigate and execute the recent commands with the keyboard', () => {
+          executeItem('Three');
+          executeItem('One');
+          palette.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              bubbles,
+              keyCode: 40 // Down Arrow
+            })
+          );
+          palette.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              bubbles,
+              keyCode: 40 // Down Arrow
+            })
+          );
+          MessageLoop.flush();
+          let active = palette.contentNode.querySelector(
+            '.lm-CommandPalette-item.lm-mod-active'
+          )!;
+          expect(
+            active.querySelector('.lm-CommandPalette-itemLabel')!.textContent
+          ).to.equal('Three');
+          palette.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              bubbles,
+              keyCode: 13 // Enter
+            })
+          );
+          expect(recentLabels()).to.deep.equal(['Three', 'One']);
+        });
+
+        it('should order the recently executed commands by recency', () => {
+          executeItem('Three');
+          executeItem('One');
+          expect(recentLabels()).to.deep.equal(['One', 'Three']);
+          expect(itemLabels()).to.deep.equal([
+            'One',
+            'Three',
+            'Four',
+            'Hidden',
+            'Two'
+          ]);
+          executeItem('Three');
+          expect(recentLabels()).to.deep.equal(['Three', 'One']);
+          expect(itemLabels()).to.deep.equal([
+            'Three',
+            'One',
+            'Four',
+            'Hidden',
+            'Two'
+          ]);
+        });
+
+        it('should drop the oldest command when the history is full', () => {
+          executeItem('One');
+          executeItem('Two');
+          executeItem('Three');
+          executeItem('Four');
+          expect(recentLabels()).to.deep.equal(['Four', 'Three', 'Two']);
+          expect(itemLabels()).to.deep.equal([
+            'Four',
+            'Three',
+            'Two',
+            'Hidden',
+            'One'
+          ]);
+        });
+
+        it('should track items with distinct arguments separately', () => {
+          commands.addCommand('test:args', {
+            execute: () => {},
+            label: args => `Arg ${args.n}`
+          });
+          palette.addItem({
+            command: 'test:args',
+            args: { n: 1 },
+            category: 'Numbers'
+          });
+          palette.addItem({
+            command: 'test:args',
+            args: { n: 2 },
+            category: 'Numbers'
+          });
+          executeItem('Arg 1');
+          executeItem('Arg 2');
+          expect(recentLabels()).to.deep.equal(['Arg 2', 'Arg 1']);
+        });
+
+        it('should mark the recently executed commands when searching', () => {
+          executeItem('Four');
+          expect(recentLabels()).to.deep.equal(['Four']);
+          palette.inputNode.value = 'four';
+          palette.refresh();
+          expect(headerLabels()).to.deep.equal(['Numbers']);
+          expect(itemLabels()).to.deep.equal(['Four']);
+          expect(recentLabels()).to.deep.equal(['Four']);
+          palette.inputNode.value = 'three';
+          palette.refresh();
+          expect(itemLabels()).to.deep.equal(['Three']);
+          expect(recentLabels()).to.deep.equal([]);
+        });
+
+        it('should not change the order of the search results', () => {
+          executeItem('Two');
+          palette.inputNode.value = 't';
+          palette.refresh();
+          expect(itemLabels()).to.deep.equal(['Three', 'Two']);
+          expect(recentLabels()).to.deep.equal(['Two']);
+        });
+
+        it('should drop the oldest commands when the limit is lowered', () => {
+          executeItem('One');
+          executeItem('Two');
+          palette.maxRecentCommands = 1;
+          expect(recentLabels()).to.deep.equal(['Two']);
+          expect(itemLabels()).to.deep.equal([
+            'Two',
+            'Four',
+            'Hidden',
+            'One',
+            'Three'
+          ]);
+        });
+
+        it('should clear and disable the history when set to `0`', () => {
+          executeItem('One');
+          expect(recentLabels()).to.deep.equal(['One']);
+          palette.maxRecentCommands = 0;
+          expect(recentLabels()).to.deep.equal([]);
+          palette.maxRecentCommands = 3;
+          expect(recentLabels()).to.deep.equal([]);
+        });
+
+        it('should not display commands which were removed', () => {
+          executeItem('One');
+          palette.removeItemAt(0);
+          expect(recentLabels()).to.deep.equal([]);
+          expect(itemLabels()).to.deep.equal([
+            'Four',
+            'Hidden',
+            'Three',
+            'Two'
+          ]);
+        });
+
+        it('should not display commands which are not visible', () => {
+          executeItem('Hidden');
+          expect(recentLabels()).to.deep.equal(['Hidden']);
+          visibleFlag = false;
+          palette.refresh();
+          expect(recentLabels()).to.deep.equal([]);
+          expect(itemLabels()).to.deep.equal(['Four', 'One', 'Three', 'Two']);
+        });
+
+        it('should not display commands which are disabled', () => {
+          let enabled = true;
+          commands.addCommand('test:enabled', {
+            execute: () => {},
+            isEnabled: () => enabled,
+            label: 'Enabled'
+          });
+          palette.addItem({ command: 'test:enabled', category: 'Numbers' });
+          executeItem('Enabled');
+          expect(recentLabels()).to.deep.equal(['Enabled']);
+          enabled = false;
+          palette.refresh();
+          expect(recentLabels()).to.deep.equal([]);
+          expect(itemLabels()).to.deep.equal([
+            'Enabled',
+            'Four',
+            'Hidden',
+            'One',
+            'Three',
+            'Two'
+          ]);
+        });
+      });
+    });
+
     describe('#addItems()', () => {
       it('should add items to a command palette using options', () => {
         const item = {
@@ -300,6 +572,31 @@ describe('@lumino/widgets', () => {
         expect(palette.items.length).to.equal(2);
         palette.clearItems();
         expect(palette.items.length).to.equal(0);
+      });
+    });
+
+    describe('#clearRecentCommands()', () => {
+      it('should clear the recently executed commands', () => {
+        palette.maxRecentCommands = 3;
+        commands.addCommand('test', { execute: () => {}, label: 'test' });
+        palette.addItem(defaultOptions);
+        MessageLoop.flush();
+
+        let recents = () =>
+          palette.contentNode.querySelectorAll(
+            '.lm-CommandPalette-item.lm-mod-recent'
+          );
+        let item = palette.contentNode.querySelector(
+          '.lm-CommandPalette-item'
+        )!;
+
+        item.dispatchEvent(new MouseEvent('click', { bubbles }));
+        MessageLoop.flush();
+        expect(recents()).to.have.length(1);
+
+        palette.clearRecentCommands();
+        MessageLoop.flush();
+        expect(recents()).to.have.length(0);
       });
     });
 
@@ -928,6 +1225,17 @@ describe('@lumino/widgets', () => {
           let node = VirtualDOM.realize(vNode);
           expect(node.classList.contains('lm-mod-active')).to.equal(true);
         });
+
+        it('should handle the recent state', () => {
+          let vNode = renderer.renderItem({
+            item,
+            indices: null,
+            active: false,
+            recent: true
+          });
+          let node = VirtualDOM.realize(vNode);
+          expect(node.classList.contains('lm-mod-recent')).to.equal(true);
+        });
       });
 
       describe('#renderEmptyMessage()', () => {
@@ -1007,10 +1315,11 @@ describe('@lumino/widgets', () => {
           let name = renderer.createItemClass({
             item,
             indices: null,
-            active: true
+            active: true,
+            recent: true
           });
           let expected =
-            'lm-CommandPalette-item lm-mod-disabled lm-mod-toggled lm-mod-active testClass';
+            'lm-CommandPalette-item lm-mod-disabled lm-mod-toggled lm-mod-active lm-mod-recent testClass';
           expect(name).to.equal(expected);
         });
       });

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -36,7 +36,7 @@ class LogPalette extends CommandPalette {
  *
  * #### Notes
  * This demonstrates how a downstream application can implement a
- * "recently used commands" feature with the `itemExecuted` signal
+ * "recently used commands" feature with the `itemTriggered` signal
  * and the protected `search()` method.
  */
 class RecentsPalette extends CommandPalette {
@@ -44,7 +44,7 @@ class RecentsPalette extends CommandPalette {
 
   constructor(options: CommandPalette.IOptions) {
     super(options);
-    this.itemExecuted.connect((sender, item) => {
+    this.itemTriggered.connect((sender, item) => {
       let index = this.recents.findIndex(recent => {
         return (
           recent.command === item.command &&
@@ -130,12 +130,12 @@ describe('@lumino/widgets', () => {
       });
     });
 
-    describe('#itemExecuted', () => {
+    describe('#itemTriggered', () => {
       it('should be emitted when an item is clicked', () => {
         commands.addCommand('test', { execute: () => {} });
 
         let executed: CommandPalette.IItem | null = null;
-        palette.itemExecuted.connect((sender, item) => {
+        palette.itemTriggered.connect((sender, item) => {
           expect(sender).to.equal(palette);
           executed = item;
         });
@@ -153,7 +153,7 @@ describe('@lumino/widgets', () => {
         commands.addCommand('test', { execute: () => {} });
 
         let executed: CommandPalette.IItem | null = null;
-        palette.itemExecuted.connect((sender, item) => {
+        palette.itemTriggered.connect((sender, item) => {
           executed = item;
         });
 
@@ -175,11 +175,31 @@ describe('@lumino/widgets', () => {
         expect(executed!.command).to.equal('test');
       });
 
+      it('should be emitted before the command is executed', () => {
+        let order: string[] = [];
+        commands.addCommand('test', {
+          execute: () => {
+            order.push('execute');
+          }
+        });
+
+        palette.itemTriggered.connect(() => {
+          order.push('triggered');
+        });
+
+        palette.addItem(defaultOptions);
+        MessageLoop.flush();
+
+        let node = palette.contentNode.querySelector('.lm-CommandPalette-item');
+        node!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(order).to.deep.equal(['triggered', 'execute']);
+      });
+
       it('should not be emitted when a command is executed directly', () => {
         commands.addCommand('test', { execute: () => {} });
 
         let emitted = false;
-        palette.itemExecuted.connect(() => {
+        palette.itemTriggered.connect(() => {
           emitted = true;
         });
 
@@ -197,7 +217,7 @@ describe('@lumino/widgets', () => {
         });
 
         let emitted = false;
-        palette.itemExecuted.connect(() => {
+        palette.itemTriggered.connect(() => {
           emitted = true;
         });
 
@@ -213,7 +233,7 @@ describe('@lumino/widgets', () => {
         commands.addCommand('test', { execute: () => {} });
 
         let emitted = false;
-        palette.itemExecuted.connect(() => {
+        palette.itemTriggered.connect(() => {
           emitted = true;
         });
 
@@ -821,7 +841,7 @@ describe('@lumino/widgets', () => {
 
         // Activate and trigger the pinned item.
         let executed: CommandPalette.IItem | null = null;
-        palette.itemExecuted.connect((sender, item) => {
+        palette.itemTriggered.connect((sender, item) => {
           executed = item;
         });
         palette.node.dispatchEvent(

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -12,6 +12,8 @@ import { expect } from 'chai';
 
 import { CommandRegistry } from '@lumino/commands';
 
+import { JSONExt, ReadonlyJSONObject } from '@lumino/coreutils';
+
 import { Platform } from '@lumino/domutils';
 
 import { MessageLoop } from '@lumino/messaging';
@@ -26,6 +28,64 @@ class LogPalette extends CommandPalette {
   handleEvent(event: Event): void {
     super.handleEvent(event);
     this.events.push(event.type);
+  }
+}
+
+/**
+ * A command palette which pins recently executed items to the top.
+ *
+ * #### Notes
+ * This demonstrates how a downstream application can implement a
+ * "recently used commands" feature with the `itemExecuted` signal
+ * and the protected `search()` method.
+ */
+class RecentsPalette extends CommandPalette {
+  readonly recents: { command: string; args: ReadonlyJSONObject }[] = [];
+
+  constructor(options: CommandPalette.IOptions) {
+    super(options);
+    this.itemExecuted.connect((sender, item) => {
+      let index = this.recents.findIndex(recent => {
+        return (
+          recent.command === item.command &&
+          JSONExt.deepEqual(recent.args, item.args)
+        );
+      });
+      if (index !== -1) {
+        this.recents.splice(index, 1);
+      }
+      this.recents.unshift({ command: item.command, args: item.args });
+    }, this);
+  }
+
+  protected search(query: string): CommandPalette.SearchResult[] {
+    // Use the default search behavior when there is a query.
+    if (query.replace(/\s+/g, '')) {
+      return super.search(query);
+    }
+
+    // Resolve the recently executed commands to their palette items,
+    // keeping only the items which can be displayed and executed.
+    let resolved: CommandPalette.IItem[] = [];
+    for (let recent of this.recents) {
+      let item = this.items.find(candidate => {
+        return (
+          candidate.command === recent.command &&
+          JSONExt.deepEqual(candidate.args, recent.args)
+        );
+      });
+      if (item && item.isVisible && item.isEnabled) {
+        resolved.push(item);
+      }
+    }
+
+    // Pin the recent items to the top of the palette, without a
+    // category header, followed by the remaining items.
+    let pinned: CommandPalette.SearchResult[] = resolved.map(item => {
+      return { type: 'item', item, indices: null };
+    });
+    let others = this.items.filter(item => resolved.indexOf(item) === -1);
+    return [...pinned, ...CommandPalette.search(others, query)];
   }
 }
 
@@ -67,6 +127,104 @@ describe('@lumino/widgets', () => {
         palette.dispose();
         expect(palette.items.length).to.equal(0);
         expect(palette.isDisposed).to.equal(true);
+      });
+    });
+
+    describe('#itemExecuted', () => {
+      it('should be emitted when an item is clicked', () => {
+        commands.addCommand('test', { execute: () => {} });
+
+        let executed: CommandPalette.IItem | null = null;
+        palette.itemExecuted.connect((sender, item) => {
+          expect(sender).to.equal(palette);
+          executed = item;
+        });
+
+        palette.addItem(defaultOptions);
+        MessageLoop.flush();
+
+        let node = palette.contentNode.querySelector('.lm-CommandPalette-item');
+        node!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(executed!.command).to.equal('test');
+        expect(executed!.args).to.deep.equal({ foo: 'bar' });
+      });
+
+      it('should be emitted when the active item is triggered with enter', () => {
+        commands.addCommand('test', { execute: () => {} });
+
+        let executed: CommandPalette.IItem | null = null;
+        palette.itemExecuted.connect((sender, item) => {
+          executed = item;
+        });
+
+        palette.addItem(defaultOptions);
+        MessageLoop.flush();
+
+        palette.node.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            bubbles: true,
+            keyCode: 40 // Down arrow
+          })
+        );
+        palette.node.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            bubbles: true,
+            keyCode: 13 // Enter
+          })
+        );
+        expect(executed!.command).to.equal('test');
+      });
+
+      it('should not be emitted when a command is executed directly', () => {
+        commands.addCommand('test', { execute: () => {} });
+
+        let emitted = false;
+        palette.itemExecuted.connect(() => {
+          emitted = true;
+        });
+
+        palette.addItem(defaultOptions);
+        MessageLoop.flush();
+
+        commands.execute('test', { foo: 'bar' });
+        expect(emitted).to.equal(false);
+      });
+
+      it('should not be emitted when a disabled item is clicked', () => {
+        commands.addCommand('test', {
+          execute: () => {},
+          isEnabled: () => false
+        });
+
+        let emitted = false;
+        palette.itemExecuted.connect(() => {
+          emitted = true;
+        });
+
+        palette.addItem(defaultOptions);
+        MessageLoop.flush();
+
+        let node = palette.contentNode.querySelector('.lm-CommandPalette-item');
+        node!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(emitted).to.equal(false);
+      });
+
+      it('should not be emitted when a header is clicked', () => {
+        commands.addCommand('test', { execute: () => {} });
+
+        let emitted = false;
+        palette.itemExecuted.connect(() => {
+          emitted = true;
+        });
+
+        palette.addItem(defaultOptions);
+        MessageLoop.flush();
+
+        let node = palette.contentNode.querySelector(
+          '.lm-CommandPalette-header'
+        );
+        node!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        expect(emitted).to.equal(false);
       });
     });
 
@@ -112,278 +270,6 @@ describe('@lumino/widgets', () => {
         palette.addItem(defaultOptions);
         expect(palette.items.length).to.equal(1);
         expect(palette.items[0].command).to.equal('test');
-      });
-    });
-
-    describe('#maxRecentCommands', () => {
-      it('should default to `0`', () => {
-        expect(palette.maxRecentCommands).to.equal(0);
-      });
-
-      it('should be initialized from the palette options', () => {
-        let palette = new CommandPalette({ commands, maxRecentCommands: 5 });
-        expect(palette.maxRecentCommands).to.equal(5);
-        palette.dispose();
-      });
-
-      it('should normalize invalid values', () => {
-        palette.maxRecentCommands = 2.7;
-        expect(palette.maxRecentCommands).to.equal(2);
-        palette.maxRecentCommands = -1;
-        expect(palette.maxRecentCommands).to.equal(0);
-        palette.maxRecentCommands = NaN;
-        expect(palette.maxRecentCommands).to.equal(0);
-      });
-
-      context('recent commands', () => {
-        let visibleFlag = true;
-
-        const executeItem = (label: string): void => {
-          MessageLoop.flush();
-          let labels = Array.from(
-            palette.contentNode.querySelectorAll('.lm-CommandPalette-itemLabel')
-          );
-          let labelNode = labels.find(node => node.textContent === label)!;
-          let itemNode = labelNode.closest('.lm-CommandPalette-item')!;
-          itemNode.dispatchEvent(new MouseEvent('click', { bubbles }));
-          MessageLoop.flush();
-        };
-
-        const headerLabels = (): (string | null)[] => {
-          MessageLoop.flush();
-          return Array.from(
-            palette.contentNode.querySelectorAll('.lm-CommandPalette-header')
-          ).map(node => node.textContent);
-        };
-
-        const itemLabels = (): (string | null)[] => {
-          MessageLoop.flush();
-          return Array.from(
-            palette.contentNode.querySelectorAll('.lm-CommandPalette-itemLabel')
-          ).map(node => node.textContent);
-        };
-
-        const recentLabels = (): (string | null)[] => {
-          MessageLoop.flush();
-          return Array.from(
-            palette.contentNode.querySelectorAll(
-              '.lm-CommandPalette-item.lm-mod-recent .lm-CommandPalette-itemLabel'
-            )
-          ).map(node => node.textContent);
-        };
-
-        beforeEach(() => {
-          visibleFlag = true;
-          palette.maxRecentCommands = 3;
-          ['One', 'Two', 'Three', 'Four'].forEach(label => {
-            let command = `test:${label.toLowerCase()}`;
-            commands.addCommand(command, { execute: () => {}, label });
-            palette.addItem({ command, category: 'Numbers' });
-          });
-          commands.addCommand('test:hidden', {
-            execute: () => {},
-            isVisible: () => visibleFlag,
-            label: 'Hidden'
-          });
-          palette.addItem({ command: 'test:hidden', category: 'Numbers' });
-        });
-
-        it('should display the recently executed commands at the top', () => {
-          expect(recentLabels()).to.deep.equal([]);
-          executeItem('Two');
-          expect(recentLabels()).to.deep.equal(['Two']);
-          expect(itemLabels()).to.deep.equal([
-            'Two',
-            'Four',
-            'Hidden',
-            'One',
-            'Three'
-          ]);
-          // The recent items are displayed before the category headers.
-          expect(headerLabels()).to.deep.equal(['Numbers']);
-          let first = palette.contentNode.firstElementChild!;
-          expect(first.classList.contains('lm-CommandPalette-item')).to.equal(
-            true
-          );
-          expect(first.classList.contains('lm-mod-recent')).to.equal(true);
-        });
-
-        it('should navigate and execute the recent commands with the keyboard', () => {
-          executeItem('Three');
-          executeItem('One');
-          palette.node.dispatchEvent(
-            new KeyboardEvent('keydown', {
-              bubbles,
-              keyCode: 40 // Down Arrow
-            })
-          );
-          palette.node.dispatchEvent(
-            new KeyboardEvent('keydown', {
-              bubbles,
-              keyCode: 40 // Down Arrow
-            })
-          );
-          MessageLoop.flush();
-          let active = palette.contentNode.querySelector(
-            '.lm-CommandPalette-item.lm-mod-active'
-          )!;
-          expect(
-            active.querySelector('.lm-CommandPalette-itemLabel')!.textContent
-          ).to.equal('Three');
-          palette.node.dispatchEvent(
-            new KeyboardEvent('keydown', {
-              bubbles,
-              keyCode: 13 // Enter
-            })
-          );
-          expect(recentLabels()).to.deep.equal(['Three', 'One']);
-        });
-
-        it('should order the recently executed commands by recency', () => {
-          executeItem('Three');
-          executeItem('One');
-          expect(recentLabels()).to.deep.equal(['One', 'Three']);
-          expect(itemLabels()).to.deep.equal([
-            'One',
-            'Three',
-            'Four',
-            'Hidden',
-            'Two'
-          ]);
-          executeItem('Three');
-          expect(recentLabels()).to.deep.equal(['Three', 'One']);
-          expect(itemLabels()).to.deep.equal([
-            'Three',
-            'One',
-            'Four',
-            'Hidden',
-            'Two'
-          ]);
-        });
-
-        it('should drop the oldest command when the history is full', () => {
-          executeItem('One');
-          executeItem('Two');
-          executeItem('Three');
-          executeItem('Four');
-          expect(recentLabels()).to.deep.equal(['Four', 'Three', 'Two']);
-          expect(itemLabels()).to.deep.equal([
-            'Four',
-            'Three',
-            'Two',
-            'Hidden',
-            'One'
-          ]);
-        });
-
-        it('should track items with distinct arguments separately', () => {
-          commands.addCommand('test:args', {
-            execute: () => {},
-            label: args => `Arg ${args.n}`
-          });
-          palette.addItem({
-            command: 'test:args',
-            args: { n: 1 },
-            category: 'Numbers'
-          });
-          palette.addItem({
-            command: 'test:args',
-            args: { n: 2 },
-            category: 'Numbers'
-          });
-          executeItem('Arg 1');
-          executeItem('Arg 2');
-          expect(recentLabels()).to.deep.equal(['Arg 2', 'Arg 1']);
-        });
-
-        it('should mark the recently executed commands when searching', () => {
-          executeItem('Four');
-          expect(recentLabels()).to.deep.equal(['Four']);
-          palette.inputNode.value = 'four';
-          palette.refresh();
-          expect(headerLabels()).to.deep.equal(['Numbers']);
-          expect(itemLabels()).to.deep.equal(['Four']);
-          expect(recentLabels()).to.deep.equal(['Four']);
-          palette.inputNode.value = 'three';
-          palette.refresh();
-          expect(itemLabels()).to.deep.equal(['Three']);
-          expect(recentLabels()).to.deep.equal([]);
-        });
-
-        it('should not change the order of the search results', () => {
-          executeItem('Two');
-          palette.inputNode.value = 't';
-          palette.refresh();
-          expect(itemLabels()).to.deep.equal(['Three', 'Two']);
-          expect(recentLabels()).to.deep.equal(['Two']);
-        });
-
-        it('should drop the oldest commands when the limit is lowered', () => {
-          executeItem('One');
-          executeItem('Two');
-          palette.maxRecentCommands = 1;
-          expect(recentLabels()).to.deep.equal(['Two']);
-          expect(itemLabels()).to.deep.equal([
-            'Two',
-            'Four',
-            'Hidden',
-            'One',
-            'Three'
-          ]);
-        });
-
-        it('should clear and disable the history when set to `0`', () => {
-          executeItem('One');
-          expect(recentLabels()).to.deep.equal(['One']);
-          palette.maxRecentCommands = 0;
-          expect(recentLabels()).to.deep.equal([]);
-          palette.maxRecentCommands = 3;
-          expect(recentLabels()).to.deep.equal([]);
-        });
-
-        it('should not display commands which were removed', () => {
-          executeItem('One');
-          palette.removeItemAt(0);
-          expect(recentLabels()).to.deep.equal([]);
-          expect(itemLabels()).to.deep.equal([
-            'Four',
-            'Hidden',
-            'Three',
-            'Two'
-          ]);
-        });
-
-        it('should not display commands which are not visible', () => {
-          executeItem('Hidden');
-          expect(recentLabels()).to.deep.equal(['Hidden']);
-          visibleFlag = false;
-          palette.refresh();
-          expect(recentLabels()).to.deep.equal([]);
-          expect(itemLabels()).to.deep.equal(['Four', 'One', 'Three', 'Two']);
-        });
-
-        it('should not display commands which are disabled', () => {
-          let enabled = true;
-          commands.addCommand('test:enabled', {
-            execute: () => {},
-            isEnabled: () => enabled,
-            label: 'Enabled'
-          });
-          palette.addItem({ command: 'test:enabled', category: 'Numbers' });
-          executeItem('Enabled');
-          expect(recentLabels()).to.deep.equal(['Enabled']);
-          enabled = false;
-          palette.refresh();
-          expect(recentLabels()).to.deep.equal([]);
-          expect(itemLabels()).to.deep.equal([
-            'Enabled',
-            'Four',
-            'Hidden',
-            'One',
-            'Three',
-            'Two'
-          ]);
-        });
       });
     });
 
@@ -572,31 +458,6 @@ describe('@lumino/widgets', () => {
         expect(palette.items.length).to.equal(2);
         palette.clearItems();
         expect(palette.items.length).to.equal(0);
-      });
-    });
-
-    describe('#clearRecentCommands()', () => {
-      it('should clear the recently executed commands', () => {
-        palette.maxRecentCommands = 3;
-        commands.addCommand('test', { execute: () => {}, label: 'test' });
-        palette.addItem(defaultOptions);
-        MessageLoop.flush();
-
-        let recents = () =>
-          palette.contentNode.querySelectorAll(
-            '.lm-CommandPalette-item.lm-mod-recent'
-          );
-        let item = palette.contentNode.querySelector(
-          '.lm-CommandPalette-item'
-        )!;
-
-        item.dispatchEvent(new MouseEvent('click', { bubbles }));
-        MessageLoop.flush();
-        expect(recents()).to.have.length(1);
-
-        palette.clearRecentCommands();
-        MessageLoop.flush();
-        expect(recents()).to.have.length(0);
       });
     });
 
@@ -904,6 +765,82 @@ describe('@lumino/widgets', () => {
         } finally {
           parent.dispose();
         }
+      });
+    });
+
+    describe('#search()', () => {
+      let palette: RecentsPalette;
+
+      beforeEach(() => {
+        commands.addCommand('a', { label: 'A', execute: () => {} });
+        commands.addCommand('b', { label: 'B', execute: () => {} });
+        palette = new RecentsPalette({ commands });
+        palette.addItem({ command: 'a', category: 'One' });
+        palette.addItem({ command: 'b', category: 'Two' });
+        Widget.attach(palette, document.body);
+        MessageLoop.flush();
+      });
+
+      afterEach(() => {
+        palette.dispose();
+      });
+
+      it('should allow a subclass to customize the search results', () => {
+        // The default results start with a category header.
+        let first = palette.contentNode.firstElementChild!;
+        expect(first.classList.contains('lm-CommandPalette-header')).to.equal(
+          true
+        );
+
+        // Execute the last item in the palette.
+        let node = palette.contentNode.querySelector('[data-command="b"]')!;
+        node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        MessageLoop.flush();
+
+        // The executed item is now pinned to the top, without a header.
+        first = palette.contentNode.firstElementChild!;
+        expect(first.classList.contains('lm-CommandPalette-item')).to.equal(
+          true
+        );
+        expect(first.getAttribute('data-command')).to.equal('b');
+      });
+
+      it('should not duplicate items excluded from the default results', () => {
+        let node = palette.contentNode.querySelector('[data-command="b"]')!;
+        node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        MessageLoop.flush();
+
+        let nodes = palette.contentNode.querySelectorAll('[data-command="b"]');
+        expect(nodes.length).to.equal(1);
+      });
+
+      it('should support keyboard interaction with the custom results', () => {
+        let node = palette.contentNode.querySelector('[data-command="b"]')!;
+        node.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        MessageLoop.flush();
+
+        // Activate and trigger the pinned item.
+        let executed: CommandPalette.IItem | null = null;
+        palette.itemExecuted.connect((sender, item) => {
+          executed = item;
+        });
+        palette.node.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            bubbles: true,
+            keyCode: 40 // Down arrow
+          })
+        );
+        MessageLoop.flush();
+
+        let active = palette.contentNode.querySelector('.lm-mod-active')!;
+        expect(active.getAttribute('data-command')).to.equal('b');
+        palette.node.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            bubbles: true,
+            keyCode: 13 // Enter
+          })
+        );
+        expect(executed!.command).to.equal('b');
       });
     });
 
@@ -1225,17 +1162,6 @@ describe('@lumino/widgets', () => {
           let node = VirtualDOM.realize(vNode);
           expect(node.classList.contains('lm-mod-active')).to.equal(true);
         });
-
-        it('should handle the recent state', () => {
-          let vNode = renderer.renderItem({
-            item,
-            indices: null,
-            active: false,
-            recent: true
-          });
-          let node = VirtualDOM.realize(vNode);
-          expect(node.classList.contains('lm-mod-recent')).to.equal(true);
-        });
       });
 
       describe('#renderEmptyMessage()', () => {
@@ -1315,11 +1241,10 @@ describe('@lumino/widgets', () => {
           let name = renderer.createItemClass({
             item,
             indices: null,
-            active: true,
-            recent: true
+            active: true
           });
           let expected =
-            'lm-CommandPalette-item lm-mod-disabled lm-mod-toggled lm-mod-active lm-mod-recent testClass';
+            'lm-CommandPalette-item lm-mod-disabled lm-mod-toggled lm-mod-active testClass';
           expect(name).to.equal(expected);
         });
       });
@@ -1419,6 +1344,48 @@ describe('@lumino/widgets', () => {
           });
           expect(child).to.equal('A simple test command');
         });
+      });
+    });
+
+    describe('.search()', () => {
+      beforeEach(() => {
+        commands.addCommand('a', { label: 'Apple', execute: () => {} });
+        commands.addCommand('b', { label: 'Banana', execute: () => {} });
+        palette.addItem({ command: 'a', category: 'One' });
+        palette.addItem({ command: 'b', category: 'Two' });
+      });
+
+      it('should include all visible items for an empty query', () => {
+        let results = CommandPalette.search(palette.items, '');
+        expect(results.length).to.equal(4);
+        expect(results[0].type).to.equal('header');
+        expect(results[1].type).to.equal('item');
+        expect(results[2].type).to.equal('header');
+        expect(results[3].type).to.equal('item');
+        let result = results[1] as CommandPalette.IItemResult;
+        expect(result.item.command).to.equal('a');
+        expect(result.indices).to.equal(null);
+      });
+
+      it('should fuzzy match the items against the query', () => {
+        let results = CommandPalette.search(palette.items, 'ban');
+        expect(results.length).to.equal(2);
+        expect(results[0].type).to.equal('header');
+        let result = results[1] as CommandPalette.IItemResult;
+        expect(result.item.command).to.equal('b');
+        expect(result.indices).to.not.equal(null);
+      });
+
+      it('should ignore items which are not visible', () => {
+        commands.addCommand('c', {
+          label: 'Cherry',
+          execute: () => {},
+          isVisible: () => false
+        });
+        palette.addItem({ command: 'c', category: 'One' });
+        let results = CommandPalette.search(palette.items, '');
+        let items = results.filter(result => result.type === 'item');
+        expect(items.length).to.equal(2);
       });
     });
   });

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -179,8 +179,8 @@ export class CommandPalette extends Widget {
     dispose(): void;
     handleEvent(event: Event): void;
     get inputNode(): HTMLInputElement;
-    get itemExecuted(): ISignal<this, CommandPalette.IItem>;
     get items(): ReadonlyArray<CommandPalette.IItem>;
+    get itemTriggered(): ISignal<this, CommandPalette.IItem>;
     protected onActivateRequest(msg: Message): void;
     protected onAfterDetach(msg: Message): void;
     protected onAfterShow(msg: Message): void;

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -174,15 +174,13 @@ export class CommandPalette extends Widget {
     addItem(options: CommandPalette.IItemOptions): CommandPalette.IItem;
     addItems(items: CommandPalette.IItemOptions[]): CommandPalette.IItem[];
     clearItems(): void;
-    clearRecentCommands(): void;
     readonly commands: CommandRegistry;
     get contentNode(): HTMLUListElement;
     dispose(): void;
     handleEvent(event: Event): void;
     get inputNode(): HTMLInputElement;
+    get itemExecuted(): ISignal<this, CommandPalette.IItem>;
     get items(): ReadonlyArray<CommandPalette.IItem>;
-    get maxRecentCommands(): number;
-    set maxRecentCommands(value: number);
     protected onActivateRequest(msg: Message): void;
     protected onAfterDetach(msg: Message): void;
     protected onAfterShow(msg: Message): void;
@@ -192,6 +190,7 @@ export class CommandPalette extends Widget {
     removeItem(item: CommandPalette.IItem): void;
     removeItemAt(index: number): void;
     readonly renderer: CommandPalette.IRenderer;
+    protected search(query: string): CommandPalette.SearchResult[];
     get searchNode(): HTMLDivElement;
 }
 
@@ -203,6 +202,11 @@ export namespace CommandPalette {
     export interface IHeaderRenderData {
         readonly category: string;
         readonly indices: ReadonlyArray<number> | null;
+    }
+    export interface IHeaderResult {
+        readonly category: string;
+        readonly indices: ReadonlyArray<number> | null;
+        readonly type: 'header';
     }
     export interface IItem {
         readonly args: ReadonlyJSONObject;
@@ -232,11 +236,14 @@ export namespace CommandPalette {
         readonly active: boolean;
         readonly indices: ReadonlyArray<number> | null;
         readonly item: IItem;
-        readonly recent?: boolean;
+    }
+    export interface IItemResult {
+        readonly indices: ReadonlyArray<number> | null;
+        readonly item: IItem;
+        readonly type: 'item';
     }
     export interface IOptions {
         commands: CommandRegistry;
-        maxRecentCommands?: number;
         renderer?: IRenderer;
     }
     export interface IRenderer {
@@ -262,7 +269,9 @@ export namespace CommandPalette {
         renderItemLabel(data: IItemRenderData): VirtualElement;
         renderItemShortcut(data: IItemRenderData): VirtualElement;
     }
+    export function search(items: ReadonlyArray<IItem>, query: string): SearchResult[];
     const defaultRenderer: Renderer;
+    export type SearchResult = IHeaderResult | IItemResult;
 }
 
 // @public

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -174,12 +174,15 @@ export class CommandPalette extends Widget {
     addItem(options: CommandPalette.IItemOptions): CommandPalette.IItem;
     addItems(items: CommandPalette.IItemOptions[]): CommandPalette.IItem[];
     clearItems(): void;
+    clearRecentCommands(): void;
     readonly commands: CommandRegistry;
     get contentNode(): HTMLUListElement;
     dispose(): void;
     handleEvent(event: Event): void;
     get inputNode(): HTMLInputElement;
     get items(): ReadonlyArray<CommandPalette.IItem>;
+    get maxRecentCommands(): number;
+    set maxRecentCommands(value: number);
     protected onActivateRequest(msg: Message): void;
     protected onAfterDetach(msg: Message): void;
     protected onAfterShow(msg: Message): void;
@@ -229,9 +232,11 @@ export namespace CommandPalette {
         readonly active: boolean;
         readonly indices: ReadonlyArray<number> | null;
         readonly item: IItem;
+        readonly recent?: boolean;
     }
     export interface IOptions {
         commands: CommandRegistry;
+        maxRecentCommands?: number;
         renderer?: IRenderer;
     }
     export interface IRenderer {


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/lumino/issues/735

This will allow downstreams like JupyterLab to better show recently used commands in the palette:

<img width="1168" height="886" alt="image" src="https://github.com/user-attachments/assets/abdc2166-bd12-4a93-ac2b-9072dccc5b3e" />
