### PR TITLE
Hide nested DockPanel overlays on descendant drops

### DIFF
--- a/packages/widgets/src/dockpanel.ts
+++ b/packages/widgets/src/dockpanel.ts
@@ -475,6 +475,7 @@ export class DockPanel extends Widget {
     this.node.addEventListener('lm-dragenter', this);
     this.node.addEventListener('lm-dragleave', this);
     this.node.addEventListener('lm-dragover', this);
+    this.node.addEventListener('lm-drop', this._evtDropCapture, true);
     this.node.addEventListener('lm-drop', this);
     this.node.addEventListener('pointerdown', this);
   }
@@ -486,6 +487,7 @@ export class DockPanel extends Widget {
     this.node.removeEventListener('lm-dragenter', this);
     this.node.removeEventListener('lm-dragleave', this);
     this.node.removeEventListener('lm-dragover', this);
+    this.node.removeEventListener('lm-drop', this._evtDropCapture, true);
     this.node.removeEventListener('lm-drop', this);
     this.node.removeEventListener('pointerdown', this);
     this._releaseMouse();
@@ -568,6 +570,13 @@ export class DockPanel extends Widget {
       event.dropAction = event.proposedAction;
     }
   }
+
+  /**
+   * Handle the capture phase of the `'lm-drop'` event for the dock panel.
+   */
+  private _evtDropCapture = (): void => {
+    this.overlay.hide(0);
+  };
 
   /**
    * Handle the `'lm-drop'` event for the dock panel.

--- a/packages/widgets/tests/src/dockpanel.spec.ts
+++ b/packages/widgets/tests/src/dockpanel.spec.ts
@@ -12,6 +12,20 @@ import { expect } from 'chai';
 
 import { DockPanel, TabBar, Widget } from '@lumino/widgets';
 
+class TestOverlay implements DockPanel.IOverlay {
+  readonly node = document.createElement('div');
+
+  hidden = true;
+
+  show(): void {
+    this.hidden = false;
+  }
+
+  hide(): void {
+    this.hidden = true;
+  }
+}
+
 describe('@lumino/widgets', () => {
   describe('DockPanel', () => {
     describe('#constructor()', () => {
@@ -64,6 +78,30 @@ describe('@lumino/widgets', () => {
         expect(panel.isDisposed).to.equal(true);
         panel.dispose();
         expect(panel.isDisposed).to.equal(true);
+      });
+    });
+
+    describe('drag-drop overlay', () => {
+      it('should hide when a descendant handles the drop', () => {
+        let overlay = new TestOverlay();
+        let panel = new DockPanel({ overlay });
+        let descendant = document.createElement('div');
+
+        descendant.addEventListener('lm-drop', event => {
+          event.preventDefault();
+          event.stopPropagation();
+        });
+
+        Widget.attach(panel, document.body);
+        panel.node.appendChild(descendant);
+        overlay.show();
+
+        descendant.dispatchEvent(
+          new Event('lm-drop', { bubbles: true, cancelable: true })
+        );
+
+        expect(overlay.hidden).to.equal(true);
+        panel.dispose();
       });
     });
 


### PR DESCRIPTION
Closes #833 

Fixes a nested `DockPanel` drag/drop case where an ancestor drop overlay could remain visible after a child panel handled and stopped the `lm-drop` event. The panel now hides its overlay during the drop capture phase, before descendants can stop propagation, without changing which panel accepts the drop. Adds a regression test for descendant-handled drops.